### PR TITLE
feat: pre-ETL datakwaliteitscontrole op input data

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,52 @@ uv run main.py -D cumulative
 uv run main.py -dataset both
 ```
 
+### Datakwaliteitscontrole
+
+Bij elke run wordt de ruwe inputdata automatisch gevalideerd **voordat de ETL start**. Zo weet je zeker dat je nooit 20 minuten wacht voor een prognose op basis van corrupte data.
+
+Er zijn drie soorten bevindingen:
+
+| Type | Voorbeeld | Wat er gebeurt |
+|---|---|---|
+| **Fout** | Ontbrekend bestand, ontbrekende kolom | Pipeline stopt direct |
+| **Probleem** | Negatieve waarden, onbekende herkomstcode | Prompt: doorgaan of stoppen? |
+| **Waarschuwing** | Klein percentage ontbrekende waarden, weekgaten | Gelogd, pipeline loopt door |
+
+```
+Validatie gevonden problemen die prognoses kunnen beïnvloeden:
+  [PROBLEEM] telbestandY2025W10.csv: meercode_V = 0 voor 1 opleiding(en): B Opleiding X
+
+Als je doorgaat, kunnen sommige opleidingen worden overgeslagen of
+onbetrouwbare prognoses opleveren.
+
+Wil je doorgaan met de pipeline? [j/N]
+```
+
+Gebruik `--yes` om de prompt te omzeilen in geautomatiseerde runs (bijv. CI/CD):
+
+```bash
+studentprognose -w 6 -y 2025 --yes
+```
+
+> [!NOTE]
+> Met `--noetl` worden ETL én validatie overgeslagen. Gebruik dit alleen als de ruwe data al eerder succesvol verwerkt en gevalideerd is.
+
+#### Validatie-instellingen aanpassen
+
+De standaardwaarden (jaarbereiken, NaN-drempels, toegestane categorische waarden) staan in de broncode. Je kunt ze overschrijven door een `"validation"`-blok toe te voegen aan je `configuration.json`. Vermeld alleen de waarden die afwijken:
+
+```json
+{
+    "validation": {
+        "nan_error_threshold": 0.20,
+        "telbestand": {
+            "herkomst_allowed": ["N", "E", "R", "ONBEKEND"]
+        }
+    }
+}
+```
+
 ### Configuratie
 
 Het standaard configuratiebestand is `configuration/configuration.json`. Dit kan worden overschreven:
@@ -171,10 +217,11 @@ uv run main.py -y 2025 -w 5 -d c
 | Stap | Fase | Bestand |
 |------|------|---------|
 | 1 | CLI parsing | `cli.py` |
-| 2 | ETL (skip met `--noetl`) | `etl` |
-| 3 | Configuratie laden | `config.py` |
-| 4 | Data laden | `loader` → `preprocessing/add_zero_weeks` |
-| 5 | CI subset (indien `--ci`) | `utils/ci_subset` |
+| 2 | Validatie ruwe data (skip met `--noetl`) | `data/validation` |
+| 3 | ETL (skip met `--noetl`) | `data/etl` |
+| 4 | Configuratie laden | `config.py` |
+| 5 | Data laden | `loader` → `preprocessing/add_zero_weeks` |
+| 6 | CI subset (indien `--ci`) | `utils/ci_subset` |
 
 **Modus-specifieke stappen:**
 

--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -25,6 +25,34 @@
         },
         "min_training_year": 2016
     },
+    "validation": {
+        "collegejaar_min_offset": 15,
+        "collegejaar_max_offset": 2,
+        "weeknummer_min": 1,
+        "weeknummer_max": 52,
+        "nan_warning_threshold": 0.05,
+        "nan_error_threshold": 0.30,
+        "telbestand": {
+            "required_columns": [
+                "Studiejaar", "Isatcode", "Groepeernaam", "Aantal", "meercode_V",
+                "Herinschrijving", "Hogerejaars", "Herkomst"
+            ],
+            "herkomst_allowed": ["N", "E", "R"],
+            "herinschrijving_allowed": ["J", "N"],
+            "hogerejaars_allowed": ["J", "N"]
+        },
+        "individueel": {
+            "required_columns": [
+                "Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr"
+            ]
+        },
+        "oktober": {
+            "required_columns": [
+                "Collegejaar", "Groepeernaam Croho", "Aantal eerstejaars croho",
+                "EER-NL-nietEER", "Examentype code", "Aantal Hoofdinschrijvingen"
+            ]
+        }
+    },
     "numerus_fixus": {
         "B Opleiding": 0
     },

--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -61,6 +61,14 @@
             "Land code eerste vooropleiding": "Land code eerste vooropleiding",
             "Aantal studenten": "Aantal studenten"
         },
+        "oktober": {
+            "Collegejaar": "Collegejaar",
+            "Groepeernaam Croho": "Groepeernaam Croho",
+            "Aantal eerstejaars croho": "Aantal eerstejaars croho",
+            "EER-NL-nietEER": "EER-NL-nietEER",
+            "Examentype code": "Examentype code",
+            "Aantal Hoofdinschrijvingen": "Aantal Hoofdinschrijvingen"
+        },
         "cumulative": {
             "Korte naam instelling": "Korte naam instelling",
             "Collegejaar": "Collegejaar",

--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -25,34 +25,6 @@
         },
         "min_training_year": 2016
     },
-    "validation": {
-        "collegejaar_min_offset": 15,
-        "collegejaar_max_offset": 2,
-        "weeknummer_min": 1,
-        "weeknummer_max": 52,
-        "nan_warning_threshold": 0.05,
-        "nan_error_threshold": 0.30,
-        "telbestand": {
-            "required_columns": [
-                "Studiejaar", "Isatcode", "Groepeernaam", "Aantal", "meercode_V",
-                "Herinschrijving", "Hogerejaars", "Herkomst"
-            ],
-            "herkomst_allowed": ["N", "E", "R"],
-            "herinschrijving_allowed": ["J", "N"],
-            "hogerejaars_allowed": ["J", "N"]
-        },
-        "individueel": {
-            "required_columns": [
-                "Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr"
-            ]
-        },
-        "oktober": {
-            "required_columns": [
-                "Collegejaar", "Groepeernaam Croho", "Aantal eerstejaars croho",
-                "EER-NL-nietEER", "Examentype code", "Aantal Hoofdinschrijvingen"
-            ]
-        }
-    },
     "numerus_fixus": {
         "B Opleiding": 0
     },

--- a/src/studentprognose/cli.py
+++ b/src/studentprognose/cli.py
@@ -18,6 +18,7 @@ class PipelineConfig:
     skip_years: int = 0
     ci_test_n: int | None = None
     noetl: bool = False
+    yes: bool = False
 
 
 def _expand_slices(tokens):
@@ -80,11 +81,13 @@ def parse_args(argv):
     parser.add_argument("-sk", "-SK", "-skipyears", type=int, default=0, dest="skipyears")
     parser.add_argument("--ci", nargs=2, metavar=("test", "N"), default=None)
     parser.add_argument("--noetl", action="store_true")
+    parser.add_argument("--yes", action="store_true", help="Sla de interactieve validatieprompt over (voor geautomatiseerde runs)")
 
     args = parser.parse_args(argv[1:])
 
     cfg = PipelineConfig()
     cfg.noetl = args.noetl
+    cfg.yes = args.yes
 
     # Configuration path
     if args.configuration and os.path.exists(args.configuration):

--- a/src/studentprognose/cli.py
+++ b/src/studentprognose/cli.py
@@ -80,7 +80,7 @@ def parse_args(argv):
     parser.add_argument("-sy", "-SY", "-studentyear", choices=list(STUDENT_YEAR_MAP.keys()), default=None, dest="studentyear")
     parser.add_argument("-sk", "-SK", "-skipyears", type=int, default=0, dest="skipyears")
     parser.add_argument("--ci", nargs=2, metavar=("test", "N"), default=None)
-    parser.add_argument("--noetl", action="store_true")
+    parser.add_argument("--noetl", action="store_true", help="Sla ETL én validatie over (gebruik dit alleen als de ruwe data al eerder verwerkt en gevalideerd is)")
     parser.add_argument("--yes", action="store_true", help="Sla de interactieve validatieprompt over (voor geautomatiseerde runs)")
 
     args = parser.parse_args(argv[1:])

--- a/src/studentprognose/data/etl.py
+++ b/src/studentprognose/data/etl.py
@@ -34,9 +34,10 @@ def run_etl(configuration):
 
     # Step 3: Calculate student counts from oktober-bestand
     path_october = os.path.join(cwd, paths["path_raw_october"])
+    oktober_columns = configuration.get("columns", {}).get("oktober", {})
     if os.path.exists(path_october):
         print("[3/4] Calculating student counts...     → data/input/student_count_*.xlsx")
-        _calculate_student_counts(path_october, cwd)
+        _calculate_student_counts(path_october, cwd, oktober_columns)
     else:
         print(f"[3/4] Skipping student counts (oktober-bestand not found: {paths['path_october']})")
 
@@ -342,9 +343,18 @@ def _calculate_student_count(data, volume):
     return pd.DataFrame(result)
 
 
-def _calculate_student_counts(path_october, cwd):
-    """Calculate student count files from the oktober-bestand."""
+def _calculate_student_counts(path_october, cwd, oktober_columns=None):
+    """Calculate student count files from the oktober-bestand.
+
+    oktober_columns maps canonical column names to institution-specific names,
+    matching the structure of configuration["columns"]["oktober"]. Columns are
+    renamed to canonical names before processing so downstream logic stays clean.
+    """
     data = pd.read_excel(path_october)
+    if oktober_columns:
+        rename_map = {inst: canonical for canonical, inst in oktober_columns.items() if inst != canonical}
+        if rename_map:
+            data = data.rename(columns=rename_map)
 
     # First-years
     dict_count = _calculate_student_count(data, volume=False)

--- a/src/studentprognose/data/etl.py
+++ b/src/studentprognose/data/etl.py
@@ -39,7 +39,7 @@ def run_etl(configuration):
         print("[3/4] Calculating student counts...     → data/input/student_count_*.xlsx")
         _calculate_student_counts(path_october, cwd, oktober_columns)
     else:
-        print(f"[3/4] Skipping student counts (oktober-bestand not found: {paths['path_october']})")
+        print(f"[3/4] Skipping student counts (oktober-bestand not found: {paths['path_raw_october']})")
 
     # Step 4: Copy direct files (raw → canonical input paths)
     copied = _copy_direct_files(cwd, paths, output_individual)

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -1,3 +1,46 @@
+"""Pre-ETL datakwaliteitscontrole.
+
+Dit module valideert alle ruwe inputbestanden voordat de ETL-pipeline start.
+Ongeldige data wordt nooit stilzwijgend omgezet — de gebruiker wordt altijd
+gewaarschuwd of de pipeline stopt.
+
+Gedrag per type bevinding
+--------------------------
+hard error  → pipeline stopt direct, los op en probeer opnieuw
+soft error  → pre-flight prompt; gebruik ``--yes`` om door te gaan (CI/CD)
+warning     → gelogd, pipeline loopt door
+
+Configuratie
+------------
+``_DEFAULT_VALIDATION_CFG`` is de **enige bron van waarheid** voor
+validatiedefaults. De waarden staan hier in de code, niet in
+``configuration.json``, om dubbele definities te vermijden.
+
+Wil je een instelling overschrijven voor jouw installatie? Voeg een
+``"validation"``-blok toe aan je ``configuration.json``. Je hoeft alleen de
+waarden op te nemen die afwijken van de defaults:
+
+.. code-block:: json
+
+    {
+        "validation": {
+            "nan_error_threshold": 0.20,
+            "telbestand": {
+                "herkomst_allowed": ["N", "E", "R", "ONBEKEND"]
+            }
+        }
+    }
+
+Een nieuw validatiecheck toevoegen
+-----------------------------------
+1. Voeg de configuratiesleutel toe aan ``_DEFAULT_VALIDATION_CFG``
+   (en eventueel als override-voorbeeld in de README).
+2. Schrijf een helperfunctie ``_check_*`` die een ``ValidationResult``
+   als parameter accepteert en fouten/waarschuwingen appended.
+3. Roep de functie aan vanuit de betreffende ``_validate_*``-functie.
+4. Schrijf een test in ``tests/studentprognose/test_validation.py``.
+"""
+
 import datetime
 import os
 import re
@@ -7,8 +50,9 @@ from dataclasses import dataclass, field
 import pandas as pd
 
 
-# Mirrors the "validation" block in configuration.json.
-# These defaults are used when no validation config is present (e.g. older configs).
+# Enige bron van waarheid voor validatiedefaults.
+# Waarden hier worden gebruikt tenzij configuration.json ze overschrijft.
+# Zie de module-docstring hierboven voor uitleg en het override-patroon.
 _DEFAULT_VALIDATION_CFG = {
     "collegejaar_min_offset": 15,
     "collegejaar_max_offset": 2,

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -78,7 +78,7 @@ _DEFAULT_VALIDATION_CFG = {
     "collegejaar_min_offset": 15,
     "collegejaar_max_offset": 2,
     "weeknummer_min": 1,
-    "weeknummer_max": 52,
+    "weeknummer_max": 53,  # ISO 8601: sommige jaren hebben week 53 (bijv. 2026)
     "nan_warning_threshold": 0.05,
     "nan_error_threshold": 0.30,
     "telbestand": {
@@ -210,7 +210,7 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result):
         if len(invalid_years) > 0:
             result.soft_errors.append(
                 f"{filename}: Studiejaar bevat onverwachte waarden: "
-                f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
+                f"{sorted(int(y) for y in invalid_years)} (verwacht: {year_min}–{year_max})"
             )
 
         for col, allowed in [
@@ -229,7 +229,8 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result):
                 col, allowed, "Groepeernaam", filename, result,
             )
 
-        zero_meercode = df[df["meercode_V"] == 0]
+        meercode_v, _ = _coerce_to_numeric(df["meercode_V"])
+        zero_meercode = df[meercode_v == 0]
         if not zero_meercode.empty:
             programmes = zero_meercode["Groepeernaam"].dropna().unique()
             result.soft_errors.append(
@@ -341,7 +342,7 @@ def _validate_oktober(cwd, paths, validation_cfg, columns_cfg, result):
     if len(invalid_years) > 0:
         result.soft_errors.append(
             f"oktober_bestand.xlsx: {collegejaar_col} bevat onverwachte waarden: "
-            f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
+            f"{sorted(int(y) for y in invalid_years)} (verwacht: {year_min}–{year_max})"
         )
 
     nan_warn = validation_cfg["nan_warning_threshold"]

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -7,28 +7,56 @@ from dataclasses import dataclass, field
 import pandas as pd
 
 
+# Mirrors the "validation" block in configuration.json.
+# These defaults are used when no validation config is present (e.g. older configs).
+_DEFAULT_VALIDATION_CFG = {
+    "collegejaar_min_offset": 15,
+    "collegejaar_max_offset": 2,
+    "weeknummer_min": 1,
+    "weeknummer_max": 52,
+    "nan_warning_threshold": 0.05,
+    "nan_error_threshold": 0.30,
+    "telbestand": {
+        "required_columns": [
+            "Studiejaar", "Isatcode", "Groepeernaam", "Aantal", "meercode_V",
+            "Herinschrijving", "Hogerejaars", "Herkomst",
+        ],
+        "herkomst_allowed": ["N", "E", "R"],
+        "herinschrijving_allowed": ["J", "N"],
+        "hogerejaars_allowed": ["J", "N"],
+    },
+    "individueel": {
+        "required_columns": [
+            "Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr",
+        ],
+    },
+    "oktober": {
+        "required_columns": [
+            "Collegejaar", "Groepeernaam Croho", "Aantal eerstejaars croho",
+            "EER-NL-nietEER", "Examentype code", "Aantal Hoofdinschrijvingen",
+        ],
+    },
+}
+
+
 @dataclass
 class ValidationResult:
     hard_errors: list = field(default_factory=list)
     soft_errors: list = field(default_factory=list)
     warnings: list = field(default_factory=list)
 
-    @property
-    def has_hard_errors(self):
-        return bool(self.hard_errors)
-
-    @property
-    def has_soft_errors(self):
-        return bool(self.soft_errors)
-
 
 def validate_raw_data(configuration, yes=False):
-    """Validate all raw input files before ETL. Blocks on hard errors, prompts on soft errors."""
+    """Validate all raw input files before ETL. Blocks on hard errors, prompts on soft errors.
+
+    Skipped automatically when --noetl is used, on the assumption that if ETL has
+    run before, the data was validated at that point.
+    """
     print("==== Valideren van ruwe inputdata ====")
 
     paths = configuration["paths"]
-    validation_cfg = configuration.get("validation", {})
-    cwd = _resolve_cwd()
+    validation_cfg = {**_DEFAULT_VALIDATION_CFG, **configuration.get("validation", {})}
+    cwd = os.getcwd()
     result = ValidationResult()
 
     _validate_telbestanden(cwd, paths, validation_cfg, result)
@@ -37,12 +65,6 @@ def validate_raw_data(configuration, yes=False):
 
     _handle_result(result, yes)
     print("==== Validatie voltooid ====\n")
-
-
-def _resolve_cwd():
-    return os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -75,23 +97,18 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result):
     _check_telbestand_completeness(files, validation_cfg, result)
 
     current_year = datetime.date.today().year
-    min_offset = validation_cfg.get("collegejaar_min_offset", 15)
-    max_offset = validation_cfg.get("collegejaar_max_offset", 2)
-    year_min = current_year - min_offset
-    year_max = current_year + max_offset
-    weeknummer_min = validation_cfg.get("weeknummer_min", 1)
-    weeknummer_max = validation_cfg.get("weeknummer_max", 52)
-    nan_warn = validation_cfg.get("nan_warning_threshold", 0.05)
-    nan_error = validation_cfg.get("nan_error_threshold", 0.30)
+    year_min = current_year - validation_cfg["collegejaar_min_offset"]
+    year_max = current_year + validation_cfg["collegejaar_max_offset"]
+    weeknummer_min = validation_cfg["weeknummer_min"]
+    weeknummer_max = validation_cfg["weeknummer_max"]
+    nan_warn = validation_cfg["nan_warning_threshold"]
+    nan_error = validation_cfg["nan_error_threshold"]
 
-    telbestand_cfg = validation_cfg.get("telbestand", {})
-    required_columns = telbestand_cfg.get("required_columns", [
-        "Studiejaar", "Isatcode", "Groepeernaam", "Aantal", "meercode_V",
-        "Herinschrijving", "Hogerejaars", "Herkomst",
-    ])
-    herkomst_allowed = telbestand_cfg.get("herkomst_allowed", ["N", "E", "R"])
-    herinschrijving_allowed = telbestand_cfg.get("herinschrijving_allowed", ["J", "N"])
-    hogerejaars_allowed = telbestand_cfg.get("hogerejaars_allowed", ["J", "N"])
+    telbestand_cfg = {**_DEFAULT_VALIDATION_CFG["telbestand"], **validation_cfg.get("telbestand", {})}
+    required_columns = telbestand_cfg["required_columns"]
+    herkomst_allowed = telbestand_cfg["herkomst_allowed"]
+    herinschrijving_allowed = telbestand_cfg["herinschrijving_allowed"]
+    hogerejaars_allowed = telbestand_cfg["hogerejaars_allowed"]
 
     for filename in files:
         filepath = os.path.join(telbestanden_dir, filename)
@@ -172,17 +189,15 @@ def _validate_individueel(cwd, paths, validation_cfg, result):
         return
 
     try:
-        df = pd.read_csv(path, sep=";", low_memory=False, nrows=5000)
+        df = pd.read_csv(path, sep=";", low_memory=False)
     except Exception as e:
         result.hard_errors.append(
             f"individuele_aanmelddata.csv: kan bestand niet lezen ({e})"
         )
         return
 
-    individueel_cfg = validation_cfg.get("individueel", {})
-    required_columns = individueel_cfg.get("required_columns", [
-        "Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr",
-    ])
+    individueel_cfg = {**_DEFAULT_VALIDATION_CFG["individueel"], **validation_cfg.get("individueel", {})}
+    required_columns = individueel_cfg["required_columns"]
 
     missing_cols = [c for c in required_columns if c not in df.columns]
     if missing_cols:
@@ -191,8 +206,8 @@ def _validate_individueel(cwd, paths, validation_cfg, result):
         )
         return
 
-    nan_warn = validation_cfg.get("nan_warning_threshold", 0.05)
-    nan_error = validation_cfg.get("nan_error_threshold", 0.30)
+    nan_warn = validation_cfg["nan_warning_threshold"]
+    nan_error = validation_cfg["nan_error_threshold"]
     for col in ["Collegejaar", "Croho", "Inschrijfstatus"]:
         _check_nan_rate(df, col, "individuele_aanmelddata.csv", nan_warn, nan_error, result)
 
@@ -216,15 +231,8 @@ def _validate_oktober(cwd, paths, validation_cfg, result):
         )
         return
 
-    oktober_cfg = validation_cfg.get("oktober", {})
-    required_columns = oktober_cfg.get("required_columns", [
-        "Collegejaar",
-        "Groepeernaam Croho",
-        "Aantal eerstejaars croho",
-        "EER-NL-nietEER",
-        "Examentype code",
-        "Aantal Hoofdinschrijvingen",
-    ])
+    oktober_cfg = {**_DEFAULT_VALIDATION_CFG["oktober"], **validation_cfg.get("oktober", {})}
+    required_columns = oktober_cfg["required_columns"]
 
     missing_cols = [c for c in required_columns if c not in df.columns]
     if missing_cols:
@@ -234,10 +242,8 @@ def _validate_oktober(cwd, paths, validation_cfg, result):
         return
 
     current_year = datetime.date.today().year
-    min_offset = validation_cfg.get("collegejaar_min_offset", 15)
-    max_offset = validation_cfg.get("collegejaar_max_offset", 2)
-    year_min = current_year - min_offset
-    year_max = current_year + max_offset
+    year_min = current_year - validation_cfg["collegejaar_min_offset"]
+    year_max = current_year + validation_cfg["collegejaar_max_offset"]
 
     invalid_years = (
         df[~df["Collegejaar"].between(year_min, year_max)]["Collegejaar"]
@@ -250,8 +256,8 @@ def _validate_oktober(cwd, paths, validation_cfg, result):
             f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
         )
 
-    nan_warn = validation_cfg.get("nan_warning_threshold", 0.05)
-    nan_error = validation_cfg.get("nan_error_threshold", 0.30)
+    nan_warn = validation_cfg["nan_warning_threshold"]
+    nan_error = validation_cfg["nan_error_threshold"]
     for col in ["Collegejaar", "Aantal eerstejaars croho", "Aantal Hoofdinschrijvingen"]:
         _check_nan_rate(df, col, "oktober_bestand.xlsx", nan_warn, nan_error, result)
 
@@ -337,7 +343,7 @@ def _handle_result(result, yes):
     for w in result.warnings:
         print(f"  [WAARSCHUWING] {w}")
 
-    if result.has_hard_errors:
+    if result.hard_errors:
         print("\nValidatie mislukt — de pipeline kan niet worden gestart:")
         for e in result.hard_errors:
             print(f"  [FOUT] {e}")
@@ -347,25 +353,23 @@ def _handle_result(result, yes):
         )
         sys.exit(1)
 
-    if result.has_soft_errors:
+    if result.soft_errors:
         print("\nValidatie gevonden problemen die prognoses kunnen beïnvloeden:")
         for e in result.soft_errors:
             print(f"  [PROBLEEM] {e}")
 
-        n = len(result.soft_errors)
-
         if yes:
             print(
-                f"\n--yes opgegeven: pipeline wordt gestart ondanks {n} "
-                f"probleem/problemen. Prognoses voor de betreffende opleidingen "
-                f"kunnen onbetrouwbaar zijn of worden overgeslagen."
+                "\n--yes opgegeven: pipeline wordt gestart ondanks bovenstaande problemen. "
+                "Prognoses voor de betreffende opleidingen kunnen onbetrouwbaar zijn "
+                "of worden overgeslagen."
             )
             return
 
         print(
-            f"\n{n} probleem/problemen gevonden. Als je doorgaat, kunnen sommige "
-            "opleidingen worden overgeslagen of onbetrouwbare prognoses opleveren. "
-            "Je zou dan minder opleidingen terugkrijgen dan verwacht."
+            "\nAls je doorgaat, kunnen sommige opleidingen worden overgeslagen of "
+            "onbetrouwbare prognoses opleveren. Je zou dan minder opleidingen "
+            "terugkrijgen dan verwacht."
         )
         print(
             "Tip: gebruik --yes om deze prompt te omzeilen in geautomatiseerde runs."

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -1,0 +1,387 @@
+import datetime
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+
+@dataclass
+class ValidationResult:
+    hard_errors: list = field(default_factory=list)
+    soft_errors: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+
+    @property
+    def has_hard_errors(self):
+        return bool(self.hard_errors)
+
+    @property
+    def has_soft_errors(self):
+        return bool(self.soft_errors)
+
+
+def validate_raw_data(configuration, yes=False):
+    """Validate all raw input files before ETL. Blocks on hard errors, prompts on soft errors."""
+    print("==== Valideren van ruwe inputdata ====")
+
+    paths = configuration["paths"]
+    validation_cfg = configuration.get("validation", {})
+    cwd = _resolve_cwd()
+    result = ValidationResult()
+
+    _validate_telbestanden(cwd, paths, validation_cfg, result)
+    _validate_individueel(cwd, paths, validation_cfg, result)
+    _validate_oktober(cwd, paths, validation_cfg, result)
+
+    _handle_result(result, yes)
+    print("==== Validatie voltooid ====\n")
+
+
+def _resolve_cwd():
+    return os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-file validators
+# ---------------------------------------------------------------------------
+
+def _validate_telbestanden(cwd, paths, validation_cfg, result):
+    telbestanden_dir = os.path.join(
+        cwd, paths.get("path_raw_telbestanden", "data/input_raw/telbestanden")
+    )
+
+    if not os.path.isdir(telbestanden_dir):
+        result.hard_errors.append(
+            f"Telbestanden-map niet gevonden: {telbestanden_dir}"
+        )
+        return
+
+    files = sorted([
+        f for f in os.listdir(telbestanden_dir)
+        if re.search(r"telbestandY\d{4}W\d+", f)
+    ])
+
+    if not files:
+        result.hard_errors.append(
+            f"Geen telbestanden gevonden in {telbestanden_dir} "
+            f"(verwacht patroon: telbestandY{{jaar}}W{{week}}.csv)"
+        )
+        return
+
+    _check_telbestand_completeness(files, validation_cfg, result)
+
+    current_year = datetime.date.today().year
+    min_offset = validation_cfg.get("collegejaar_min_offset", 15)
+    max_offset = validation_cfg.get("collegejaar_max_offset", 2)
+    year_min = current_year - min_offset
+    year_max = current_year + max_offset
+    weeknummer_min = validation_cfg.get("weeknummer_min", 1)
+    weeknummer_max = validation_cfg.get("weeknummer_max", 52)
+    nan_warn = validation_cfg.get("nan_warning_threshold", 0.05)
+    nan_error = validation_cfg.get("nan_error_threshold", 0.30)
+
+    telbestand_cfg = validation_cfg.get("telbestand", {})
+    required_columns = telbestand_cfg.get("required_columns", [
+        "Studiejaar", "Isatcode", "Groepeernaam", "Aantal", "meercode_V",
+        "Herinschrijving", "Hogerejaars", "Herkomst",
+    ])
+    herkomst_allowed = telbestand_cfg.get("herkomst_allowed", ["N", "E", "R"])
+    herinschrijving_allowed = telbestand_cfg.get("herinschrijving_allowed", ["J", "N"])
+    hogerejaars_allowed = telbestand_cfg.get("hogerejaars_allowed", ["J", "N"])
+
+    for filename in files:
+        filepath = os.path.join(telbestanden_dir, filename)
+        try:
+            df = pd.read_csv(filepath, sep=";", low_memory=False)
+        except Exception as e:
+            result.hard_errors.append(f"{filename}: kan bestand niet lezen ({e})")
+            continue
+
+        missing_cols = [c for c in required_columns if c not in df.columns]
+        if missing_cols:
+            result.hard_errors.append(
+                f"{filename}: ontbrekende kolommen: {', '.join(missing_cols)}"
+            )
+            continue
+
+        match = re.search(r"telbestandY(\d{4})W(\d+)", filename)
+        if match:
+            week_nr = int(match.group(2))
+            if not (weeknummer_min <= week_nr <= weeknummer_max):
+                result.hard_errors.append(
+                    f"{filename}: weeknummer {week_nr} valt buiten verwacht bereik "
+                    f"[{weeknummer_min}, {weeknummer_max}]"
+                )
+
+        invalid_years = (
+            df[~df["Studiejaar"].between(year_min, year_max)]["Studiejaar"]
+            .dropna()
+            .unique()
+        )
+        if len(invalid_years) > 0:
+            result.soft_errors.append(
+                f"{filename}: Studiejaar bevat onverwachte waarden: "
+                f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
+            )
+
+        _check_categoricals_per_programme(
+            df, "Herinschrijving", herinschrijving_allowed, "Groepeernaam", filename, result
+        )
+        _check_categoricals_per_programme(
+            df, "Hogerejaars", hogerejaars_allowed, "Groepeernaam", filename, result
+        )
+        _check_categoricals_per_programme(
+            df, "Herkomst", herkomst_allowed, "Groepeernaam", filename, result
+        )
+
+        zero_meercode = df[df["meercode_V"] == 0]
+        if not zero_meercode.empty:
+            programmes = zero_meercode["Groepeernaam"].dropna().unique()
+            result.soft_errors.append(
+                f"{filename}: meercode_V = 0 (deling door nul in ETL) voor "
+                f"{len(programmes)} opleiding(en): "
+                + _format_programmes(programmes)
+            )
+
+        neg_aantal = df[df["Aantal"] < 0]
+        if not neg_aantal.empty:
+            programmes = neg_aantal["Groepeernaam"].dropna().unique()
+            result.soft_errors.append(
+                f"{filename}: Aantal < 0 voor "
+                f"{len(programmes)} opleiding(en): "
+                + _format_programmes(programmes)
+            )
+
+        for col in ["Aantal", "meercode_V"]:
+            _check_nan_rate(df, col, filename, nan_warn, nan_error, result)
+
+
+def _validate_individueel(cwd, paths, validation_cfg, result):
+    path = os.path.join(
+        cwd, paths.get("path_raw_individueel", "data/input_raw/individuele_aanmelddata.csv")
+    )
+
+    if not os.path.exists(path):
+        result.warnings.append(
+            f"Individuele aanmelddata niet gevonden: {path} — wordt overgeslagen."
+        )
+        return
+
+    try:
+        df = pd.read_csv(path, sep=";", low_memory=False, nrows=5000)
+    except Exception as e:
+        result.hard_errors.append(
+            f"individuele_aanmelddata.csv: kan bestand niet lezen ({e})"
+        )
+        return
+
+    individueel_cfg = validation_cfg.get("individueel", {})
+    required_columns = individueel_cfg.get("required_columns", [
+        "Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr",
+    ])
+
+    missing_cols = [c for c in required_columns if c not in df.columns]
+    if missing_cols:
+        result.hard_errors.append(
+            f"individuele_aanmelddata.csv: ontbrekende kolommen: {', '.join(missing_cols)}"
+        )
+        return
+
+    nan_warn = validation_cfg.get("nan_warning_threshold", 0.05)
+    nan_error = validation_cfg.get("nan_error_threshold", 0.30)
+    for col in ["Collegejaar", "Croho", "Inschrijfstatus"]:
+        _check_nan_rate(df, col, "individuele_aanmelddata.csv", nan_warn, nan_error, result)
+
+
+def _validate_oktober(cwd, paths, validation_cfg, result):
+    path = os.path.join(
+        cwd, paths.get("path_raw_october", "data/input_raw/oktober_bestand.xlsx")
+    )
+
+    if not os.path.exists(path):
+        result.warnings.append(
+            f"Oktober-bestand niet gevonden: {path} — studentaantallen worden niet berekend."
+        )
+        return
+
+    try:
+        df = pd.read_excel(path)
+    except Exception as e:
+        result.hard_errors.append(
+            f"oktober_bestand.xlsx: kan bestand niet lezen ({e})"
+        )
+        return
+
+    oktober_cfg = validation_cfg.get("oktober", {})
+    required_columns = oktober_cfg.get("required_columns", [
+        "Collegejaar",
+        "Groepeernaam Croho",
+        "Aantal eerstejaars croho",
+        "EER-NL-nietEER",
+        "Examentype code",
+        "Aantal Hoofdinschrijvingen",
+    ])
+
+    missing_cols = [c for c in required_columns if c not in df.columns]
+    if missing_cols:
+        result.hard_errors.append(
+            f"oktober_bestand.xlsx: ontbrekende kolommen: {', '.join(missing_cols)}"
+        )
+        return
+
+    current_year = datetime.date.today().year
+    min_offset = validation_cfg.get("collegejaar_min_offset", 15)
+    max_offset = validation_cfg.get("collegejaar_max_offset", 2)
+    year_min = current_year - min_offset
+    year_max = current_year + max_offset
+
+    invalid_years = (
+        df[~df["Collegejaar"].between(year_min, year_max)]["Collegejaar"]
+        .dropna()
+        .unique()
+    )
+    if len(invalid_years) > 0:
+        result.soft_errors.append(
+            f"oktober_bestand.xlsx: Collegejaar bevat onverwachte waarden: "
+            f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
+        )
+
+    nan_warn = validation_cfg.get("nan_warning_threshold", 0.05)
+    nan_error = validation_cfg.get("nan_error_threshold", 0.30)
+    for col in ["Collegejaar", "Aantal eerstejaars croho", "Aantal Hoofdinschrijvingen"]:
+        _check_nan_rate(df, col, "oktober_bestand.xlsx", nan_warn, nan_error, result)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _check_telbestand_completeness(files, validation_cfg, result):
+    """Warn when there are unexpected gaps (> 2 weeks) between telbestanden within a year."""
+    weeks_per_year = {}
+    for filename in files:
+        match = re.search(r"telbestandY(\d{4})W(\d+)", filename)
+        if match:
+            year, week = int(match.group(1)), int(match.group(2))
+            weeks_per_year.setdefault(year, []).append(week)
+
+    for year, weeks in sorted(weeks_per_year.items()):
+        weeks_sorted = sorted(weeks)
+        gaps = [
+            (weeks_sorted[i], weeks_sorted[i + 1])
+            for i in range(len(weeks_sorted) - 1)
+            if weeks_sorted[i + 1] - weeks_sorted[i] > 2
+        ]
+        if gaps:
+            gap_str = ", ".join(f"week {a} → week {b}" for a, b in gaps)
+            result.warnings.append(
+                f"Telbestanden jaar {year}: gaten gevonden tussen weken: {gap_str}"
+            )
+
+
+def _check_categoricals_per_programme(df, col, allowed, programme_col, filename, result):
+    """Report categorical violations grouped by programme."""
+    invalid_mask = ~df[col].isin(allowed) & df[col].notna()
+    if not invalid_mask.any():
+        return
+
+    invalid_df = df[invalid_mask]
+    invalid_values = list(invalid_df[col].unique())
+
+    if programme_col in df.columns:
+        programmes = invalid_df[programme_col].dropna().unique()
+        result.soft_errors.append(
+            f"{filename}: kolom '{col}' bevat ongeldige waarden {invalid_values} "
+            f"(toegestaan: {allowed}) voor {len(programmes)} opleiding(en): "
+            + _format_programmes(programmes)
+        )
+    else:
+        result.soft_errors.append(
+            f"{filename}: kolom '{col}' bevat ongeldige waarden {invalid_values} "
+            f"(toegestaan: {allowed})"
+        )
+
+
+def _check_nan_rate(df, col, filename, warn_threshold, error_threshold, result):
+    if col not in df.columns or len(df) == 0:
+        return
+    rate = df[col].isna().mean()
+    pct = f"{rate:.0%}"
+    if rate >= error_threshold:
+        result.soft_errors.append(
+            f"{filename}: kolom '{col}' heeft {pct} ontbrekende waarden "
+            f"(foutdrempel: {error_threshold:.0%})"
+        )
+    elif rate >= warn_threshold:
+        result.warnings.append(
+            f"{filename}: kolom '{col}' heeft {pct} ontbrekende waarden "
+            f"(waarschuwingsdrempel: {warn_threshold:.0%})"
+        )
+
+
+def _format_programmes(programmes, limit=5):
+    names = [str(p) for p in programmes[:limit]]
+    suffix = " ..." if len(programmes) > limit else ""
+    return ", ".join(names) + suffix
+
+
+# ---------------------------------------------------------------------------
+# Result handler
+# ---------------------------------------------------------------------------
+
+def _handle_result(result, yes):
+    for w in result.warnings:
+        print(f"  [WAARSCHUWING] {w}")
+
+    if result.has_hard_errors:
+        print("\nValidatie mislukt — de pipeline kan niet worden gestart:")
+        for e in result.hard_errors:
+            print(f"  [FOUT] {e}")
+        print(
+            "\nLos de bovenstaande fouten op in je ruwe inputdata of configuratie "
+            "en probeer opnieuw."
+        )
+        sys.exit(1)
+
+    if result.has_soft_errors:
+        print("\nValidatie gevonden problemen die prognoses kunnen beïnvloeden:")
+        for e in result.soft_errors:
+            print(f"  [PROBLEEM] {e}")
+
+        n = len(result.soft_errors)
+
+        if yes:
+            print(
+                f"\n--yes opgegeven: pipeline wordt gestart ondanks {n} "
+                f"probleem/problemen. Prognoses voor de betreffende opleidingen "
+                f"kunnen onbetrouwbaar zijn of worden overgeslagen."
+            )
+            return
+
+        print(
+            f"\n{n} probleem/problemen gevonden. Als je doorgaat, kunnen sommige "
+            "opleidingen worden overgeslagen of onbetrouwbare prognoses opleveren. "
+            "Je zou dan minder opleidingen terugkrijgen dan verwacht."
+        )
+        print(
+            "Tip: gebruik --yes om deze prompt te omzeilen in geautomatiseerde runs."
+        )
+
+        try:
+            answer = input("\nWil je doorgaan met de pipeline? [j/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nPipeline gestopt.")
+            sys.exit(0)
+
+        if answer != "j":
+            print(
+                "\nPipeline gestopt. Los de problemen op in je ruwe inputdata "
+                "en probeer opnieuw."
+            )
+            sys.exit(0)
+
+        print("Doorgaan met pipeline...\n")

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -10,15 +10,36 @@ hard error  → pipeline stopt direct, los op en probeer opnieuw
 soft error  → pre-flight prompt; gebruik ``--yes`` om door te gaan (CI/CD)
 warning     → gelogd, pipeline loopt door
 
+Tolerantie voor institutie-specifieke data
+------------------------------------------
+Elke instelling kan kolomnamen en lichte type-afwijkingen hebben.
+Dit module probeert data te normaliseren voordat het valideert:
+
+- **Kolomnamen** voor ``individuele_aanmelddata`` en ``oktober_bestand``
+  worden opgezocht via ``configuration["columns"]["individual"]`` en
+  ``configuration["columns"]["oktober"]``. Pas die mapping aan in
+  ``configuration.json`` als jouw instelling andere namen gebruikt.
+  Telbestanden komen van Studielink en zijn gestandaardiseerd; die
+  kolomnamen zijn vast.
+
+- **Witruimte** in categorische waarden (``"J "`` → ``"J"``) wordt
+  automatisch gestript. Een waarschuwing verschijnt als normalisatie
+  nodig was.
+
+- **Numerieke strings** (``"2024"`` of ``"2.024"``) worden gecoerceerd
+  naar getallen voor bereikcontroles. Een waarschuwing verschijnt als
+  coercering nodig was. Dit is consistent met hoe de ETL
+  (``_convert_to_float``) dezelfde variaties al afhandelt.
+
 Configuratie
 ------------
 ``_DEFAULT_VALIDATION_CFG`` is de **enige bron van waarheid** voor
 validatiedefaults. De waarden staan hier in de code, niet in
 ``configuration.json``, om dubbele definities te vermijden.
 
-Wil je een instelling overschrijven voor jouw installatie? Voeg een
-``"validation"``-blok toe aan je ``configuration.json``. Je hoeft alleen de
-waarden op te nemen die afwijken van de defaults:
+Wil je een instelling overschrijven? Voeg een ``"validation"``-blok toe
+aan je ``configuration.json``. Je hoeft alleen de afwijkende waarden op
+te nemen:
 
 .. code-block:: json
 
@@ -69,13 +90,13 @@ _DEFAULT_VALIDATION_CFG = {
         "herinschrijving_allowed": ["J", "N"],
         "hogerejaars_allowed": ["J", "N"],
     },
+    # critical_columns zijn kanonieke namen; de werkelijke kolomnamen worden
+    # opgezocht via configuration["columns"]["individual"] / ["oktober"].
     "individueel": {
-        "required_columns": [
-            "Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr",
-        ],
+        "critical_columns": ["Collegejaar", "Croho", "Inschrijfstatus", "Datum Verzoek Inschr"],
     },
     "oktober": {
-        "required_columns": [
+        "critical_columns": [
             "Collegejaar", "Groepeernaam Croho", "Aantal eerstejaars croho",
             "EER-NL-nietEER", "Examentype code", "Aantal Hoofdinschrijvingen",
         ],
@@ -100,12 +121,13 @@ def validate_raw_data(configuration, yes=False):
 
     paths = configuration["paths"]
     validation_cfg = {**_DEFAULT_VALIDATION_CFG, **configuration.get("validation", {})}
+    columns_cfg = configuration.get("columns", {})
     cwd = os.getcwd()
     result = ValidationResult()
 
     _validate_telbestanden(cwd, paths, validation_cfg, result)
-    _validate_individueel(cwd, paths, validation_cfg, result)
-    _validate_oktober(cwd, paths, validation_cfg, result)
+    _validate_individueel(cwd, paths, validation_cfg, columns_cfg, result)
+    _validate_oktober(cwd, paths, validation_cfg, columns_cfg, result)
 
     _handle_result(result, yes)
     print("==== Validatie voltooid ====\n")
@@ -178,26 +200,34 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result):
                     f"[{weeknummer_min}, {weeknummer_max}]"
                 )
 
-        invalid_years = (
-            df[~df["Studiejaar"].between(year_min, year_max)]["Studiejaar"]
-            .dropna()
-            .unique()
-        )
+        studiejaar, was_coerced = _coerce_to_numeric(df["Studiejaar"])
+        if was_coerced:
+            result.warnings.append(
+                f"{filename}: kolom 'Studiejaar' is geen numeriek type — "
+                f"waarden worden automatisch geconverteerd"
+            )
+        invalid_years = studiejaar[~studiejaar.between(year_min, year_max)].dropna().unique()
         if len(invalid_years) > 0:
             result.soft_errors.append(
                 f"{filename}: Studiejaar bevat onverwachte waarden: "
                 f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
             )
 
-        _check_categoricals_per_programme(
-            df, "Herinschrijving", herinschrijving_allowed, "Groepeernaam", filename, result
-        )
-        _check_categoricals_per_programme(
-            df, "Hogerejaars", hogerejaars_allowed, "Groepeernaam", filename, result
-        )
-        _check_categoricals_per_programme(
-            df, "Herkomst", herkomst_allowed, "Groepeernaam", filename, result
-        )
+        for col, allowed in [
+            ("Herinschrijving", herinschrijving_allowed),
+            ("Hogerejaars", hogerejaars_allowed),
+            ("Herkomst", herkomst_allowed),
+        ]:
+            normalized, was_normalized = _normalize_series(df[col])
+            if was_normalized:
+                result.warnings.append(
+                    f"{filename}: kolom '{col}' bevat witruimte — "
+                    f"waarden worden automatisch gestript"
+                )
+            _check_categoricals_per_programme(
+                df.assign(**{col: normalized}),
+                col, allowed, "Groepeernaam", filename, result,
+            )
 
         zero_meercode = df[df["meercode_V"] == 0]
         if not zero_meercode.empty:
@@ -221,7 +251,7 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result):
             _check_nan_rate(df, col, filename, nan_warn, nan_error, result)
 
 
-def _validate_individueel(cwd, paths, validation_cfg, result):
+def _validate_individueel(cwd, paths, validation_cfg, columns_cfg, result):
     path = os.path.join(
         cwd, paths.get("path_raw_individueel", "data/input_raw/individuele_aanmelddata.csv")
     )
@@ -240,10 +270,15 @@ def _validate_individueel(cwd, paths, validation_cfg, result):
         )
         return
 
+    col_map = columns_cfg.get("individual", {})
     individueel_cfg = {**_DEFAULT_VALIDATION_CFG["individueel"], **validation_cfg.get("individueel", {})}
-    required_columns = individueel_cfg["required_columns"]
+    critical_columns = individueel_cfg["critical_columns"]
 
-    missing_cols = [c for c in required_columns if c not in df.columns]
+    missing_cols = [
+        f"{_resolve_column(c, col_map)} (verwacht als '{c}')"
+        for c in critical_columns
+        if _resolve_column(c, col_map) not in df.columns
+    ]
     if missing_cols:
         result.hard_errors.append(
             f"individuele_aanmelddata.csv: ontbrekende kolommen: {', '.join(missing_cols)}"
@@ -252,11 +287,12 @@ def _validate_individueel(cwd, paths, validation_cfg, result):
 
     nan_warn = validation_cfg["nan_warning_threshold"]
     nan_error = validation_cfg["nan_error_threshold"]
-    for col in ["Collegejaar", "Croho", "Inschrijfstatus"]:
-        _check_nan_rate(df, col, "individuele_aanmelddata.csv", nan_warn, nan_error, result)
+    for canonical in ["Collegejaar", "Croho", "Inschrijfstatus"]:
+        actual = _resolve_column(canonical, col_map)
+        _check_nan_rate(df, actual, "individuele_aanmelddata.csv", nan_warn, nan_error, result)
 
 
-def _validate_oktober(cwd, paths, validation_cfg, result):
+def _validate_oktober(cwd, paths, validation_cfg, columns_cfg, result):
     path = os.path.join(
         cwd, paths.get("path_raw_october", "data/input_raw/oktober_bestand.xlsx")
     )
@@ -275,40 +311,80 @@ def _validate_oktober(cwd, paths, validation_cfg, result):
         )
         return
 
+    col_map = columns_cfg.get("oktober", {})
     oktober_cfg = {**_DEFAULT_VALIDATION_CFG["oktober"], **validation_cfg.get("oktober", {})}
-    required_columns = oktober_cfg["required_columns"]
+    critical_columns = oktober_cfg["critical_columns"]
 
-    missing_cols = [c for c in required_columns if c not in df.columns]
+    missing_cols = [
+        f"{_resolve_column(c, col_map)} (verwacht als '{c}')"
+        for c in critical_columns
+        if _resolve_column(c, col_map) not in df.columns
+    ]
     if missing_cols:
         result.hard_errors.append(
             f"oktober_bestand.xlsx: ontbrekende kolommen: {', '.join(missing_cols)}"
         )
         return
 
+    collegejaar_col = _resolve_column("Collegejaar", col_map)
+    collegejaar, was_coerced = _coerce_to_numeric(df[collegejaar_col])
+    if was_coerced:
+        result.warnings.append(
+            f"oktober_bestand.xlsx: kolom '{collegejaar_col}' is geen numeriek type — "
+            f"waarden worden automatisch geconverteerd"
+        )
+
     current_year = datetime.date.today().year
     year_min = current_year - validation_cfg["collegejaar_min_offset"]
     year_max = current_year + validation_cfg["collegejaar_max_offset"]
-
-    invalid_years = (
-        df[~df["Collegejaar"].between(year_min, year_max)]["Collegejaar"]
-        .dropna()
-        .unique()
-    )
+    invalid_years = collegejaar[~collegejaar.between(year_min, year_max)].dropna().unique()
     if len(invalid_years) > 0:
         result.soft_errors.append(
-            f"oktober_bestand.xlsx: Collegejaar bevat onverwachte waarden: "
+            f"oktober_bestand.xlsx: {collegejaar_col} bevat onverwachte waarden: "
             f"{sorted(invalid_years)} (verwacht: {year_min}–{year_max})"
         )
 
     nan_warn = validation_cfg["nan_warning_threshold"]
     nan_error = validation_cfg["nan_error_threshold"]
-    for col in ["Collegejaar", "Aantal eerstejaars croho", "Aantal Hoofdinschrijvingen"]:
-        _check_nan_rate(df, col, "oktober_bestand.xlsx", nan_warn, nan_error, result)
+    for canonical in ["Collegejaar", "Aantal eerstejaars croho", "Aantal Hoofdinschrijvingen"]:
+        actual = _resolve_column(canonical, col_map)
+        _check_nan_rate(df, actual, "oktober_bestand.xlsx", nan_warn, nan_error, result)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _resolve_column(canonical, col_map):
+    """Resolve a canonical column name to the institution-specific name via the columns config."""
+    return col_map.get(canonical, canonical)
+
+
+def _normalize_series(series):
+    """Strip leading/trailing whitespace from a string series.
+
+    Returns (normalized_series, was_changed).
+    """
+    if not (pd.api.types.is_object_dtype(series) or pd.api.types.is_string_dtype(series)):
+        return series, False
+    normalized = series.str.strip()
+    was_changed = bool((normalized.fillna("") != series.fillna("")).any())
+    return normalized, was_changed
+
+
+def _coerce_to_numeric(series):
+    """Coerce a series to numeric, handling Dutch decimal notation (comma separator).
+
+    Returns (coerced_series, was_coerced). If already numeric, returns as-is.
+    """
+    if pd.api.types.is_numeric_dtype(series):
+        return series, False
+    coerced = pd.to_numeric(
+        series.astype(str).str.replace(".", "", regex=False).str.replace(",", ".", regex=False),
+        errors="coerce",
+    )
+    return coerced, True
+
 
 def _check_telbestand_completeness(files, validation_cfg, result):
     """Warn when there are unexpected gaps (> 2 weeks) between telbestanden within a year."""

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -120,6 +120,12 @@ def validate_raw_data(configuration, yes=False):
     print("==== Valideren van ruwe inputdata ====")
 
     paths = configuration["paths"]
+    # Top-level merge: voegt flat overrides toe (bijv. nan_error_threshold).
+    # Nested sub-dicts (telbestand, individueel, oktober) worden hier shallow
+    # vervangen als de gebruiker ze overschrijft. Elke _validate_*-functie
+    # doet daarom een tweede sub-merge met _DEFAULT_VALIDATION_CFG als basis,
+    # zodat een partial override nooit sleutels verliest. Voeg je een nieuwe
+    # sectie toe, volg dan hetzelfde patroon: zie _validate_telbestanden.
     validation_cfg = {**_DEFAULT_VALIDATION_CFG, **configuration.get("validation", {})}
     columns_cfg = configuration.get("columns", {})
     cwd = os.getcwd()
@@ -288,7 +294,7 @@ def _validate_individueel(cwd, paths, validation_cfg, columns_cfg, result):
 
     nan_warn = validation_cfg["nan_warning_threshold"]
     nan_error = validation_cfg["nan_error_threshold"]
-    for canonical in ["Collegejaar", "Croho", "Inschrijfstatus"]:
+    for canonical in critical_columns:
         actual = _resolve_column(canonical, col_map)
         _check_nan_rate(df, actual, "individuele_aanmelddata.csv", nan_warn, nan_error, result)
 
@@ -347,7 +353,7 @@ def _validate_oktober(cwd, paths, validation_cfg, columns_cfg, result):
 
     nan_warn = validation_cfg["nan_warning_threshold"]
     nan_error = validation_cfg["nan_error_threshold"]
-    for canonical in ["Collegejaar", "Aantal eerstejaars croho", "Aantal Hoofdinschrijvingen"]:
+    for canonical in critical_columns:
         actual = _resolve_column(canonical, col_map)
         _check_nan_rate(df, actual, "oktober_bestand.xlsx", nan_warn, nan_error, result)
 

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -13,10 +13,13 @@ from studentprognose.utils.weeks import DataOption, StudentYearPrediction, HIGHE
 def main(argv):
     cfg = parse_args(argv)
 
-    # Step 0: ETL (default — raw data → input data, skip with --noetl)
+    # Step 0: Validate raw input data, then run ETL (skip both with --noetl)
     if not cfg.noetl:
+        from studentprognose.data.validation import validate_raw_data
         from studentprognose.data.etl import run_etl
-        run_etl(load_configuration(cfg.configuration_path))
+        pipeline_configuration = load_configuration(cfg.configuration_path)
+        validate_raw_data(pipeline_configuration, yes=cfg.yes)
+        run_etl(pipeline_configuration)
 
     # Step 1: Load configuration and data
     print("Loading configuration...")

--- a/tests/studentprognose/test_validation.py
+++ b/tests/studentprognose/test_validation.py
@@ -1,0 +1,324 @@
+import os
+import re
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from studentprognose.data.validation import (
+    ValidationResult,
+    _check_categoricals_per_programme,
+    _check_nan_rate,
+    _check_telbestand_completeness,
+    _handle_result,
+    _DEFAULT_VALIDATION_CFG,
+    validate_raw_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult
+# ---------------------------------------------------------------------------
+
+class TestValidationResult:
+    def test_defaults_are_empty(self):
+        r = ValidationResult()
+        assert r.hard_errors == []
+        assert r.soft_errors == []
+        assert r.warnings == []
+
+    def test_append_to_lists(self):
+        r = ValidationResult()
+        r.hard_errors.append("fout")
+        r.soft_errors.append("probleem")
+        r.warnings.append("waarschuwing")
+        assert len(r.hard_errors) == 1
+        assert len(r.soft_errors) == 1
+        assert len(r.warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# _check_nan_rate
+# ---------------------------------------------------------------------------
+
+class TestCheckNanRate:
+    def _df(self, values):
+        return pd.DataFrame({"kolom": values})
+
+    def test_no_nans_produces_no_entries(self):
+        r = ValidationResult()
+        _check_nan_rate(self._df([1, 2, 3]), "kolom", "bestand.csv", 0.05, 0.30, r)
+        assert not r.warnings and not r.soft_errors
+
+    def test_below_warning_threshold_produces_no_entries(self):
+        r = ValidationResult()
+        _check_nan_rate(self._df([None] + [1] * 99), "kolom", "bestand.csv", 0.05, 0.30, r)
+        assert not r.warnings and not r.soft_errors
+
+    def test_above_warning_threshold_produces_warning(self):
+        r = ValidationResult()
+        _check_nan_rate(self._df([None] * 10 + [1] * 90), "kolom", "bestand.csv", 0.05, 0.30, r)
+        assert len(r.warnings) == 1
+        assert not r.soft_errors
+
+    def test_above_error_threshold_produces_soft_error(self):
+        r = ValidationResult()
+        _check_nan_rate(self._df([None] * 40 + [1] * 60), "kolom", "bestand.csv", 0.05, 0.30, r)
+        assert len(r.soft_errors) == 1
+        assert not r.warnings
+
+    def test_missing_column_is_ignored(self):
+        r = ValidationResult()
+        df = pd.DataFrame({"andere_kolom": [1, 2, 3]})
+        _check_nan_rate(df, "kolom", "bestand.csv", 0.05, 0.30, r)
+        assert not r.warnings and not r.soft_errors
+
+    def test_empty_dataframe_is_ignored(self):
+        r = ValidationResult()
+        _check_nan_rate(pd.DataFrame({"kolom": []}), "kolom", "bestand.csv", 0.05, 0.30, r)
+        assert not r.warnings and not r.soft_errors
+
+
+# ---------------------------------------------------------------------------
+# _check_categoricals_per_programme
+# ---------------------------------------------------------------------------
+
+class TestCheckCategoricalsPerProgramme:
+    def _df(self, values, programmes=None):
+        data = {"Herkomst": values}
+        if programmes is not None:
+            data["Groepeernaam"] = programmes
+        return pd.DataFrame(data)
+
+    def test_all_valid_produces_no_entry(self):
+        r = ValidationResult()
+        df = self._df(["N", "E", "R", "N"], ["A", "A", "B", "B"])
+        _check_categoricals_per_programme(df, "Herkomst", ["N", "E", "R"], "Groepeernaam", "f.csv", r)
+        assert not r.soft_errors
+
+    def test_invalid_value_produces_soft_error(self):
+        r = ValidationResult()
+        df = self._df(["N", "X"], ["A", "B"])
+        _check_categoricals_per_programme(df, "Herkomst", ["N", "E", "R"], "Groepeernaam", "f.csv", r)
+        assert len(r.soft_errors) == 1
+        assert "X" in r.soft_errors[0]
+        assert "B" in r.soft_errors[0]
+
+    def test_nan_values_are_ignored(self):
+        r = ValidationResult()
+        df = self._df(["N", None], ["A", "B"])
+        _check_categoricals_per_programme(df, "Herkomst", ["N", "E", "R"], "Groepeernaam", "f.csv", r)
+        assert not r.soft_errors
+
+    def test_without_programme_column_still_reports(self):
+        r = ValidationResult()
+        df = pd.DataFrame({"Herkomst": ["N", "ONBEKEND"]})
+        _check_categoricals_per_programme(df, "Herkomst", ["N", "E", "R"], "Groepeernaam", "f.csv", r)
+        assert len(r.soft_errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# _check_telbestand_completeness
+# ---------------------------------------------------------------------------
+
+class TestCheckTelbestandCompleteness:
+    def test_consecutive_weeks_no_warning(self):
+        r = ValidationResult()
+        files = [f"telbestandY2024W{w:02d}.csv" for w in range(1, 10)]
+        _check_telbestand_completeness(files, {}, r)
+        assert not r.warnings
+
+    def test_small_gap_no_warning(self):
+        r = ValidationResult()
+        files = ["telbestandY2024W01.csv", "telbestandY2024W03.csv"]
+        _check_telbestand_completeness(files, {}, r)
+        assert not r.warnings
+
+    def test_large_gap_produces_warning(self):
+        r = ValidationResult()
+        files = ["telbestandY2024W01.csv", "telbestandY2024W10.csv"]
+        _check_telbestand_completeness(files, {}, r)
+        assert len(r.warnings) == 1
+        assert "2024" in r.warnings[0]
+
+    def test_multiple_years_checked_independently(self):
+        r = ValidationResult()
+        files = [
+            "telbestandY2023W01.csv", "telbestandY2023W02.csv",
+            "telbestandY2024W01.csv", "telbestandY2024W15.csv",
+        ]
+        _check_telbestand_completeness(files, {}, r)
+        assert len(r.warnings) == 1
+        assert "2024" in r.warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# _handle_result
+# ---------------------------------------------------------------------------
+
+class TestHandleResult:
+    def test_no_issues_passes_silently(self, capsys):
+        r = ValidationResult()
+        _handle_result(r, yes=False)
+        out = capsys.readouterr().out
+        assert out == ""
+
+    def test_warning_is_printed(self, capsys):
+        r = ValidationResult()
+        r.warnings.append("let op dit")
+        _handle_result(r, yes=False)
+        assert "let op dit" in capsys.readouterr().out
+
+    def test_hard_error_exits(self):
+        r = ValidationResult()
+        r.hard_errors.append("kritieke fout")
+        with pytest.raises(SystemExit):
+            _handle_result(r, yes=False)
+
+    def test_soft_error_with_yes_does_not_prompt(self, capsys):
+        r = ValidationResult()
+        r.soft_errors.append("klein probleem")
+        _handle_result(r, yes=True)
+        assert "--yes" in capsys.readouterr().out
+
+    def test_soft_error_without_yes_prompts_and_j_continues(self, capsys):
+        r = ValidationResult()
+        r.soft_errors.append("klein probleem")
+        with patch("builtins.input", return_value="j"):
+            _handle_result(r, yes=False)
+        assert "Doorgaan" in capsys.readouterr().out
+
+    def test_soft_error_without_yes_prompts_and_n_exits(self):
+        r = ValidationResult()
+        r.soft_errors.append("klein probleem")
+        with patch("builtins.input", return_value="n"):
+            with pytest.raises(SystemExit):
+                _handle_result(r, yes=False)
+
+    def test_soft_error_eof_exits_gracefully(self):
+        r = ValidationResult()
+        r.soft_errors.append("klein probleem")
+        with patch("builtins.input", side_effect=EOFError):
+            with pytest.raises(SystemExit):
+                _handle_result(r, yes=False)
+
+
+# ---------------------------------------------------------------------------
+# validate_raw_data integration (file-based with tmp_path)
+# ---------------------------------------------------------------------------
+
+def _make_valid_telbestand(path, year=2024, week=1):
+    df = pd.DataFrame({
+        "Studiejaar": [year],
+        "Isatcode": ["12345"],
+        "Groepeernaam": ["B Opleiding"],
+        "Aantal": [10],
+        "meercode_V": [2],
+        "Herinschrijving": ["N"],
+        "Hogerejaars": ["N"],
+        "Herkomst": ["N"],
+    })
+    df.to_csv(path, sep=";", index=False)
+
+
+def _make_configuration(tmp_path, telbestanden_dir, with_individueel=False, with_oktober=False):
+    cfg = {
+        "paths": {
+            "path_raw_telbestanden": str(telbestanden_dir),
+            "path_raw_individueel": str(tmp_path / "individuele_aanmelddata.csv") if with_individueel else "nonexistent.csv",
+            "path_raw_october": str(tmp_path / "oktober_bestand.xlsx") if with_oktober else "nonexistent.xlsx",
+        },
+        "validation": {},
+    }
+    if with_individueel:
+        pd.DataFrame({
+            "Collegejaar": [2024],
+            "Croho": ["12345"],
+            "Inschrijfstatus": ["Ingeschreven"],
+            "Datum Verzoek Inschr": ["2024-01-01"],
+        }).to_csv(tmp_path / "individuele_aanmelddata.csv", sep=";", index=False)
+    return cfg
+
+
+class TestValidateRawDataIntegration:
+    def test_valid_data_passes(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        _make_valid_telbestand(telbestanden_dir / "telbestandY2024W01.csv")
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        validate_raw_data(cfg, yes=True)
+
+    def test_missing_telbestanden_dir_exits(self, tmp_path, monkeypatch):
+        cfg = _make_configuration(tmp_path, tmp_path / "nonexistent")
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            validate_raw_data(cfg, yes=True)
+
+    def test_missing_column_in_telbestand_exits(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        pd.DataFrame({"Studiejaar": [2024], "Isatcode": ["12345"]}).to_csv(
+            telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False
+        )
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            validate_raw_data(cfg, yes=True)
+
+    def test_zero_meercode_triggers_soft_error_yes_passes(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        df = pd.DataFrame({
+            "Studiejaar": [2024],
+            "Isatcode": ["12345"],
+            "Groepeernaam": ["B Opleiding"],
+            "Aantal": [10],
+            "meercode_V": [0],
+            "Herinschrijving": ["N"],
+            "Hogerejaars": ["N"],
+            "Herkomst": ["N"],
+        })
+        df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        validate_raw_data(cfg, yes=True)
+
+    def test_invalid_herkomst_prompts_and_n_exits(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        df = pd.DataFrame({
+            "Studiejaar": [2024],
+            "Isatcode": ["12345"],
+            "Groepeernaam": ["B Opleiding"],
+            "Aantal": [10],
+            "meercode_V": [2],
+            "Herinschrijving": ["N"],
+            "Hogerejaars": ["N"],
+            "Herkomst": ["ONBEKEND"],
+        })
+        df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        with patch("builtins.input", return_value="n"):
+            with pytest.raises(SystemExit):
+                validate_raw_data(cfg, yes=False)
+
+    def test_yes_flag_skips_prompt_for_soft_errors(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        df = pd.DataFrame({
+            "Studiejaar": [2024],
+            "Isatcode": ["12345"],
+            "Groepeernaam": ["B Opleiding"],
+            "Aantal": [10],
+            "meercode_V": [2],
+            "Herinschrijving": ["N"],
+            "Hogerejaars": ["N"],
+            "Herkomst": ["ONBEKEND"],
+        })
+        df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        validate_raw_data(cfg, yes=True)

--- a/tests/studentprognose/test_validation.py
+++ b/tests/studentprognose/test_validation.py
@@ -173,11 +173,12 @@ class TestHandleResult:
         _handle_result(r, yes=False)
         assert "let op dit" in capsys.readouterr().out
 
-    def test_hard_error_exits(self):
+    def test_hard_error_exits_with_code_1(self):
         r = ValidationResult()
         r.hard_errors.append("kritieke fout")
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             _handle_result(r, yes=False)
+        assert exc_info.value.code == 1
 
     def test_soft_error_with_yes_does_not_prompt(self, capsys):
         r = ValidationResult()
@@ -192,19 +193,132 @@ class TestHandleResult:
             _handle_result(r, yes=False)
         assert "Doorgaan" in capsys.readouterr().out
 
-    def test_soft_error_without_yes_prompts_and_n_exits(self):
+    def test_soft_error_without_yes_prompts_and_n_exits_with_code_0(self):
         r = ValidationResult()
         r.soft_errors.append("klein probleem")
         with patch("builtins.input", return_value="n"):
-            with pytest.raises(SystemExit):
+            with pytest.raises(SystemExit) as exc_info:
                 _handle_result(r, yes=False)
+        assert exc_info.value.code == 0
 
-    def test_soft_error_eof_exits_gracefully(self):
+    def test_soft_error_eof_exits_gracefully_with_code_0(self):
         r = ValidationResult()
         r.soft_errors.append("klein probleem")
         with patch("builtins.input", side_effect=EOFError):
-            with pytest.raises(SystemExit):
+            with pytest.raises(SystemExit) as exc_info:
                 _handle_result(r, yes=False)
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# _validate_oktober unit tests
+# ---------------------------------------------------------------------------
+
+def _make_valid_oktober(path, year=2024, col_map=None):
+    """Write a minimal valid oktober_bestand.xlsx to path."""
+    col_map = col_map or {}
+    cols = {
+        "Collegejaar": year,
+        "Groepeernaam Croho": "B Opleiding",
+        "Aantal eerstejaars croho": 1,
+        "EER-NL-nietEER": "NL",
+        "Examentype code": "Bachelor eerstejaars",
+        "Aantal Hoofdinschrijvingen": 100,
+    }
+    # Apply institution-specific column names if provided
+    renamed = {col_map.get(k, k): v for k, v in cols.items()}
+    pd.DataFrame([renamed]).to_excel(path, index=False)
+
+
+class TestValidateOktober:
+    def _cfg(self, tmp_path, col_map=None):
+        return {
+            "paths": {"path_raw_october": str(tmp_path / "oktober_bestand.xlsx")},
+            "validation": {},
+            "columns": {"oktober": col_map or {
+                "Collegejaar": "Collegejaar",
+                "Groepeernaam Croho": "Groepeernaam Croho",
+                "Aantal eerstejaars croho": "Aantal eerstejaars croho",
+                "EER-NL-nietEER": "EER-NL-nietEER",
+                "Examentype code": "Examentype code",
+                "Aantal Hoofdinschrijvingen": "Aantal Hoofdinschrijvingen",
+            }},
+        }
+
+    def test_valid_file_passes(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _make_valid_oktober(tmp_path / "oktober_bestand.xlsx")
+        from studentprognose.data.validation import _validate_oktober, _DEFAULT_VALIDATION_CFG
+        result = ValidationResult()
+        cfg = self._cfg(tmp_path)
+        validation_cfg = {**_DEFAULT_VALIDATION_CFG, **cfg.get("validation", {})}
+        _validate_oktober(str(tmp_path), cfg["paths"], validation_cfg, cfg["columns"], result)
+        assert not result.hard_errors
+        assert not result.soft_errors
+
+    def test_missing_file_produces_warning(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from studentprognose.data.validation import _validate_oktober, _DEFAULT_VALIDATION_CFG
+        result = ValidationResult()
+        cfg = self._cfg(tmp_path)
+        validation_cfg = {**_DEFAULT_VALIDATION_CFG}
+        _validate_oktober(str(tmp_path), cfg["paths"], validation_cfg, cfg["columns"], result)
+        assert not result.hard_errors
+        assert len(result.warnings) == 1
+        assert "Oktober-bestand" in result.warnings[0]
+
+    def test_missing_column_produces_hard_error(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        pd.DataFrame({"Collegejaar": [2024]}).to_excel(
+            tmp_path / "oktober_bestand.xlsx", index=False
+        )
+        from studentprognose.data.validation import _validate_oktober, _DEFAULT_VALIDATION_CFG
+        result = ValidationResult()
+        cfg = self._cfg(tmp_path)
+        validation_cfg = {**_DEFAULT_VALIDATION_CFG}
+        _validate_oktober(str(tmp_path), cfg["paths"], validation_cfg, cfg["columns"], result)
+        assert len(result.hard_errors) == 1
+        assert "ontbrekende kolommen" in result.hard_errors[0]
+
+    def test_out_of_range_collegejaar_produces_soft_error(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _make_valid_oktober(tmp_path / "oktober_bestand.xlsx", year=1990)
+        from studentprognose.data.validation import _validate_oktober, _DEFAULT_VALIDATION_CFG
+        result = ValidationResult()
+        cfg = self._cfg(tmp_path)
+        validation_cfg = {**_DEFAULT_VALIDATION_CFG}
+        _validate_oktober(str(tmp_path), cfg["paths"], validation_cfg, cfg["columns"], result)
+        assert len(result.soft_errors) == 1
+        assert "1990" in result.soft_errors[0]
+
+    def test_year_displayed_as_int_not_float(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _make_valid_oktober(tmp_path / "oktober_bestand.xlsx", year=1990)
+        from studentprognose.data.validation import _validate_oktober, _DEFAULT_VALIDATION_CFG
+        result = ValidationResult()
+        cfg = self._cfg(tmp_path)
+        validation_cfg = {**_DEFAULT_VALIDATION_CFG}
+        _validate_oktober(str(tmp_path), cfg["paths"], validation_cfg, cfg["columns"], result)
+        assert "1990.0" not in result.soft_errors[0]
+        assert "1990" in result.soft_errors[0]
+
+    def test_institution_specific_column_names_pass(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        col_map = {
+            "Collegejaar": "Academic Year",
+            "Groepeernaam Croho": "Programme",
+            "Aantal eerstejaars croho": "First Year Count",
+            "EER-NL-nietEER": "Origin",
+            "Examentype code": "Exam Type",
+            "Aantal Hoofdinschrijvingen": "Enrolments",
+        }
+        _make_valid_oktober(tmp_path / "oktober_bestand.xlsx", col_map=col_map)
+        from studentprognose.data.validation import _validate_oktober, _DEFAULT_VALIDATION_CFG
+        result = ValidationResult()
+        cfg = self._cfg(tmp_path, col_map=col_map)
+        validation_cfg = {**_DEFAULT_VALIDATION_CFG}
+        _validate_oktober(str(tmp_path), cfg["paths"], validation_cfg, cfg["columns"], result)
+        assert not result.hard_errors
 
 
 # ---------------------------------------------------------------------------

--- a/tests/studentprognose/test_validation.py
+++ b/tests/studentprognose/test_validation.py
@@ -11,7 +11,10 @@ from studentprognose.data.validation import (
     _check_categoricals_per_programme,
     _check_nan_rate,
     _check_telbestand_completeness,
+    _coerce_to_numeric,
     _handle_result,
+    _normalize_series,
+    _resolve_column,
     _DEFAULT_VALIDATION_CFG,
     validate_raw_data,
 )
@@ -222,7 +225,8 @@ def _make_valid_telbestand(path, year=2024, week=1):
     df.to_csv(path, sep=";", index=False)
 
 
-def _make_configuration(tmp_path, telbestanden_dir, with_individueel=False, with_oktober=False):
+def _make_configuration(tmp_path, telbestanden_dir, with_individueel=False, with_oktober=False,
+                        individueel_col_map=None, oktober_col_map=None):
     cfg = {
         "paths": {
             "path_raw_telbestanden": str(telbestanden_dir),
@@ -230,13 +234,30 @@ def _make_configuration(tmp_path, telbestanden_dir, with_individueel=False, with
             "path_raw_october": str(tmp_path / "oktober_bestand.xlsx") if with_oktober else "nonexistent.xlsx",
         },
         "validation": {},
+        "columns": {
+            "individual": individueel_col_map or {
+                "Collegejaar": "Collegejaar",
+                "Croho": "Croho",
+                "Inschrijfstatus": "Inschrijfstatus",
+                "Datum Verzoek Inschr": "Datum Verzoek Inschr",
+            },
+            "oktober": oktober_col_map or {
+                "Collegejaar": "Collegejaar",
+                "Groepeernaam Croho": "Groepeernaam Croho",
+                "Aantal eerstejaars croho": "Aantal eerstejaars croho",
+                "EER-NL-nietEER": "EER-NL-nietEER",
+                "Examentype code": "Examentype code",
+                "Aantal Hoofdinschrijvingen": "Aantal Hoofdinschrijvingen",
+            },
+        },
     }
     if with_individueel:
+        col_map = cfg["columns"]["individual"]
         pd.DataFrame({
-            "Collegejaar": [2024],
-            "Croho": ["12345"],
-            "Inschrijfstatus": ["Ingeschreven"],
-            "Datum Verzoek Inschr": ["2024-01-01"],
+            col_map.get("Collegejaar", "Collegejaar"): [2024],
+            col_map.get("Croho", "Croho"): ["12345"],
+            col_map.get("Inschrijfstatus", "Inschrijfstatus"): ["Ingeschreven"],
+            col_map.get("Datum Verzoek Inschr", "Datum Verzoek Inschr"): ["2024-01-01"],
         }).to_csv(tmp_path / "individuele_aanmelddata.csv", sep=";", index=False)
     return cfg
 
@@ -322,3 +343,145 @@ class TestValidateRawDataIntegration:
         cfg = _make_configuration(tmp_path, telbestanden_dir)
         monkeypatch.chdir(tmp_path)
         validate_raw_data(cfg, yes=True)
+
+    def test_whitespace_in_herkomst_produces_warning_not_error(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        df = pd.DataFrame({
+            "Studiejaar": [2024],
+            "Isatcode": ["12345"],
+            "Groepeernaam": ["B Opleiding"],
+            "Aantal": [10],
+            "meercode_V": [2],
+            "Herinschrijving": ["N"],
+            "Hogerejaars": ["N"],
+            "Herkomst": ["N "],  # trailing whitespace
+        })
+        df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        validate_raw_data(cfg, yes=True)
+
+    def test_string_studiejaar_produces_warning_not_error(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        df = pd.DataFrame({
+            "Studiejaar": ["2024"],  # string instead of int
+            "Isatcode": ["12345"],
+            "Groepeernaam": ["B Opleiding"],
+            "Aantal": [10],
+            "meercode_V": [2],
+            "Herinschrijving": ["N"],
+            "Hogerejaars": ["N"],
+            "Herkomst": ["N"],
+        })
+        df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
+        cfg = _make_configuration(tmp_path, telbestanden_dir)
+        monkeypatch.chdir(tmp_path)
+        validate_raw_data(cfg, yes=True)
+
+    def test_institution_specific_column_names_in_individueel(self, tmp_path, monkeypatch):
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        _make_valid_telbestand(telbestanden_dir / "telbestandY2024W01.csv")
+
+        col_map = {
+            "Collegejaar": "Academic Year",
+            "Croho": "Programme Code",
+            "Inschrijfstatus": "Status",
+            "Datum Verzoek Inschr": "Request Date",
+        }
+        cfg = _make_configuration(tmp_path, telbestanden_dir, with_individueel=True,
+                                  individueel_col_map=col_map)
+        monkeypatch.chdir(tmp_path)
+        validate_raw_data(cfg, yes=True)
+
+    def test_canonical_column_names_in_individueel_fail_when_mapped(self, tmp_path, monkeypatch):
+        """If config maps 'Collegejaar' → 'Academic Year' but file still has 'Collegejaar', it fails."""
+        telbestanden_dir = tmp_path / "telbestanden"
+        telbestanden_dir.mkdir()
+        _make_valid_telbestand(telbestanden_dir / "telbestandY2024W01.csv")
+
+        col_map = {
+            "Collegejaar": "Academic Year",
+            "Croho": "Croho",
+            "Inschrijfstatus": "Inschrijfstatus",
+            "Datum Verzoek Inschr": "Datum Verzoek Inschr",
+        }
+        cfg = _make_configuration(tmp_path, telbestanden_dir, with_individueel=False,
+                                  individueel_col_map=col_map)
+        # Write file with canonical names, but mapping expects 'Academic Year'
+        pd.DataFrame({
+            "Collegejaar": [2024], "Croho": ["12345"],
+            "Inschrijfstatus": ["Ingeschreven"], "Datum Verzoek Inschr": ["2024-01-01"],
+        }).to_csv(tmp_path / "individuele_aanmelddata.csv", sep=";", index=False)
+        cfg["paths"]["path_raw_individueel"] = str(tmp_path / "individuele_aanmelddata.csv")
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            validate_raw_data(cfg, yes=True)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for new helpers
+# ---------------------------------------------------------------------------
+
+class TestResolveColumn:
+    def test_returns_mapped_name(self):
+        assert _resolve_column("Collegejaar", {"Collegejaar": "Academic Year"}) == "Academic Year"
+
+    def test_returns_canonical_when_not_in_map(self):
+        assert _resolve_column("Collegejaar", {}) == "Collegejaar"
+
+    def test_returns_canonical_when_mapping_is_identity(self):
+        assert _resolve_column("Collegejaar", {"Collegejaar": "Collegejaar"}) == "Collegejaar"
+
+
+class TestNormalizeSeries:
+    def test_strips_whitespace(self):
+        s = pd.Series(["N ", " E", " R "])
+        normalized, was_changed = _normalize_series(s)
+        assert list(normalized) == ["N", "E", "R"]
+        assert was_changed is True
+
+    def test_clean_series_not_changed(self):
+        s = pd.Series(["N", "E", "R"])
+        _, was_changed = _normalize_series(s)
+        assert was_changed is False
+
+    def test_non_string_series_returned_as_is(self):
+        s = pd.Series([1, 2, 3])
+        normalized, was_changed = _normalize_series(s)
+        assert was_changed is False
+        assert list(normalized) == [1, 2, 3]
+
+    def test_nan_not_treated_as_changed(self):
+        s = pd.Series(["N", None])
+        _, was_changed = _normalize_series(s)
+        assert was_changed is False
+
+
+class TestCoerceToNumeric:
+    def test_already_numeric_not_coerced(self):
+        s = pd.Series([2024, 2025])
+        result, was_coerced = _coerce_to_numeric(s)
+        assert was_coerced is False
+        assert list(result) == [2024, 2025]
+
+    def test_string_integers_coerced(self):
+        s = pd.Series(["2024", "2025"])
+        result, was_coerced = _coerce_to_numeric(s)
+        assert was_coerced is True
+        assert list(result) == [2024.0, 2025.0]
+
+    def test_dutch_decimal_notation_coerced(self):
+        s = pd.Series(["2.024", "2.025"])
+        result, was_coerced = _coerce_to_numeric(s)
+        assert was_coerced is True
+        assert list(result) == [2024.0, 2025.0]
+
+    def test_unparseable_becomes_nan(self):
+        s = pd.Series(["abc", "2024"])
+        result, was_coerced = _coerce_to_numeric(s)
+        assert was_coerced is True
+        assert pd.isna(result.iloc[0])
+        assert result.iloc[1] == 2024.0


### PR DESCRIPTION
Closes #54

## Wat is er gedaan

Pre-ETL validatie van alle ruwe inputbestanden vóór de pipeline start. Geen stille fouten meer — de gebruiker weet wat er mis is voordat er 20 minuten draaitijd verspild wordt.

## Wat er gevalideerd wordt

**Telbestanden** (`telbestandY{jaar}W{week}.csv`):
- Aanwezigheid van de map en minimaal één bestand
- Schema: alle vereiste kolommen aanwezig
- Weeknummer in bestandsnaam valt binnen [1, 53] (ISO 8601: sommige jaren hebben week 53)
- `Studiejaar` binnen dynamisch bereik (huidig jaar ± configureerbare offset)
- Categorische waarden: `Herinschrijving` ∈ {J, N}, `Hogerejaars` ∈ {J, N}, `Herkomst` ∈ {N, E, R}
- `meercode_V = 0` (deling door nul in ETL), `Aantal < 0`
- NaN-drempels op numerieke kernkolommen
- Gaten (> 2 weken) tussen telbestanden per jaar

**Individuele aanmelddata** en **oktober-bestand**: schema- en NaN-checks.

## Gedragsontwerp

| Type | Voorbeeld | Gedrag |
|---|---|---|
| Hard fout | Ontbrekend bestand, ontbrekende kolom | Pipeline stopt direct |
| Zacht probleem | Range-schending, meercode_V=0, hoog NaN% | Pre-flight prompt |
| Waarschuwing | Klein NaN%, weekgaten | Gelogd, pipeline loopt door |

De pre-flight prompt maakt duidelijk welke opleidingen worden geraakt **voordat de pipeline start**, zodat de gebruiker nooit verrast wordt door minder output dan verwacht na een lange run.

`--yes` slaat de prompt over voor geautomatiseerde runs (CI/CD).

## Ontwerpbeslissing: één bron van waarheid voor defaults

Validatiedefaults staan uitsluitend in `_DEFAULT_VALIDATION_CFG` in `validation.py`. Het `validation`-blok is **bewust weggelaten** uit `configuration.json`.

**Waarom:** twee plekken die hetzelfde definiëren lopen onvermijdelijk uit de pas. `configuration.json` is bedoeld voor *overrides*, niet voor het dupliceren van defaults.

**Overriden:** voeg alleen de afwijkende waarden toe aan je `configuration.json`:
```json
{
    "validation": {
        "nan_error_threshold": 0.20,
        "telbestand": {
            "herkomst_allowed": ["N", "E", "R", "ONBEKEND"]
        }
    }
}
```

Jaarbereiken zijn niet hardcoded — ze worden berekend als `huidig_jaar ± offset` uit de config.

## Wijzigingen

- `src/studentprognose/data/validation.py` — nieuw validatiemodule met module-docstring (uitleg gedrag, override-patroon, stappenplan voor nieuwe checks)
- `src/studentprognose/cli.py` — `--yes` flag, `--noetl` helptekst verduidelijkt
- `src/studentprognose/main.py` — validatie aangeroepen vóór ETL in step 0
- `configuration/configuration.json` — `columns.oktober` mapping toegevoegd (identity default, instelling kan overschrijven)
- `README.md` — validatiesectie voor eindgebruikers + architectuurtabel bijgewerkt

## Tests

50 tests dekken: `ValidationResult`, NaN-checks, categorische checks, bestandscompleteness, prompt-gedrag (`--yes`, `j/N`, EOF), en end-to-end integratietests met echte bestanden via `tmp_path`.

```
$ uv run pytest tests/studentprognose/test_validation.py
50 passed in 0.57s
```

## Test plan

### 1. Geldige data — validatie passeert zonder prompt

```
$ uv run main.py -w 6 -y 2024 -d c
==== Valideren van ruwe inputdata ====
==== Validatie voltooid ====

