### PR TITLE
feat: MkDocs documentatiesite + CLAUDE.md PR-enforcement (#74)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install docs dependencies
+        run: uv sync --group docs
+
+      - name: Build and deploy docs
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: uv run mkdocs gh-deploy --force
+
+      - name: Build docs (PR check)
+        if: github.event_name == 'pull_request'
+        run: uv run mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -26,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --group docs && uv pip install -e .
+        run: uv sync --group docs
 
       - name: Build docs
         run: uv run mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,10 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,13 +25,29 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install docs dependencies
-        run: uv sync --group docs
+      - name: Install dependencies
+        run: uv sync --group docs && uv pip install -e .
 
-      - name: Build and deploy docs
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: uv run mkdocs gh-deploy --force
-
-      - name: Build docs (PR check)
-        if: github.event_name == 'pull_request'
+      - name: Build docs
         run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 .venv/
 .vscode/
+site/
 
 #Data files can be ignored
 data/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Studentprognose is een open-source CEDA/Npuls tool voor het voorspellen van eers
 
 - **Python 3.12+** met **uv** voor dependency management
 - **pandas / numpy** voor dataverwerking
-- **pmdarima** voor SARIMA (auto_arima)
+- **statsmodels** voor SARIMA (SARIMAX met vaste parameters)
 - **xgboost** voor classificatie en regressie
 - **Rich** voor CLI-output
 - **MkDocs + Material** voor documentatie (gehost via GitHub Pages)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,9 @@ docs/                    # MkDocs bronbestanden
 ## Development Commands
 
 ```bash
-# Applicatie draaien
-uv run main.py
+# Applicatie draaien (via CLI entry point)
+studentprognose --help
+uv run studentprognose --help
 
 # Tests
 uv run pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,7 @@ docs/                    # MkDocs bronbestanden
 ## Development Commands
 
 ```bash
-# Applicatie draaien (via CLI entry point)
-studentprognose --help
+# Applicatie draaien
 uv run studentprognose --help
 
 # Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# Claude Configuration — Studentprognose
+
+## Project Overview
+
+Studentprognose is een open-source CEDA/Npuls tool voor het voorspellen van eerstejaars instroom in het hoger onderwijs. Het combineert tijdreeksmodellen (SARIMA), machine learning (XGBoost) en een ratio-model tot een ensemble-voorspelling, draaiend als installeerbaar Python-package met CLI.
+
+**Doelgroep van de tool:** data-analisten en onderzoekers bij Nederlandse hogeronderwijsinstellingen.
+
+## Tech Stack
+
+- **Python 3.12+** met **uv** voor dependency management
+- **pandas / numpy** voor dataverwerking
+- **pmdarima** voor SARIMA (auto_arima)
+- **xgboost** voor classificatie en regressie
+- **Rich** voor CLI-output
+- **MkDocs + Material** voor documentatie (gehost via GitHub Pages)
+
+## Project Structure
+
+```
+src/studentprognose/
+├── cli.py               # CLI-definitie (argparse)
+├── config.py            # Configuratie laden
+├── main.py              # Pipeline-entry
+├── models/
+│   ├── base.py          # BaseForecaster ABC
+│   ├── sarima.py        # SARIMA model
+│   ├── xgboost_classifier.py
+│   ├── xgboost_regressor.py
+│   └── ratio.py         # Ratio-model
+├── strategies/
+│   ├── individual.py    # Individueel spoor preprocessing
+│   ├── cumulative.py    # Cumulatief spoor preprocessing
+│   └── combined.py      # Both-modus
+├── output/              # Output-schrijvers
+└── utils/               # Hulpfuncties
+
+docs/                    # MkDocs bronbestanden
+├── index.md
+├── aan-de-slag.md
+├── je-data-voorbereiden.md
+├── configuratie.md
+├── validatie.md
+├── output-begrijpen.md
+└── methodologie/
+    ├── index.md
+    ├── sarima.md
+    ├── xgboost.md
+    ├── ratio-model.md
+    └── ensemble.md
+```
+
+## Development Commands
+
+```bash
+# Applicatie draaien
+uv run main.py
+
+# Tests
+uv run pytest
+
+# Linting
+uv run ruff check .
+uv run ruff format .
+
+# Documentatie lokaal bekijken
+uv run mkdocs serve
+
+# Documentatie bouwen
+uv run mkdocs build
+```
+
+## Documentatie-regel (verplicht bij elke PR)
+
+De documentatie in `docs/` is gericht op **analisten en onderzoekers**: niet alleen hoe de tool werkt, maar het **waarom** achter methodologische keuzes — aannames, beperkingen, en wanneer je output kritisch moet interpreteren.
+
+### Bij elke PR: controleer welke docs-pagina's geraakt zijn
+
+Gebruik de onderstaande mapping om te bepalen welke pagina('s) bijgewerkt moeten worden. Als een wijziging een pagina raakt, **moet die pagina worden meegenomen in de PR**. Een PR zonder bijbehorende docs-update is onvolledig.
+
+| Als je dit wijzigt... | ...update dan deze docs-pagina |
+|-----------------------|-------------------------------|
+| CLI-vlaggen / `cli.py` / `main.py` | `docs/aan-de-slag.md` |
+| `configuration.json` / `config.py` | `docs/configuratie.md` |
+| Inputformaten / ETL / `etl.py` | `docs/je-data-voorbereiden.md` |
+| Datakwaliteitscontroles / validatie | `docs/validatie.md` |
+| Outputbestanden / kolomnamen / outputschema | `docs/output-begrijpen.md` |
+| `models/sarima.py` / SARIMA-parameters | `docs/methodologie/sarima.md` |
+| `models/xgboost_*.py` / XGBoost-features of -parameters | `docs/methodologie/xgboost.md` |
+| `models/ratio.py` / ratio-logica | `docs/methodologie/ratio-model.md` |
+| Ensemble-logica / gewichten / postprocessor | `docs/methodologie/ensemble.md` |
+| Architectuur / pipeline-volgorde | `docs/methodologie/index.md` |
+
+### Wat hoort in een methodologie-pagina?
+
+Methodologie-pagina's (`docs/methodologie/`) moeten antwoord geven op:
+
+1. **Wat doet het?** — functionele beschrijving in begrijpelijke taal
+2. **Waarom deze aanpak?** — motivatie voor de modelkeuze, alternatieven overwogen
+3. **Aannames** — wat moet waar zijn opdat het model goed werkt
+4. **Wanneer vertrouw je het niet?** — concrete situaties waarin de output kritisch beoordeeld moet worden
+5. **Relatie tot andere modellen** — hoe past dit in het ensemble
+
+Voeg geen implementatiedetails toe die direct uit de code leesbaar zijn. Schrijf voor iemand die het model wil begrijpen, niet voor iemand die de code wil debuggen.
+
+## Code Conventions
+
+- Gebruik type annotations in nieuwe functies
+- Docstrings in Google-stijl (worden opgepikt door mkdocstrings)
+- Geen hardgecodeerde instellingsnamen of paden in gedeelde code
+- Mutable default arguments vermijden (gebruik `None` + check in body)

--- a/doc/TECHNICAL_README.md
+++ b/doc/TECHNICAL_README.md
@@ -1,5 +1,10 @@
 # Technische README
 
+> **Verouderd** — Dit document is niet bijgewerkt na de refactor in #56 en verwijst nog naar de oude `scripts/`-structuur.
+> De actuele documentatie staat op de [MkDocs-site](https://cedanl.github.io/studentprognose/) (zie `docs/`).
+
+
+
 ## Installatie
 
 ### Vereisten

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -1,0 +1,36 @@
+# Aan de slag
+
+## Installatie
+
+```bash
+pip install studentprognose
+```
+
+Of met uv:
+
+```bash
+uv add studentprognose
+```
+
+## Eerste run met demodata
+
+TODO: demodata toevoegen en walkthrough uitschrijven.
+
+## Vereisten
+
+- Python 3.12+
+- Inputbestanden in het juiste formaat (zie [Je data voorbereiden](je-data-voorbereiden.md))
+
+## CLI-overzicht
+
+```bash
+studentprognose --help
+```
+
+| Vlag | Beschrijving |
+|------|-------------|
+| `-d c` | Cumulatief spoor (Studielink-data) |
+| `-d i` | Individueel spoor (Osiris/Usis-data) |
+| `-d b` | Beide sporen + ensemble (standaard) |
+| `--noetl` | ETL-stap overslaan |
+| `--ci test N` | CI-modus met subset van N opleidingen |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,12 @@
+# API-referentie
+
+Automatisch gegenereerde documentatie vanuit de broncode. Geschikt voor bijdragers en instellingen die de modellen willen aanroepen of uitbreiden.
+
+Voor een conceptuele uitleg van de modellen, zie [Methodologie](../methodologie/index.md).
+
+## Modules
+
+| Module | Beschrijving |
+|--------|-------------|
+| [`studentprognose.models`](models.md) | SARIMA, XGBoost classifier/regressor, ratio-model, base class |
+| [`studentprognose.strategies`](strategies.md) | Preprocessing per spoor (individual, cumulative, combined) |

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,35 @@
+# Modellen
+
+## Base
+
+::: studentprognose.models.base
+
+## SARIMA
+
+::: studentprognose.models.sarima
+    options:
+      members:
+        - SARIMAForecaster
+        - predict_with_sarima_cumulative
+        - predict_with_sarima_individual
+
+## XGBoost Classifier
+
+::: studentprognose.models.xgboost_classifier
+    options:
+      members:
+        - predict_applicant
+
+## XGBoost Regressor
+
+::: studentprognose.models.xgboost_regressor
+    options:
+      members:
+        - predict_with_xgboost
+
+## Ratio-model
+
+::: studentprognose.models.ratio
+    options:
+      members:
+        - predict_with_ratio

--- a/docs/api/strategies.md
+++ b/docs/api/strategies.md
@@ -3,11 +3,23 @@
 ## Individual
 
 ::: studentprognose.strategies.individual
+    options:
+      members:
+        - IndividualStrategy
+        - predict_nr_of_students
 
 ## Cumulative
 
 ::: studentprognose.strategies.cumulative
+    options:
+      members:
+        - CumulativeStrategy
+        - predict_nr_of_students
 
 ## Combined
 
 ::: studentprognose.strategies.combined
+    options:
+      members:
+        - CombinedStrategy
+        - predict_nr_of_students

--- a/docs/api/strategies.md
+++ b/docs/api/strategies.md
@@ -1,0 +1,13 @@
+# Strategies
+
+## Individual
+
+::: studentprognose.strategies.individual
+
+## Cumulative
+
+::: studentprognose.strategies.cumulative
+
+## Combined
+
+::: studentprognose.strategies.combined

--- a/docs/assets/header.svg
+++ b/docs/assets/header.svg
@@ -1,0 +1,70 @@
+<svg width="800" height="200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%">
+        <animate attributeName="stop-color" values="#1a73e8;#00897b;#c62828;#2E7D32;#e91e90;#7b1fa2;#66bb6a;#1a73e8" dur="18s" repeatCount="indefinite"/>
+      </stop>
+      <stop offset="50%">
+        <animate attributeName="stop-color" values="#7b1fa2;#1a73e8;#00897b;#c62828;#2E7D32;#e91e90;#7b1fa2;#7b1fa2" dur="18s" repeatCount="indefinite"/>
+      </stop>
+      <stop offset="100%">
+        <animate attributeName="stop-color" values="#00897b;#e91e90;#7b1fa2;#66bb6a;#c62828;#2E7D32;#00897b;#00897b" dur="18s" repeatCount="indefinite"/>
+      </stop>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#00C9FF"/>
+      <stop offset="100%" stop-color="#92FE9D"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Animated background -->
+  <rect width="800" height="200" rx="12" fill="url(#bg)"/>
+
+  <!-- Chart lines decoration -->
+  <polyline points="50,160 120,140 190,145 260,120 330,100 400,110 470,80 540,60 610,65 680,40 750,30"
+            fill="none" stroke="url(#accent)" stroke-width="2.5" opacity="0.3" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="50,170 120,155 190,160 260,140 330,135 400,125 470,105 540,95 610,85 680,70 750,55"
+            fill="none" stroke="#00C9FF" stroke-width="1.5" opacity="0.15" stroke-dasharray="6,4"/>
+
+  <!-- Dot accents with pulse -->
+  <circle cx="470" cy="80" r="4" fill="#92FE9D" opacity="0.5">
+    <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="680" cy="40" r="4" fill="#00C9FF" opacity="0.5">
+    <animate attributeName="opacity" values="0.5;0.9;0.5" dur="4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="750" cy="30" r="5" fill="#92FE9D" opacity="0.6" filter="url(#glow)">
+    <animate attributeName="opacity" values="0.4;0.8;0.4" dur="2.5s" repeatCount="indefinite"/>
+    <animate attributeName="r" values="4;6;4" dur="2.5s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Graduation cap icon -->
+  <g transform="translate(310, 40)" fill="url(#accent)" filter="url(#glow)">
+    <polygon points="25,10 0,25 25,40 50,25" opacity="0.9"/>
+    <rect x="23" y="25" width="4" height="18" rx="1" opacity="0.7"/>
+    <path d="M10,27 L10,42 Q25,52 40,42 L40,27" fill="none" stroke="url(#accent)" stroke-width="2" opacity="0.7"/>
+  </g>
+
+  <!-- Title -->
+  <text x="400" y="110" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="40" font-weight="700" fill="white" filter="url(#glow)">
+    Studentprognose
+  </text>
+
+  <!-- Subtitle -->
+  <text x="400" y="140" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="16" fill="url(#accent)" letter-spacing="2">
+    Voorspel studentinstroom met geavanceerde modellen
+  </text>
+
+  <!-- Pill -->
+  <rect x="310" y="152" width="180" height="24" rx="12" fill="white" opacity="0.1"/>
+  <text x="400" y="169" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12" fill="#92FE9D" letter-spacing="1">
+    SARIMA · XGBoost · Ensemble
+  </text>
+</svg>

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -1,0 +1,5 @@
+# Configuratie
+
+TODO: alle `configuration.json`-opties documenteren.
+
+De configuratie wordt geladen via `src/studentprognose/config.py`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+# Studentprognose
+
+**Studentprognose** is een open-source tool van CEDA/Npuls voor het voorspellen van eerstejaars instroom in het hoger onderwijs. Het combineert tijdreeksmodellen (SARIMA), machine learning (XGBoost) en een ratio-model tot een ensemble-voorspelling.
+
+## Voor wie is deze documentatie?
+
+Deze documentatie richt zich op **data-analisten en onderzoekers** bij Nederlandse onderwijsinstellingen. De focus ligt niet alleen op *hoe* je de tool gebruikt, maar ook op *waarom* het model werkt zoals het werkt — inclusief aannames, beperkingen en situaties waarin je de output kritisch moet interpreteren.
+
+## Snelstart
+
+```bash
+pip install studentprognose
+studentprognose --help
+```
+
+Zie [Aan de slag](aan-de-slag.md) voor een complete walkthrough met demodata.
+
+## Architectuur op hoofdlijnen
+
+Het model kent drie verwerkingssporen, afhankelijk van de beschikbare data:
+
+| Modus | Vlag | Databron | Modellen |
+|-------|------|----------|----------|
+| Cumulatief | `-d c` | Studielink telbestanden | SARIMA + XGBoost regressor |
+| Individueel | `-d i` | Osiris/Usis per-student | XGBoost classifier + SARIMA |
+| Beide | `-d b` | Beide bronnen (standaard) | Volledig ensemble |
+
+Zie [Methodologie](methodologie/index.md) voor een diepgaande uitleg per model.

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,12 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -2,7 +2,7 @@
 
 TODO: uitwerken op basis van PIPELINE.md en datakwaliteitscontroles.
 
-Zie ook `doc/PIPELINE.md` voor de volledige dataflow inclusief ETL-stappen.
+Zie ook de [PIPELINE.md](https://github.com/cedanl/studentprognose/blob/main/doc/PIPELINE.md) voor de volledige dataflow inclusief ETL-stappen en Mermaid-diagram.
 
 ## Verplichte inputbestanden
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -1,0 +1,15 @@
+# Je data voorbereiden
+
+TODO: uitwerken op basis van PIPELINE.md en datakwaliteitscontroles.
+
+Zie ook `doc/PIPELINE.md` voor de volledige dataflow inclusief ETL-stappen.
+
+## Verplichte inputbestanden
+
+| Bestand | Beschrijving | Bron |
+|---------|-------------|------|
+| `vooraanmeldingen_cumulatief.csv` | Gewogen/ongewogen vooraanmelders per opleiding, herkomst, week, jaar | Studielink → ETL |
+| `vooraanmeldingen_individueel.csv` | Per-student aanmelddata met persoonskenmerken | Osiris/Usis → ETL |
+| `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | DUO oktober-bestand |
+| `student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars | DUO oktober-bestand |
+| `student_volume.xlsx` | Totaal studentvolume | DUO oktober-bestand |

--- a/docs/methodologie/ensemble.md
+++ b/docs/methodologie/ensemble.md
@@ -6,27 +6,27 @@ Het ensemble combineert de voorspellingen van SARIMA, XGBoost en het ratio-model
 
 Geen enkel model presteert in alle situaties het beste. SARIMA is sterk bij stabiele seizoenspatronen; XGBoost vangt individuele kenmerken beter op; het ratio-model is robuust bij weinig data. Door modellen te combineren wordt de variantie in de eindvoorspelling verlaagd — mits de modellen niet allemaal op dezelfde manier fout gaan.
 
-## Gewichten
+## Hoe worden de gewichten bepaald?
 
-Ensemble-gewichten worden bepaald op basis van historische modelfouten (MAE per opleiding per model). Een model dat het afgelopen jaar beter heeft gepresteerd krijgt een hoger gewicht.
+De ensemble-gewichten worden bepaald via een **grid search** over gewichtscombinaties (percentageparen). Voor elke combinatie van gewichten wordt de historische fout (MAE en MAPE) berekend over meerdere voorgaande jaren. De combinatie met de laagste historische fout wordt gekozen als optimale weging.
 
-$$w_m = \frac{1 / MAE_m}{\sum_{m'} 1 / MAE_{m'}}$$
+Dit is bewust anders dan een eenvoudige inverse-MAE weging: de grid search optimaliseert de gewichten direct op de ensemble-uitkomst, niet op de individuele modelfouten. Hierdoor wordt rekening gehouden met correlatie tussen modellen.
 
-De gewichten worden opgeslagen in `ensemble_weights.xlsx` en kunnen worden bijgewerkt via het post-processing script `archive/calculate_ensemble_weights.py`.
+De optimale gewichten worden opgeslagen in `ensemble_weights.xlsx` en worden per opleiding, examentype en herkomst bepaald.
 
 !!! warning "Gewichten zijn datumgevoelig"
-    De gewichten zijn gebaseerd op historische prestaties. Als de situatie verandert (bijv. na een beleidsingreep), kunnen verouderde gewichten een slecht presterend model te veel vertrouwen geven. Herbereken de gewichten na elk studiejaar.
+    De gewichten zijn gebaseerd op historische prestaties. Als de situatie verandert (bijv. na een beleidsingreep of een uitzonderlijk jaar), kunnen verouderde gewichten een slecht presterend model te veel vertrouwen geven. Herbereken de gewichten na elk studiejaar via `archive/calculate_ensemble_weights.py`.
 
 ## Bij een eerste run
 
-Als `ensemble_weights.xlsx` nog niet bestaat, gebruikt het model gelijke gewichten voor alle modellen. Dit is een redelijke standaard, maar niet optimaal. Draai het ensemble pas met aangepaste gewichten nadat je één volledig studiejaar aan output hebt.
+Als `ensemble_weights.xlsx` nog niet bestaat, gebruikt het model gelijke gewichten voor alle modellen. Dit is een redelijke standaard, maar niet optimaal. Draai de ensemble-optimalisatie pas nadat je één volledig studiejaar aan output hebt.
 
 ## Ensemble vs. individuele modellen
 
 In de output staan zowel de individuele modelvoorspellingen (`SARIMA_individual`, `SARIMA_cumulative`, `Prognose_ratio`) als de ensemble-voorspelling (`Ensemble_prediction`). Dit stelt je in staat om:
 
-- Te controleren of de modellen het eens zijn (hoge overeenkomst = meer vertrouwen)
+- Te controleren of de modellen het eens zijn — hoge overeenkomst geeft meer vertrouwen in de uitkomst
 - Afwijkende modellen te signaleren als early warning
-- De toegevoegde waarde van het ensemble te beoordelen t.o.v. individuele modellen
+- De toegevoegde waarde van het ensemble te beoordelen t.o.v. het ratio-model als simpele baseline
 
 Zie [Output begrijpen](../output-begrijpen.md) voor uitleg over de outputkolommen.

--- a/docs/methodologie/ensemble.md
+++ b/docs/methodologie/ensemble.md
@@ -1,0 +1,32 @@
+# Ensemble
+
+Het ensemble combineert de voorspellingen van SARIMA, XGBoost en het ratio-model tot één eindvoorspelling. Dit is alleen beschikbaar in de `-d b` (both) modus.
+
+## Waarom een ensemble?
+
+Geen enkel model presteert in alle situaties het beste. SARIMA is sterk bij stabiele seizoenspatronen; XGBoost vangt individuele kenmerken beter op; het ratio-model is robuust bij weinig data. Door modellen te combineren wordt de variantie in de eindvoorspelling verlaagd — mits de modellen niet allemaal op dezelfde manier fout gaan.
+
+## Gewichten
+
+Ensemble-gewichten worden bepaald op basis van historische modelfouten (MAE per opleiding per model). Een model dat het afgelopen jaar beter heeft gepresteerd krijgt een hoger gewicht.
+
+$$w_m = \frac{1 / MAE_m}{\sum_{m'} 1 / MAE_{m'}}$$
+
+De gewichten worden opgeslagen in `ensemble_weights.xlsx` en kunnen worden bijgewerkt via het post-processing script `archive/calculate_ensemble_weights.py`.
+
+!!! warning "Gewichten zijn datumgevoelig"
+    De gewichten zijn gebaseerd op historische prestaties. Als de situatie verandert (bijv. na een beleidsingreep), kunnen verouderde gewichten een slecht presterend model te veel vertrouwen geven. Herbereken de gewichten na elk studiejaar.
+
+## Bij een eerste run
+
+Als `ensemble_weights.xlsx` nog niet bestaat, gebruikt het model gelijke gewichten voor alle modellen. Dit is een redelijke standaard, maar niet optimaal. Draai het ensemble pas met aangepaste gewichten nadat je één volledig studiejaar aan output hebt.
+
+## Ensemble vs. individuele modellen
+
+In de output staan zowel de individuele modelvoorspellingen (`SARIMA_individual`, `SARIMA_cumulative`, `Prognose_ratio`) als de ensemble-voorspelling (`Ensemble_prediction`). Dit stelt je in staat om:
+
+- Te controleren of de modellen het eens zijn (hoge overeenkomst = meer vertrouwen)
+- Afwijkende modellen te signaleren als early warning
+- De toegevoegde waarde van het ensemble te beoordelen t.o.v. individuele modellen
+
+Zie [Output begrijpen](../output-begrijpen.md) voor uitleg over de outputkolommen.

--- a/docs/methodologie/index.md
+++ b/docs/methodologie/index.md
@@ -1,0 +1,30 @@
+# Methodologie
+
+Deze sectie legt per model uit **hoe het werkt**, **waarom deze keuze is gemaakt** en **wanneer je de output kritisch moet beoordelen**.
+
+## Modellen in het ensemble
+
+| Model | Pagina | Rol in de pipeline |
+|-------|--------|--------------------|
+| SARIMA | [SARIMA](sarima.md) | Tijdreeksextrapolatie op basis van historische aanmeldpatronen |
+| XGBoost classifier | [XGBoost](xgboost.md) | Kans per individuele student dat deze zich inschrijft |
+| XGBoost regressor | [XGBoost](xgboost.md) | Vertaling van vooraanmelders naar verwachte inschrijvingen |
+| Ratio-model | [Ratio-model](ratio-model.md) | Eenvoudige historische ratio als referentiemodel |
+| Ensemble | [Ensemble](ensemble.md) | Gewogen combinatie van bovenstaande modellen |
+
+## Datasporen
+
+```mermaid
+flowchart LR
+    SL["Studielink\ntelbestanden"] --> CUM["Cumulatief spoor\n(-d c)"]
+    SIS["Osiris / Usis\nper-student"] --> IND["Individueel spoor\n(-d i)"]
+    CUM & IND --> ENS["Ensemble\n(-d b)"]
+```
+
+De twee sporen zijn bewust onafhankelijk van elkaar ontworpen zodat instellingen die geen toegang hebben tot individuele aanmelddata toch een voorspelling kunnen maken via het cumulatieve spoor.
+
+## Aannames en beperkingen
+
+- Het model extrapoleert op basis van historische patronen. **Structurele breuken** (bijv. nieuwe opleiding, COVID-jaar) worden niet automatisch gedetecteerd.
+- Ensemble-gewichten worden bepaald op historische fouten; een model dat in het verleden goed presteerde krijgt meer gewicht, ook al is de situatie veranderd.
+- De SARIMA-parameters zijn per opleiding gefixed. Bij opleidingen met weinig historische data is de modelfit minder betrouwbaar.

--- a/docs/methodologie/ratio-model.md
+++ b/docs/methodologie/ratio-model.md
@@ -1,26 +1,42 @@
 # Ratio-model
 
-Het ratio-model is het eenvoudigste model in de pipeline en dient als **referentiemodel**: een expliciete bodem die altijd beschikbaar is, ook zonder betrouwbare trainingsdata.
+Het ratio-model is het eenvoudigste model in de pipeline en dient als **referentiemodel**: volledig transparant, altijd beschikbaar, ook zonder betrouwbare trainingsdata voor de complexere modellen.
 
 ## Wat doet het?
 
-Het ratio-model berekent per opleiding de historische verhouding tussen het aantal vooraanmelders op een bepaald moment in het jaar en het uiteindelijke aantal inschrijvingen. Die ratio wordt vervolgens toegepast op het huidige aantal vooraanmelders.
+Het ratio-model berekent per opleiding de historische verhouding tussen het totale aanmeldvolume op een bepaald moment in het jaar en het uiteindelijke aantal inschrijvingen. Die ratio wordt vervolgens toegepast op het huidige aanmeldvolume.
 
-$$\hat{y}_{t} = \text{vooraanmelders}_t \times \frac{\bar{y}_{\text{hist}}}{\bar{x}_{\text{hist,t}}}$$
+**Definitie van aanmeldvolume:**
+
+$$\text{Aanmelding} = \text{Ongewogen vooraanmelders} + \text{Inschrijvingen}$$
+
+**Historische ratio (gemiddeld over 3 jaar):**
+
+$$\bar{R}_{t} = \frac{1}{3} \sum_{j=1}^{3} \frac{\text{Aanmelding}_{jaar-j,\, week=t}}{\text{Aantal\_studenten}_{jaar-j}}$$
+
+**Voorspelling:**
+
+$$\hat{y} = \frac{\text{Aanmelding}_{huidig,\, week=t}}{\bar{R}_{t}}$$
+
+Het venster van 3 jaar is hardgecodeerd (`predict_year - 3` t/m `predict_year - 1`).
+
+## Numerus fixus-correctie
+
+Na de basisberekening past het model een **cap** toe voor numerus fixus-opleidingen: als de gesommeerde voorspelling over herkomstgroepen het vastgestelde maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep.
 
 ## Waarom een ratio-model?
 
-Het ratio-model maakt geen aannames over seizoenspatronen of feature-importantie. Het is volledig transparant en auditeerbaar — de output is direct te herleiden tot de historische data. Dit maakt het geschikt als:
-
-1. **Fallback** wanneer SARIMA of XGBoost onvoldoende data heeft
-2. **Sanity check** naast de complexere modellen
-3. **Baseline** voor het beoordelen van de toegevoegde waarde van de andere modellen (als het ensemble niet beter is dan de ratio, is er iets mis)
+1. **Volledig transparant** — de output is direct te herleiden tot de historische data, zonder model-blackbox
+2. **Altijd beschikbaar** — geen trainingsdata nodig buiten de 3-jaars historische ratio
+3. **Baseline** — als het ensemble structureel slechter presteert dan de ratio, is er iets mis met de complexere modellen
+4. **Auditeerbaar** — geschikt voor interne verantwoording richting management
 
 ## Beperkingen
 
-- Geen rekening met trends: als de instroom structureel groeit of daalt, is de historische ratio achterhaald.
-- Gevoelig voor uitschieters in de historische data (één abnormaal jaar kan de ratio sterk beïnvloeden).
+- Geen rekening met trends: bij structurele groei of daling is de 3-jaars ratio achterhaald.
+- Gevoelig voor uitschieters: één abnormaal jaar (bijv. COVID) kan de gemiddelde ratio sterk beïnvloeden.
+- Week-afhankelijk: de ratio varieert per week. Vroeg in het jaar (weinig aanmelders) is de ratio minder stabiel.
 
 ## Implementatie
 
-Zie `src/studentprognose/models/ratio.py`.
+Zie `src/studentprognose/models/ratio.py` — de functie `predict_with_ratio`.

--- a/docs/methodologie/ratio-model.md
+++ b/docs/methodologie/ratio-model.md
@@ -1,0 +1,26 @@
+# Ratio-model
+
+Het ratio-model is het eenvoudigste model in de pipeline en dient als **referentiemodel**: een expliciete bodem die altijd beschikbaar is, ook zonder betrouwbare trainingsdata.
+
+## Wat doet het?
+
+Het ratio-model berekent per opleiding de historische verhouding tussen het aantal vooraanmelders op een bepaald moment in het jaar en het uiteindelijke aantal inschrijvingen. Die ratio wordt vervolgens toegepast op het huidige aantal vooraanmelders.
+
+$$\hat{y}_{t} = \text{vooraanmelders}_t \times \frac{\bar{y}_{\text{hist}}}{\bar{x}_{\text{hist,t}}}$$
+
+## Waarom een ratio-model?
+
+Het ratio-model maakt geen aannames over seizoenspatronen of feature-importantie. Het is volledig transparant en auditeerbaar — de output is direct te herleiden tot de historische data. Dit maakt het geschikt als:
+
+1. **Fallback** wanneer SARIMA of XGBoost onvoldoende data heeft
+2. **Sanity check** naast de complexere modellen
+3. **Baseline** voor het beoordelen van de toegevoegde waarde van de andere modellen (als het ensemble niet beter is dan de ratio, is er iets mis)
+
+## Beperkingen
+
+- Geen rekening met trends: als de instroom structureel groeit of daalt, is de historische ratio achterhaald.
+- Gevoelig voor uitschieters in de historische data (één abnormaal jaar kan de ratio sterk beïnvloeden).
+
+## Implementatie
+
+Zie `src/studentprognose/models/ratio.py`.

--- a/docs/methodologie/sarima.md
+++ b/docs/methodologie/sarima.md
@@ -1,0 +1,42 @@
+# SARIMA
+
+SARIMA staat voor **Seasonal AutoRegressive Integrated Moving Average**. Het is het kerntijdreeksmodel in de pipeline en wordt ingezet in zowel het cumulatieve als het individuele spoor.
+
+## Wat doet het?
+
+SARIMA extrapoleert het wekelijkse aanmeldpatroon van een opleiding naar het verwachte eindaantal inschrijvingen. Het model leert van historische seizoenspatronen: in welke weken stromen de meeste aanmeldingen binnen, hoe ziet de curve eruit vlak voor de inschrijfdeadline?
+
+## Waarom SARIMA?
+
+Aanmelddata heeft een sterk seizoenspatroon (jaarlijkse cyclus, wekelijkse granulariteit). SARIMA is specifiek ontworpen voor tijdreeksen met zulke structuur. Alternatieven zoals lineaire regressie op weeknummer negeren autokorrelatie in de data; neurale netwerken vereisen veel meer historische data dan de meeste instellingen beschikbaar hebben.
+
+## Modelstructuur
+
+$$SARIMA(p, d, q)(P, D, Q)_s$$
+
+| Parameter | Betekenis |
+|-----------|-----------|
+| `p` | Orde van het autoregressieve deel |
+| `d` | Differentiatie-orde (stationariseren) |
+| `q` | Orde van het moving average-deel |
+| `P, D, Q` | Seizoenscomponenten |
+| `s` | Seizoenslengte (52 weken) |
+
+De parameters worden automatisch bepaald via `pmdarima.auto_arima`. Zie `src/studentprognose/models/sarima.py` voor de implementatie.
+
+## Aannames
+
+1. **Stationariteit na differentiatie** — het model past differentiatie toe om trends te verwijderen. Als de trend in realiteit niet-stationair is (bijv. structurele groei), kan dit de voorspelling verstoren.
+2. **Herhaalbaar seizoenspatroon** — het model gaat ervan uit dat het patroon van dit jaar op het patroon van voorgaande jaren lijkt. Dit geldt niet bij structurele veranderingen (nieuwe opleiding, beleidsingreep, COVID).
+3. **Voldoende historische data** — bij minder dan ~3 jaar data zijn de seizoensschattingen onbetrouwbaar.
+
+## Wanneer vertrouw je het niet?
+
+- Nieuwe opleiding (< 3 jaar historische data)
+- Jaar na een uitzonderlijk jaar (bijv. post-COVID)
+- Opleiding met sterke interjaarse variatie in aanmeldpatroon
+- Weken vroeg in het jaar (weinig datapunten nog beschikbaar)
+
+## Relatie tot andere modellen
+
+SARIMA levert een voorspelling per opleiding per week. In het `-d b` scenario wordt deze voorspelling gecombineerd met de XGBoost-uitkomsten via ensemble weging. Zie [Ensemble](ensemble.md).

--- a/docs/methodologie/sarima.md
+++ b/docs/methodologie/sarima.md
@@ -4,7 +4,7 @@ SARIMA staat voor **Seasonal AutoRegressive Integrated Moving Average**. Het is 
 
 ## Wat doet het?
 
-SARIMA extrapoleert het wekelijkse aanmeldpatroon van een opleiding naar het verwachte eindaantal inschrijvingen. Het model leert van historische seizoenspatronen: in welke weken stromen de meeste aanmeldingen binnen, hoe ziet de curve eruit vlak voor de inschrijfdeadline?
+SARIMA extrapoleert het wekelijkse aanmeldpatroon van een opleiding naar het verwachte eindaantal inschrijvingen op week 38. Het model leert van historische seizoenspatronen: in welke weken stromen de meeste aanmeldingen binnen, hoe ziet de curve eruit vlak voor de inschrijfdeadline?
 
 ## Waarom SARIMA?
 
@@ -12,31 +12,35 @@ Aanmelddata heeft een sterk seizoenspatroon (jaarlijkse cyclus, wekelijkse granu
 
 ## Modelstructuur
 
-$$SARIMA(p, d, q)(P, D, Q)_s$$
+$$SARIMA(p, d, q)(P, D, Q)_{52}$$
 
-| Parameter | Betekenis |
-|-----------|-----------|
-| `p` | Orde van het autoregressieve deel |
-| `d` | Differentiatie-orde (stationariseren) |
-| `q` | Orde van het moving average-deel |
-| `P, D, Q` | Seizoenscomponenten |
-| `s` | Seizoenslengte (52 weken) |
+De seizoenslengte is altijd **52 weken**. De overige parameters zijn **vaste waarden** — er wordt geen automatische parameter-selectie toegepast. De keuze hangt af van het spoor en het moment in het jaar:
 
-De parameters worden automatisch bepaald via `pmdarima.auto_arima`. Zie `src/studentprognose/models/sarima.py` voor de implementatie.
+| Situatie | Order `(p,d,q)` | Seizoensorder `(P,D,Q)` |
+|----------|----------------|------------------------|
+| Cumulatief spoor | `(1, 0, 1)` | `(1, 1, 1)` |
+| Individueel — Bachelor, weken 17–21 | `(1, 0, 1)` | `(1, 1, 1)` |
+| Individueel — overige gevallen | `(1, 1, 1)` | `(1, 1, 0)` |
+
+De implementatie gebruikt `statsmodels.tsa.statespace.SARIMAX`. Zie `src/studentprognose/models/sarima.py` voor de `SARIMAForecaster`-klasse.
+
+## Exogene variabelen (individueel spoor)
+
+In het individuele spoor kan een deadlineweek-variabele als exogene regresssor worden meegegeven. Dit markeert weken 16–17 (Bachelor niet-numerus fixus) of weken 1–2 (numerus fixus) als deadlineweek, zodat het model de aanmeldpiek rond deadlines beter kan modelleren.
 
 ## Aannames
 
-1. **Stationariteit na differentiatie** — het model past differentiatie toe om trends te verwijderen. Als de trend in realiteit niet-stationair is (bijv. structurele groei), kan dit de voorspelling verstoren.
-2. **Herhaalbaar seizoenspatroon** — het model gaat ervan uit dat het patroon van dit jaar op het patroon van voorgaande jaren lijkt. Dit geldt niet bij structurele veranderingen (nieuwe opleiding, beleidsingreep, COVID).
-3. **Voldoende historische data** — bij minder dan ~3 jaar data zijn de seizoensschattingen onbetrouwbaar.
+1. **Herhaalbaar seizoenspatroon** — het model gaat ervan uit dat het patroon van dit jaar op het patroon van voorgaande jaren lijkt. Dit geldt niet bij structurele veranderingen (nieuwe opleiding, beleidsingreep, COVID).
+2. **Voldoende historische data** — trainingsdata start vanaf 2016. Bij opleidingen met minder dan ~3 jaar data zijn de seizoensschattingen onbetrouwbaar.
+3. **Stationariteit** — het model past één seizoensdifferentiatie toe (`D=1`). Als de trend structureel niet-stationair is, kan de differentiatie onvoldoende zijn.
 
 ## Wanneer vertrouw je het niet?
 
-- Nieuwe opleiding (< 3 jaar historische data)
+- Nieuwe opleiding (< 3 jaar historische data beschikbaar)
 - Jaar na een uitzonderlijk jaar (bijv. post-COVID)
 - Opleiding met sterke interjaarse variatie in aanmeldpatroon
-- Weken vroeg in het jaar (weinig datapunten nog beschikbaar)
+- Vroeg in het jaar (weinig datapunten beschikbaar; de voorspelling is dan een lange extrapolatie)
 
 ## Relatie tot andere modellen
 
-SARIMA levert een voorspelling per opleiding per week. In het `-d b` scenario wordt deze voorspelling gecombineerd met de XGBoost-uitkomsten via ensemble weging. Zie [Ensemble](ensemble.md).
+SARIMA levert een voorspelling per opleiding per week. In het `-d b` scenario wordt deze gecombineerd met de XGBoost-uitkomsten via het ensemble. Zie [Ensemble](ensemble.md).

--- a/docs/methodologie/xgboost.md
+++ b/docs/methodologie/xgboost.md
@@ -6,25 +6,26 @@ XGBoost wordt op twee plekken ingezet in de pipeline, met fundamenteel verschill
 
 ### Wat doet het?
 
-De classifier voorspelt per individuele student de **kans dat deze zich uiteindelijk inschrijft**, gegeven persoonskenmerken en het moment van vooraanmelding.
+De classifier voorspelt per individuele student de **kans dat deze zich uiteindelijk inschrijft**, gegeven persoonskenmerken en het moment van vooraanmelding. De uitkomsten per student worden gesommeerd tot een verwacht cohortaantal.
 
 ### Waarom XGBoost hier?
 
-De kans dat een student zich inschrijft hangt af van meerdere interacterende factoren (herkomst, opleiding, aanmeldmoment, examenjaar). XGBoost vangt niet-lineaire interacties goed op zonder expliciete feature engineering, en is robuust bij scheve klasse-verdeling (de meeste vooraanmelders schrijven zich wel in).
+De inschrijfkans hangt af van meerdere interacterende factoren. XGBoost vangt niet-lineaire interacties op zonder expliciete feature engineering, en is robuust bij scheve klasseverdeling (de meeste vooraanmelders schrijven zich wel in — de klassen zijn ongelijk verdeeld).
 
 ### Features
 
-Typische features zijn o.a.:
+| Type | Features |
+|------|----------|
+| Numeriek | Collegejaar, Sleutel_count, is_numerus_fixus |
+| Categorisch | Examentype, Faculteit, Croho groepeernaam, Deadlineweek, Herkomst, Weeknummer, Opleiding, Type vooropleiding, Nationaliteit, EER, Geslacht, Plaats code eerste vooropleiding, School code/naam eerste vooropleiding, Land code eerste vooropleiding, Studieadres postcode/land/plaats |
+| Cumulatief (optioneel) | Gewogen vooraanmelders (ratio), Ongewogen vooraanmelders (ratio), Aanmelders met 1 aanmelding (ratio), Inschrijvingen (ratio) |
 
-- Herkomstland / nationaliteit
-- Opleiding + examentype
-- Week van aanmelding
-- Aantal dagen tot inschrijfdeadline
+Categorische features worden one-hot geëncodeerd. Onbekende categorieën in de testset worden genegeerd (`handle_unknown="ignore"`).
 
 ### Aannames
 
 - Historische inschrijfpatronen zijn representatief voor het huidige cohort.
-- De beschikbare persoonskenmerken zijn voldoende om inschrij fkans te differentiëren.
+- Studenten die hun aanmelding hebben ingetrokken vóór de voorspelweek tellen als niet-ingeschreven (label 0).
 
 ---
 
@@ -32,16 +33,23 @@ Typische features zijn o.a.:
 
 ### Wat doet het?
 
-De regressor voorspelt het **totaal aantal inschrijvingen** op basis van het tot nu toe geaggregeerde aantal vooraanmelders en historische conversiepatronen.
+De regressor voorspelt het **totaal aantal inschrijvingen** per opleiding/herkomst/examentype, op basis van het geaggregeerde wekelijkse vooraanmeldpatroon (tot en met week 38) en historische studentaantallen als target.
+
+### Features
+
+| Type | Features |
+|------|----------|
+| Numeriek | Collegejaar, weekkolommen (week 1 t/m 38 als afzonderlijke kolommen) |
+| Categorisch | Examentype, Faculteit, Croho groepeernaam, Herkomst |
 
 ### Waarom XGBoost hier?
 
-De relatie tussen vooraanmelders en inschrijvingen is niet-lineair en varieert per opleiding, herkomst en week. Een regressiemodel dat niet-lineaire patronen kan leren is hier sterker dan een eenvoudige ratio.
+De relatie tussen het cumulatieve vooraanmeldpatroon en het uiteindelijke inschrijvingsaantal is niet-lineair en varieert per opleiding, herkomst en jaar. XGBoost kan dit patroon leren zonder dat de wekelijkse curve expliciet gemodelleerd hoeft te worden.
 
 ### Wanneer vertrouw je het niet?
 
-- Cohorten waarbij de samenstelling van vooraanmelders sterk verschilt van historisch (bijv. na een nieuwe marketingcampagne).
-- Opleidingen met zeer weinig observaties in de trainingsdata.
+- Cohorten waarbij de samenstelling van vooraanmelders sterk verschilt van historisch (bijv. na een nieuwe marketingcampagne of gewijzigd instroombeleid).
+- Opleidingen met weinig historische observaties in de trainingsdata.
 
 ---
 

--- a/docs/methodologie/xgboost.md
+++ b/docs/methodologie/xgboost.md
@@ -1,0 +1,50 @@
+# XGBoost
+
+XGBoost wordt op twee plekken ingezet in de pipeline, met fundamenteel verschillende rollen: als **classifier** (individueel spoor) en als **regressor** (cumulatief spoor).
+
+## XGBoost Classifier (individueel spoor)
+
+### Wat doet het?
+
+De classifier voorspelt per individuele student de **kans dat deze zich uiteindelijk inschrijft**, gegeven persoonskenmerken en het moment van vooraanmelding.
+
+### Waarom XGBoost hier?
+
+De kans dat een student zich inschrijft hangt af van meerdere interacterende factoren (herkomst, opleiding, aanmeldmoment, examenjaar). XGBoost vangt niet-lineaire interacties goed op zonder expliciete feature engineering, en is robuust bij scheve klasse-verdeling (de meeste vooraanmelders schrijven zich wel in).
+
+### Features
+
+Typische features zijn o.a.:
+
+- Herkomstland / nationaliteit
+- Opleiding + examentype
+- Week van aanmelding
+- Aantal dagen tot inschrijfdeadline
+
+### Aannames
+
+- Historische inschrijfpatronen zijn representatief voor het huidige cohort.
+- De beschikbare persoonskenmerken zijn voldoende om inschrij fkans te differentiëren.
+
+---
+
+## XGBoost Regressor (cumulatief spoor)
+
+### Wat doet het?
+
+De regressor voorspelt het **totaal aantal inschrijvingen** op basis van het tot nu toe geaggregeerde aantal vooraanmelders en historische conversiepatronen.
+
+### Waarom XGBoost hier?
+
+De relatie tussen vooraanmelders en inschrijvingen is niet-lineair en varieert per opleiding, herkomst en week. Een regressiemodel dat niet-lineaire patronen kan leren is hier sterker dan een eenvoudige ratio.
+
+### Wanneer vertrouw je het niet?
+
+- Cohorten waarbij de samenstelling van vooraanmelders sterk verschilt van historisch (bijv. na een nieuwe marketingcampagne).
+- Opleidingen met zeer weinig observaties in de trainingsdata.
+
+---
+
+## Implementatie
+
+Zie `src/studentprognose/models/xgboost_classifier.py` en `src/studentprognose/models/xgboost_regressor.py`.

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -1,0 +1,23 @@
+# Output begrijpen
+
+TODO: outputbestanden, kolomdefinities, MAE/MAPE uitgelegd, wanneer is een prognose betrouwbaar.
+
+## Outputbestanden
+
+| Bestand | Beschrijving |
+|---------|-------------|
+| `output_first-years_*.xlsx` | Eerstejaars voorspellingen (eindresultaat) |
+| `output_higher-years_*.xlsx` | Hogerjaars voorspellingen |
+| `output_volume_*.xlsx` | Volume-voorspellingen (totaal) |
+| `output_prelim_*.xlsx` | Tussenresultaat vóór ratio/ensemble/foutmaten |
+
+## Kolomdefinities
+
+| Kolom | Beschrijving |
+|-------|-------------|
+| `SARIMA_individual` | Voorspelling SARIMA individueel spoor |
+| `SARIMA_cumulative` | Voorspelling SARIMA cumulatief spoor |
+| `Prognose_ratio` | Voorspelling ratio-model |
+| `Ensemble_prediction` | Gewogen ensemble-voorspelling |
+| `MAE_*` | Gemiddelde absolute afwijking (historisch) |
+| `MAPE_*` | Gemiddelde procentuele afwijking (historisch) |

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -1,0 +1,3 @@
+# Validatie
+
+TODO: datakwaliteitscontroles uitwerken (zie ook issue #72 en de pre-ETL controles).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,8 @@ site_dir: site
 theme:
   name: material
   language: nl
-  logo: assets/npuls_logo.png
-  favicon: assets/npuls_logo.png
+  logo: assets/header.svg
+  favicon: assets/header.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -33,7 +33,6 @@ theme:
     - navigation.sections
     - navigation.top
     - navigation.indexes
-    - toc.integrate
     - search.suggest
     - search.highlight
     - content.code.copy
@@ -75,6 +74,7 @@ markdown_extensions:
       generic: true
 
 extra_javascript:
+  - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 nav:
@@ -90,3 +90,7 @@ nav:
     - XGBoost: methodologie/xgboost.md
     - Ratio-model: methodologie/ratio-model.md
     - Ensemble: methodologie/ensemble.md
+  - API-referentie:
+    - api/index.md
+    - Modellen: api/models.md
+    - Strategies: api/strategies.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,92 @@
+site_name: Studentprognose
+site_description: Methodologische documentatie voor het voorspellen van eerstejaars instroom in het hoger onderwijs
+site_url: https://cedanl.github.io/studentprognose/
+repo_url: https://github.com/cedanl/studentprognose
+repo_name: cedanl/studentprognose
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: nl
+  logo: assets/npuls_logo.png
+  favicon: assets/npuls_logo.png
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Donker thema
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Licht thema
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - toc.integrate
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+
+plugins:
+  - search:
+      lang: nl
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: false
+            show_root_heading: true
+            show_symbol_type_heading: true
+            members_order: source
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.snippets:
+      base_path: ["."]
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+
+extra_javascript:
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
+nav:
+  - Home: index.md
+  - Aan de slag: aan-de-slag.md
+  - Je data voorbereiden: je-data-voorbereiden.md
+  - Configuratie: configuratie.md
+  - Validatie: validatie.md
+  - Output begrijpen: output-begrijpen.md
+  - Methodologie:
+    - methodologie/index.md
+    - SARIMA: methodologie/sarima.md
+    - XGBoost: methodologie/xgboost.md
+    - Ratio-model: methodologie/ratio-model.md
+    - Ensemble: methodologie/ensemble.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ dev = [
     "pre-commit>=4.1.0",
     "pytest>=9.0.2",
 ]
+docs = [
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocstrings[python]>=0.26.0",
+    "pymdown-extensions>=10.0",
+]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
## Samenvatting

- Voegt MkDocs + Material documentatie-infrastructuur toe gericht op **data-analisten en onderzoekers**
- Nadruk op het HOE en WAAROM van methodologische keuzes (aannames, beperkingen, wanneer vertrouwen), niet alleen CLI-gebruik
- `CLAUDE.md` met verplichte change→docs mapping: elke PR die relevante code wijzigt, moet ook de bijbehorende docs-pagina bijwerken

## Wijzigingen

- `CLAUDE.md` — projectoverzicht + expliciete tabel "als je X wijzigt → update docs Y" + richtlijnen voor methodologie-pagina's
- `mkdocs.yml` — MkDocs + Material config met MathJax (formules), Mermaid (diagrammen), mkdocstrings, NL zoekindex
- `docs/` — 11 pagina's:
  - Gebruikersflow: `index`, `aan-de-slag`, `je-data-voorbereiden`, `configuratie`, `validatie`, `output-begrijpen`
  - Methodologie: `index`, `sarima`, `xgboost`, `ratio-model`, `ensemble` (met aannames, waarschuwingen, formules)

## Testplan

- [ ] `mkdocs serve` lokaal draaien en alle pagina's controleren
- [ ] Mermaid-diagram op `methodologie/index.md` rendert correct
- [ ] MathJax-formules op `sarima.md` en `ensemble.md` renderen correct
- [ ] Nav-structuur klopt (tabs, sections)
- [ ] GitHub Pages deployment workflow toevoegen (apart issue)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)