### PR TITLE
fix: type annotations voor griffe/docs-CI

### DIFF
--- a/src/studentprognose/models/ratio.py
+++ b/src/studentprognose/models/ratio.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 
-def predict_with_ratio(data, data_cumulative, data_studentcount, numerus_fixus_list, predict_year):
+def predict_with_ratio(data: pd.DataFrame, data_cumulative: pd.DataFrame, data_studentcount: pd.DataFrame | None, numerus_fixus_list: dict, predict_year: int) -> pd.DataFrame:
     """
     Predict student influx using the ratio between pre-registrants and actual enrollments.
 

--- a/src/studentprognose/models/sarima.py
+++ b/src/studentprognose/models/sarima.py
@@ -35,7 +35,7 @@ def create_time_series(data, pred_len):
     return np.array(ts_data)
 
 
-def predict_with_sarima_cumulative(data_cumulative, row, predict_year, predict_week, pred_len, skip_years=0, already_printed=False):
+def predict_with_sarima_cumulative(data_cumulative, row, predict_year, predict_week, pred_len, skip_years=0, already_printed=False) -> list:
     """
     Predicts pre-registrations with SARIMA per programme/origin/week for cumulative data.
 
@@ -83,7 +83,7 @@ def predict_with_sarima_cumulative(data_cumulative, row, predict_year, predict_w
         return []
 
 
-def predict_with_sarima_individual(data_individual, row, predict_year, predict_week, max_year, numerus_fixus_list, data_exog=None, already_printed=False):
+def predict_with_sarima_individual(data_individual, row, predict_year, predict_week, max_year, numerus_fixus_list, data_exog=None, already_printed=False) -> float:
     """
     Predicts nr of students with SARIMA per programme/origin/week for individual data.
 

--- a/src/studentprognose/models/xgboost_classifier.py
+++ b/src/studentprognose/models/xgboost_classifier.py
@@ -17,7 +17,7 @@ DEFAULT_STATUS_MAP = {
 MIN_TRAINING_YEAR = 2016
 
 
-def predict_applicant(data, predict_year, predict_week, max_year, data_cumulative=None, configuration=None):
+def predict_applicant(data, predict_year, predict_week, max_year, data_cumulative=None, configuration=None) -> np.ndarray | float:
     """
     Train an XGBoost classifier to predict individual applicant enrollment probability.
 

--- a/src/studentprognose/models/xgboost_regressor.py
+++ b/src/studentprognose/models/xgboost_regressor.py
@@ -6,7 +6,7 @@ from sklearn.compose import ColumnTransformer
 from studentprognose.utils.weeks import get_weeks_list
 
 
-def predict_with_xgboost(train, test, data_studentcount):
+def predict_with_xgboost(train, test, data_studentcount) -> np.ndarray | float:
     """
     Train an XGBoost regressor to predict student counts from cumulative pre-application data.
 


### PR DESCRIPTION
Griffe emitteert warnings voor functies zonder return type annotatie. In strict mode worden die errors die de docs-CI laten falen.

## Wijzigingen

| Bestand | Annotatie |
|---------|-----------|
| `sarima.py` | `predict_with_sarima_cumulative -> list`, `predict_with_sarima_individual -> float` |
| `xgboost_classifier.py` | `predict_applicant -> np.ndarray \| float` |
| `xgboost_regressor.py` | `predict_with_xgboost -> np.ndarray \| float` |
| `ratio.py` | `predict_with_ratio` volledig geannoteerd (params + `-> pd.DataFrame`) |

Geen gedragswijziging — alleen signaturen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)