==== Processing raw input data ====
...
```

### 2. Ontbrekende kolom in telbestand — hard fout, exit code 1

```python
# telbestand bevat alleen 'Brincode' en 'Weeknummer', rest ontbreekt
validate_raw_data(cfg, yes=True)
```

```
==== Valideren van ruwe inputdata ====

Validatie mislukt — de pipeline kan niet worden gestart:
  [FOUT] telbestandY2024W6.csv: ontbrekende kolommen: Studiejaar, Isatcode,
         Groepeernaam, Aantal, meercode_V, Herinschrijving, Hogerejaars, Herkomst

Los de bovenstaande fouten op in je ruwe inputdata of configuratie en probeer opnieuw.

EXIT CODE: 1
```

### 3. meercode_V = 0 — pre-flight prompt, gebruiker typt N → exit code 0

```python
# telbestand met meercode_V = 0 voor 'B Opleiding'
with patch('builtins.input', return_value='N'):
    validate_raw_data(cfg, yes=False)
```

```
==== Valideren van ruwe inputdata ====

Validatie gevonden problemen die prognoses kunnen beïnvloeden:
  [PROBLEEM] telbestandY2024W6.csv: meercode_V = 0 (deling door nul in ETL)
             voor 1 opleiding(en): B Opleiding

Als je doorgaat, kunnen sommige opleidingen worden overgeslagen of onbetrouwbare
prognoses opleveren. Je zou dan minder opleidingen terugkrijgen dan verwacht.
Tip: gebruik --yes om deze prompt te omzeilen in geautomatiseerde runs.

Pipeline gestopt. Los de problemen op in je ruwe inputdata en probeer opnieuw.

EXIT CODE: 0
```

### 4. --yes — prompt overgeslagen, pipeline gaat door

```python
# zelfde data als stap 3, nu met yes=True
validate_raw_data(cfg, yes=True)
```

```
==== Valideren van ruwe inputdata ====

Validatie gevonden problemen die prognoses kunnen beïnvloeden:
  [PROBLEEM] telbestandY2024W6.csv: meercode_V = 0 (deling door nul in ETL)
             voor 1 opleiding(en): B Opleiding

--yes opgegeven: pipeline wordt gestart ondanks bovenstaande problemen.
Prognoses voor de betreffende opleidingen kunnen onbetrouwbaar zijn of worden overgeslagen.
==== Validatie voltooid ====

Pipeline gaat door (geen exit)
```

### 5. --noetl — validatie én ETL overgeslagen

```
$ uv run main.py --noetl -w 6 -y 2024 -d c
Loading configuration...
Loading data...
Preprocessing...
...
```

Geen validatie-output — intentioneel, zie `--noetl` helptekst.

### 6. Override nan_error_threshold via config — werkt

```python
cfg = { ..., "validation": {"nan_error_threshold": 0.10} }
# telbestand met 50% NaN in kolom 'Aantal'
validate_raw_data(cfg, yes=True)
```

```
==== Valideren van ruwe inputdata ====

Validatie gevonden problemen die prognoses kunnen beïnvloeden:
  [PROBLEEM] telbestandY2024W6.csv: kolom 'Aantal' heeft 50% ontbrekende
             waarden (foutdrempel: 10%)

--yes opgegeven: pipeline wordt gestart ondanks bovenstaande problemen.
Prognoses voor de betreffende opleidingen kunnen onbetrouwbaar zijn of worden overgeslagen.
==== Validatie voltooid ====
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)