### PR TITLE
docs: vul alle stub-pagina's in (#98)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -6,31 +6,77 @@
 pip install studentprognose
 ```
 
-Of met uv:
+Of met uv in een project:
 
 ```bash
 uv add studentprognose
 ```
 
-## Eerste run met demodata
+Vereisten: Python 3.12+
 
-TODO: demodata toevoegen en walkthrough uitschrijven.
+## Je data neerzetten
 
-## Vereisten
+Zet je inputbestanden in de juiste mappen voordat je de pipeline start:
 
-- Python 3.12+
-- Inputbestanden in het juiste formaat (zie [Je data voorbereiden](je-data-voorbereiden.md))
-
-## CLI-overzicht
-
-```bash
-studentprognose --help
+```
+data/
+├── input/                          ← verwerkte inputbestanden (na ETL)
+│   ├── vooraanmeldingen_cumulatief.csv
+│   ├── vooraanmeldingen_individueel.csv
+│   ├── student_count_first-years.xlsx
+│   ├── student_count_higher-years.xlsx
+│   └── student_volume.xlsx
+└── input_raw/                      ← ruwe bronbestanden (voor ETL)
+    ├── telbestanden/               ← Studielink telbestanden
+    │   ├── telbestandY2024W01.csv
+    │   └── ...
+    ├── individuele_aanmelddata.csv ← Osiris/Usis export
+    └── oktober_bestand.xlsx        ← DUO oktober-bestand
 ```
 
-| Vlag | Beschrijving |
-|------|-------------|
-| `-d c` | Cumulatief spoor (Studielink-data) |
-| `-d i` | Individueel spoor (Osiris/Usis-data) |
-| `-d b` | Beide sporen + ensemble (standaard) |
-| `--noetl` | ETL-stap overslaan |
-| `--ci test N` | CI-modus met subset van N opleidingen |
+Zie [Je data voorbereiden](je-data-voorbereiden.md) voor kolomspecificaties per bestand.
+
+## Eerste run
+
+```bash
+# Beide sporen + ensemble (standaard) — voorspelling voor de huidige week
+uv run studentprognose
+
+# Specifieke week en jaar
+uv run studentprognose -w 10 -y 2025
+
+# Alleen cumulatief spoor (geen individuele data nodig)
+uv run studentprognose -d c
+
+# ETL overslaan (data al eerder verwerkt)
+uv run studentprognose --noetl
+```
+
+De output verschijnt in `data/output/`.
+
+## CLI-referentie
+
+| Vlag | Waarden | Standaard | Beschrijving |
+|------|---------|-----------|-------------|
+| `-w` | weeknummer(s) | huidige week | Voorspelweek(en), bijv. `-w 10` of `-w 8:12` |
+| `-y` | jaar(en) | huidig jaar | Voorspeljaar(en), bijv. `-y 2025` of `-y 2024 2025` |
+| `-d` | `b` / `c` / `i` | `b` | Dataset: `both`, `cumulative`, `individual` |
+| `-sy` | `f` / `h` / `v` | `f` | Studentjaar: `first-years`, `higher-years`, `volume` |
+| `-c` | pad | `configuration/configuration.json` | Configuratiebestand |
+| `-f` | pad | `configuration/filtering/base.json` | Filterbestand |
+| `-sk` | getal | `0` | Skip N jaren (backtesting) |
+| `--noetl` | — | uit | Sla ETL én validatie over |
+| `--yes` | — | uit | Sla validatieprompts over (voor CI/CD) |
+| `--ci test N` | getal | — | Testmodus: beperkt tot N opleidingen |
+
+Weekbereiken zijn mogelijk: `-w 8:12` is gelijk aan `-w 8 9 10 11 12`.
+
+## Bekende valkuil: stille modus-downgrade
+
+!!! warning "Let op bij `-d b`"
+    Als je `-d both` (standaard) gebruikt maar de individuele aanmelddata ontbreekt of
+    bevat niet de verwachte jaren, **degradeert de pipeline stilzwijgend naar `-d cumulative`**.
+    De output bevat dan alleen cumulatieve voorspellingen — geen ensemble, geen `SARIMA_individual`.
+
+    Controleer altijd of `SARIMA_individual` kolommen aanwezig zijn in je output als je
+    het ensemble verwacht. Zie issue [#86](https://github.com/cedanl/studentprognose/issues/86).

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -1,5 +1,145 @@
 # Configuratie
 
-TODO: alle `configuration.json`-opties documenteren.
+De pipeline wordt geconfigureerd via `configuration/configuration.json`. Het bestand heeft vier secties: `paths`, `model_config`, `numerus_fixus` en `columns`.
 
-De configuratie wordt geladen via `src/studentprognose/config.py`.
+## `paths` — bestandspaden
+
+Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
+
+| Sleutel | Standaard | Omschrijving |
+|---------|-----------|-------------|
+| `path_cumulative` | `data/input/vooraanmeldingen_cumulatief.csv` | Cumulatieve vooraanmelddata (ETL-output) |
+| `path_individual` | `data/input/vooraanmeldingen_individueel.csv` | Individuele aanmelddata (ETL-output) |
+| `path_cumulative_new` | `""` | Optioneel nieuw cumulatief bestand; wordt ingemergt en daarna verwijderd — zie [waarschuwing](je-data-voorbereiden.md#bekende-valkuil-path_cumulative_new) |
+| `path_latest_cumulative` | `data/input/totaal_cumulatief.xlsx` | Historische cumulatieve voorspellingen (post-processing output) |
+| `path_latest_individual` | `data/input/totaal_individueel.xlsx` | Historische individuele voorspellingen (post-processing output) |
+| `path_ensemble_weights` | `data/input/ensemble_weights.xlsx` | Ensemble-gewichten per opleiding/herkomst/examentype |
+| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | DUO oktober-bestand (ruwe bron) |
+| `path_raw_telbestanden` | `data/input_raw/telbestanden` | Map met Studielink telbestanden |
+| `path_raw_individueel` | `data/input_raw/individuele_aanmelddata.csv` | Ruwe individuele aanmelddata |
+| `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (DUO) |
+| `path_student_count_higher-years` | `data/input/student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars (DUO) |
+| `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (DUO) |
+| `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
+
+## `model_config` — modelparameters
+
+### `status_mapping`
+
+Bepaalt welke inschrijfstatussen als "ingeschreven" (1) of "niet-ingeschreven" (0) worden gelabeld voor het XGBoost-classificatiemodel.
+
+Standaardwaarden:
+
+| Status | Label |
+|--------|-------|
+| `Ingeschreven` | `1` |
+| `Uitgeschreven` | `1` |
+| `Geannuleerd` | `0` |
+| `Verzoek tot inschrijving` | `0` |
+| `Studie gestaakt` | `0` |
+| `Aanmelding vervolgen` | `0` |
+
+Pas dit aan als jouw instelling andere statuswaarden gebruikt. Onbekende statussen worden niet gemapt en veroorzaken een fout.
+
+### `min_training_year`
+
+Standaard: `2016`
+
+Het vroegste collegejaar dat als trainingsdata wordt meegenomen. Data van vóór dit jaar wordt genegeerd. Verlaag dit alleen als je betrouwbare historische data hebt die verder teruggaat.
+
+## `numerus_fixus`
+
+Een object met opleidingsnamen als sleutels en het maximale inschrijvingsaantal als waarde:
+
+```json
+{
+    "numerus_fixus": {
+        "B Geneeskunde": 340,
+        "B Tandheelkunde": 50
+    }
+}
+```
+
+Als de gesommeerde voorspelling over herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Opleidingen die hier niet staan worden niet gecapped.
+
+## `columns` — kolomnamen mapping
+
+Maakt het mogelijk dat instellingen andere kolomnamen gebruiken dan de kanonieke namen die de pipeline intern hanteert. Specificeer alleen de namen die afwijken — ontbrekende sleutels vallen terug op de kanonieke naam.
+
+### `individual` — individuele aanmelddata
+
+Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
+
+`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `Is hogerejaars`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
+
+### `oktober` — DUO oktober-bestand
+
+`Collegejaar`, `Groepeernaam Croho`, `Aantal eerstejaars croho`, `EER-NL-nietEER`, `Examentype code`, `Aantal Hoofdinschrijvingen`
+
+### `cumulative` — Studielink cumulatieve data
+
+`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Hogerejaars`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
+
+## `validation` — validatiedrempels overschrijven
+
+Optionele sectie. Hoeft niet in je configuratiebestand te staan. Voeg alleen toe wat afwijkt van de standaard:
+
+```json
+{
+    "validation": {
+        "nan_error_threshold": 0.20,
+        "telbestand": {
+            "herkomst_allowed": ["N", "E", "R", "ONBEKEND"]
+        }
+    }
+}
+```
+
+| Sleutel | Standaard | Omschrijving |
+|---------|-----------|-------------|
+| `nan_warning_threshold` | `0.05` | Fractie ontbrekende waarden die een waarschuwing geeft |
+| `nan_error_threshold` | `0.30` | Fractie ontbrekende waarden die een fout geeft |
+| `collegejaar_min_offset` | `15` | Collegejaren ouder dan `huidig jaar - 15` geven een fout |
+| `collegejaar_max_offset` | `2` | Collegejaren na `huidig jaar + 2` geven een fout |
+| `telbestand.herkomst_allowed` | `["N","E","R"]` | Toegestane herkomstwaarden in telbestanden |
+
+Zie [Validatie](validatie.md) voor een volledig overzicht van alle controles.
+
+## Voorbeeld minimale configuratie
+
+```json
+{
+    "paths": {
+        "path_cumulative": "data/input/vooraanmeldingen_cumulatief.csv",
+        "path_individual": "data/input/vooraanmeldingen_individueel.csv",
+        "path_cumulative_new": "",
+        "path_latest_individual": "data/input/totaal_individueel.xlsx",
+        "path_latest_cumulative": "data/input/totaal_cumulatief.xlsx",
+        "path_ensemble_weights": "data/input/ensemble_weights.xlsx",
+        "path_raw_october": "data/input_raw/oktober_bestand.xlsx",
+        "path_student_count_first-years": "data/input/student_count_first-years.xlsx",
+        "path_student_count_higher-years": "data/input/student_count_higher-years.xlsx",
+        "path_student_volume": "data/input/student_volume.xlsx",
+        "path_ratios": "data/input/ratiobestand.xlsx",
+        "path_raw_telbestanden": "data/input_raw/telbestanden",
+        "path_raw_individueel": "data/input_raw/individuele_aanmelddata.csv"
+    },
+    "model_config": {
+        "status_mapping": {
+            "Ingeschreven": 1,
+            "Geannuleerd": 0,
+            "Uitgeschreven": 1,
+            "Verzoek tot inschrijving": 0,
+            "Studie gestaakt": 0,
+            "Aanmelding vervolgen": 0
+        },
+        "min_training_year": 2016
+    },
+    "numerus_fixus": {},
+    "columns": {
+        "individual": {},
+        "oktober": {},
+        "cumulative": {}
+    }
+}
+```

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -1,15 +1,116 @@
 # Je data voorbereiden
 
-TODO: uitwerken op basis van PIPELINE.md en datakwaliteitscontroles.
+De pipeline verwacht twee typen inputmappen: `data/input_raw/` voor de ruwe bronbestanden die de ETL verwerkt, en `data/input/` voor de verwerkte bestanden die het model direct inleest.
 
-Zie ook de [PIPELINE.md](https://github.com/cedanl/studentprognose/blob/main/doc/PIPELINE.md) voor de volledige dataflow inclusief ETL-stappen en Mermaid-diagram.
+Zie de [volledige dataflow](https://github.com/cedanl/studentprognose/blob/main/doc/PIPELINE.md) voor een visueel Mermaid-diagram.
 
-## Verplichte inputbestanden
+## Ruwe bronbestanden (`data/input_raw/`)
 
-| Bestand | Beschrijving | Bron |
-|---------|-------------|------|
-| `vooraanmeldingen_cumulatief.csv` | Gewogen/ongewogen vooraanmelders per opleiding, herkomst, week, jaar | Studielink → ETL |
-| `vooraanmeldingen_individueel.csv` | Per-student aanmelddata met persoonskenmerken | Osiris/Usis → ETL |
-| `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | DUO oktober-bestand |
-| `student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars | DUO oktober-bestand |
-| `student_volume.xlsx` | Totaal studentvolume | DUO oktober-bestand |
+### Studielink telbestanden
+
+Map: `data/input_raw/telbestanden/`
+Bestandsnaampatroon: `telbestandY{jaar}W{week}.csv` (bijv. `telbestandY2024W10.csv`)
+Scheidingsteken: `;`
+
+| Kolom | Type | Omschrijving |
+|-------|------|-------------|
+| `Studiejaar` | int | Collegejaar (bijv. `2024`) |
+| `Isatcode` | str | CROHO-code |
+| `Groepeernaam` | str | Naam van de opleiding |
+| `Aantal` | int | Aantal vooraanmelders |
+| `meercode_V` | int | Weegfactor; mag niet 0 zijn (leidt tot deling door nul in ETL) |
+| `Herinschrijving` | str | `J` of `N` |
+| `Hogerejaars` | str | `J` of `N` |
+| `Herkomst` | str | `N` (Nederland), `E` (EER), `R` (rest) |
+
+### Individuele aanmelddata
+
+Pad: `data/input_raw/individuele_aanmelddata.csv`
+Bron: Osiris / Usis
+Scheidingsteken: `;`
+
+Verplichte kolommen (kanonieke namen — pas aan via `configuration.json` als jouw instelling andere namen gebruikt):
+
+| Canonieke naam | Omschrijving |
+|----------------|-------------|
+| `Sleutel` | Unieke studentidentifier |
+| `Datum Verzoek Inschr` | Datum van vooraanmelding |
+| `Ingangsdatum` | Ingangsdatum inschrijving |
+| `Collegejaar` | Collegejaar |
+| `Datum intrekking vooraanmelding` | Weeknummer van intrekking (leeg als niet ingetrokken) |
+| `Inschrijfstatus` | Zie `status_mapping` in configuratie |
+| `Faculteit` | Faculteit |
+| `Examentype` | `Bachelor` of `Master` |
+| `Croho` | CROHO-code |
+| `Croho groepeernaam` | Naam van de opleiding |
+| `Nationaliteit` | Nationaliteit student |
+| `EER` | EER-indicator |
+| `Geslacht` | Geslacht |
+| `Type vooropleiding` | Type vooropleiding |
+
+### Oktober-bestand (DUO 1-cijfer HO)
+
+Pad: `data/input_raw/oktober_bestand.xlsx`
+Bron: DUO
+
+| Canonieke naam | Omschrijving |
+|----------------|-------------|
+| `Collegejaar` | Collegejaar |
+| `Groepeernaam Croho` | Naam van de opleiding |
+| `Aantal eerstejaars croho` | Aantal eerstejaars |
+| `EER-NL-nietEER` | Herkomstgroep |
+| `Examentype code` | `B` (Bachelor) of `M` (Master) |
+| `Aantal Hoofdinschrijvingen` | Aantal hoofdinschrijvingen |
+
+## ETL-stappen
+
+De ETL draait automatisch bij elke run (tenzij `--noetl` is opgegeven). De stappen:
+
+| Stap | Actie | Input | Output |
+|------|-------|-------|--------|
+| 1 | Rowbind + reformat | `telbestanden/*.csv` | Samengevoegd cumulatief bestand |
+| 2 | Interpolatie ontbrekende weken | Samengevoegd bestand | `vooraanmeldingen_cumulatief.csv` |
+| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` | `student_count_*.xlsx`, `student_volume.xlsx` |
+| 4 | Kopiëren individuele data | `individuele_aanmelddata.csv` | `vooraanmeldingen_individueel.csv` |
+
+## Verwerkte inputbestanden (`data/input/`)
+
+Dit zijn de bestanden die het model direct inleest. Ze worden aangemaakt door de ETL of handmatig aangeleverd als je `--noetl` gebruikt.
+
+| Bestand | Wanneer nodig | Bron |
+|---------|---------------|------|
+| `vooraanmeldingen_cumulatief.csv` | `-d c` of `-d b` | ETL stap 1+2 |
+| `vooraanmeldingen_individueel.csv` | `-d i` of `-d b` | ETL stap 4 |
+| `student_count_first-years.xlsx` | Altijd | ETL stap 3 |
+| `student_count_higher-years.xlsx` | Altijd | ETL stap 3 |
+| `student_volume.xlsx` | Altijd | ETL stap 3 |
+| `ensemble_weights.xlsx` | Optioneel | `archive/calculate_ensemble_weights.py` |
+| `totaal_cumulatief.xlsx` | Optioneel | `archive/append_studentcount_and_compute_errors.py` |
+| `totaal_individueel.xlsx` | Optioneel | `archive/append_studentcount_and_compute_errors.py` |
+
+## Institutiespecifieke kolomnamen
+
+Jouw instelling gebruikt mogelijk andere kolomnamen dan de kanonieke namen hierboven. Pas de `columns`-sectie in `configuration.json` aan:
+
+```json
+{
+    "columns": {
+        "individual": {
+            "Croho groepeernaam": "CROHO_NAAM",
+            "Inschrijfstatus": "STATUS"
+        }
+    }
+}
+```
+
+Alleen de afwijkende namen hoeven opgegeven te worden. Zie [Configuratie](configuratie.md) voor de volledige kolommenlijst.
+
+## Bekende valkuil: `path_cumulative_new`
+
+!!! warning "load_data() overschrijft en verwijdert bestanden"
+    Als `path_cumulative_new` in je configuratie een bestaand bestand aanwijst, **mergt de
+    pipeline dit bestand in `vooraanmeldingen_cumulatief.csv` en verwijdert daarna het bronbestand**.
+    Bij een crash ná het schrijven maar vóór het verwijderen is de originele data onherstelbaar kwijt.
+
+    Gebruik dit mechanisme alleen als je bewust een nieuw cumulatief bestand wilt inladen.
+    Zet `path_cumulative_new` op `""` als je dit niet nodig hebt. Zie issue [#78](https://github.com/cedanl/studentprognose/issues/78).

--- a/docs/methodologie/sarima.md
+++ b/docs/methodologie/sarima.md
@@ -41,6 +41,19 @@ In het individuele spoor kan een deadlineweek-variabele als exogene regresssor w
 - Opleiding met sterke interjaarse variatie in aanmeldpatroon
 - Vroeg in het jaar (weinig datapunten beschikbaar; de voorspelling is dan een lange extrapolatie)
 
+## Bekende hardgecodeerde uitzondering: 2021
+
+In `utils/weeks.py` staat een expliciete uitzondering voor collegejaar 2021:
+
+```python
+if predict_year == 2021:
+    max_week = 38
+```
+
+Dit forceert de maximale week voor dat jaar op 38 (de standaard inschrijfdeadline), in plaats van die te berekenen uit de data. De vermoedelijke reden is dat de aanmeldingscyclus in 2021 een afwijkend patroon had door COVID, waardoor de normale berekening geen betrouwbaar resultaat gaf. De achterliggende reden is nog niet formeel gedocumenteerd — zie issue [#84](https://github.com/cedanl/studentprognose/issues/84).
+
+Dit illustreert een bredere aanname: **het model gaat ervan uit dat historische aanmeldpatronen representatief zijn**. Uitzonderingsjaren zoals 2021 moeten handmatig worden afgehandeld.
+
 ## Relatie tot andere modellen
 
 SARIMA levert een voorspelling per opleiding per week. In het `-d b` scenario wordt deze gecombineerd met de XGBoost-uitkomsten via het ensemble. Zie [Ensemble](ensemble.md).

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -1,23 +1,80 @@
 # Output begrijpen
 
-TODO: outputbestanden, kolomdefinities, MAE/MAPE uitgelegd, wanneer is een prognose betrouwbaar.
+De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvoerbestanden: een tussenresultaat en drie eindresultaten.
 
 ## Outputbestanden
 
-| Bestand | Beschrijving |
-|---------|-------------|
-| `output_first-years_*.xlsx` | Eerstejaars voorspellingen (eindresultaat) |
-| `output_higher-years_*.xlsx` | Hogerjaars voorspellingen |
-| `output_volume_*.xlsx` | Volume-voorspellingen (totaal) |
-| `output_prelim_*.xlsx` | Tussenresultaat vóór ratio/ensemble/foutmaten |
+| Bestand | Fase | Beschrijving |
+|---------|------|-------------|
+| `output_prelim_{modus}.xlsx` | Tussenresultaat | Voorlopige voorspellingen vóór ratio-model, ensemble en foutmaten. Nuttig voor debugging. |
+| `output_first-years_{modus}.xlsx` | Eindresultaat | Eerstejaars voorspellingen per opleiding/herkomst/week |
+| `output_higher-years_{modus}.xlsx` | Eindresultaat | Hogerjaars voorspellingen |
+| `output_volume_{modus}.xlsx` | Eindresultaat | Totaal studentvolume-voorspellingen |
+
+`{modus}` is `cumulatief`, `individueel` of `beide`, afhankelijk van de gebruikte `-d` vlag.
 
 ## Kolomdefinities
 
-| Kolom | Beschrijving |
+Elke rij in de output beschrijft een combinatie van **opleiding × herkomst × examentype × week × jaar**.
+
+### Voorspelkolommen
+
+| Kolom | Beschikbaar bij | Omschrijving |
+|-------|-----------------|-------------|
+| `SARIMA_cumulative` | `-d c` of `-d b` | SARIMA-voorspelling op basis van Studielink telbestanden |
+| `SARIMA_individual` | `-d i` of `-d b` | SARIMA-voorspelling op basis van individuele aanmelddata |
+| `Prognose_ratio` | `-d c` of `-d b` | Ratio-modelvoorspelling (3-jaars historisch gemiddelde) |
+| `Ensemble_prediction` | `-d b` | Gewogen combinatie van bovenstaande modellen |
+
+Als `-d b` is gebruikt maar individuele data ontbreekt, zijn `SARIMA_individual` en `Ensemble_prediction` leeg — zie [bekende valkuil](aan-de-slag.md#bekende-valkuil-stille-modus-downgrade).
+
+### Foutmaatkolommen
+
+Foutmaten zijn gebaseerd op **historische modelfouten** — hoe goed presteerde elk model in voorgaande jaren op dezelfde opleiding/herkomst/week? Ze zijn dus geen maat voor de nauwkeurigheid van de huidige voorspelling.
+
+| Kolom | Omschrijving |
 |-------|-------------|
-| `SARIMA_individual` | Voorspelling SARIMA individueel spoor |
-| `SARIMA_cumulative` | Voorspelling SARIMA cumulatief spoor |
-| `Prognose_ratio` | Voorspelling ratio-model |
-| `Ensemble_prediction` | Gewogen ensemble-voorspelling |
-| `MAE_*` | Gemiddelde absolute afwijking (historisch) |
-| `MAPE_*` | Gemiddelde procentuele afwijking (historisch) |
+| `MAE_Ensemble_prediction` | Gemiddelde absolute fout van het ensemble in voorgaande jaren |
+| `MAE_Prognose_ratio` | Gemiddelde absolute fout van het ratio-model |
+| `MAE_SARIMA_cumulative` | Gemiddelde absolute fout van SARIMA cumulatief |
+| `MAE_SARIMA_individual` | Gemiddelde absolute fout van SARIMA individueel |
+| `MAPE_Prognose_ratio` | Gemiddelde procentuele fout van het ratio-model |
+| `MAPE_SARIMA_cumulative` | Gemiddelde procentuele fout van SARIMA cumulatief |
+| `MAPE_SARIMA_individual` | Gemiddelde procentuele fout van SARIMA individueel |
+
+**MAE** (Mean Absolute Error): gemiddeld aantal studenten waarmee het model afweek.
+Een MAE van 8 betekent: het model zat in het verleden gemiddeld 8 studenten naast de werkelijkheid.
+
+**MAPE** (Mean Absolute Percentage Error): gemiddelde procentuele afwijking.
+Een MAPE van 0.12 betekent: het model zat gemiddeld 12% naast de werkelijkheid.
+
+!!! note "Foutmaten zijn alleen beschikbaar als er historische data is"
+    Bij een eerste run of bij opleidingen zonder historische modeloutput zijn de MAE/MAPE-kolommen leeg.
+
+## Wanneer is een prognose betrouwbaar?
+
+Er is geen harde drempel, maar de volgende signalen helpen:
+
+**Meer vertrouwen:**
+
+- De individuele modellen (`SARIMA_cumulative`, `SARIMA_individual`, `Prognose_ratio`) komen dicht bij elkaar uit — consensus tussen modellen is een goed teken
+- De historische MAE is klein ten opzichte van het voorspelde aantal
+- De voorspelling is gemaakt op of na week 10 (meer aanmelddata beschikbaar)
+
+**Minder vertrouwen:**
+
+- Grote spreiding tussen de modellen — overweeg elk model afzonderlijk te beoordelen
+- Hoge historische MAE of MAPE
+- Opleiding met weinig historische data (nieuw, of klein aantal inschrijvingen per jaar)
+- Vroeg in het jaar (vóór week 6) — de tijdreeks is dan erg kort
+- Het jaar na een uitzonderlijk jaar (COVID, beleidswijziging)
+
+## Meerdere modellen vergelijken
+
+De individuele modelkolommen naast `Ensemble_prediction` zijn bewust in de output opgenomen. Ze stellen je in staat om:
+
+- Te controleren of de modellen het eens zijn
+- Te signaleren welk model structureel afwijkt voor een specifieke opleiding
+- De baseline (ratio-model) te vergelijken met de complexere modellen — als het ensemble niet beter is dan de ratio, is er reden om kritischer te kijken
+
+Zie [Ensemble](methodologie/ensemble.md) voor uitleg over hoe de gewichten tot stand komen.

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -1,3 +1,70 @@
 # Validatie
 
-TODO: datakwaliteitscontroles uitwerken (zie ook issue #72 en de pre-ETL controles).
+De pipeline voert vóór de ETL automatisch een datakwaliteitscontrole uit op alle ruwe inputbestanden. Dit voorkomt dat fouten in de brondata pas later in de pipeline of in de output zichtbaar worden.
+
+Gebruik `--noetl` om zowel de ETL als de validatie over te slaan (alleen als de data eerder al gevalideerd is).
+
+## Drie typen bevindingen
+
+| Type | Gedrag | Wanneer gebruiken |
+|------|--------|------------------|
+| **Hard error** | Pipeline stopt direct | Data is structureel onbruikbaar (ontbrekende kolommen, onleesbaar bestand) |
+| **Soft error** | Pipeline vraagt om bevestiging | Data is twijfelachtig maar niet per se fout (onverwachte waarden, mogelijk verkeerd jaar) |
+| **Waarschuwing** | Pipeline loopt door, melding in console | Automatisch gecorrigeerd, of niet-kritiek |
+
+In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te omzeilen.
+
+## Gevalideerde bestanden
+
+### Telbestanden (`data/input_raw/telbestanden/`)
+
+| Controle | Type | Wat wordt gecheckt |
+|----------|------|-------------------|
+| Map bestaat | Hard error | `data/input_raw/telbestanden/` moet bestaan |
+| Bestanden aanwezig | Hard error | Minimaal één bestand met patroon `telbestandY{jaar}W{week}.csv` |
+| Verplichte kolommen | Hard error | `Studiejaar`, `Isatcode`, `Groepeernaam`, `Aantal`, `meercode_V`, `Herinschrijving`, `Hogerejaars`, `Herkomst` |
+| Weeknummer in bestandsnaam | Hard error | Weeknummer moet tussen 1 en 53 liggen |
+| Collegejaar bereik | Soft error | `Studiejaar` buiten `[huidig jaar − 15, huidig jaar + 2]` |
+| Herkomst geldige waarden | Soft error | Elke waarde in `Herkomst` moet `N`, `E` of `R` zijn |
+| Herinschrijving geldige waarden | Soft error | Elke waarde moet `J` of `N` zijn |
+| Hogerejaars geldige waarden | Soft error | Elke waarde moet `J` of `N` zijn |
+| meercode_V = 0 | Soft error | Leidt tot deling door nul in ETL |
+| Aantal < 0 | Soft error | Negatieve aantallen zijn inhoudelijk onjuist |
+| Ontbrekende waarden `Aantal` | Waarschuwing / Soft error | > 5% ontbrekend → waarschuwing; > 30% → soft error |
+| Gaten tussen weken | Waarschuwing | Gat van > 2 weken binnen een jaar |
+| Witruimte in categorische waarden | Waarschuwing | Automatisch gestript (`"J "` → `"J"`) |
+
+### Individuele aanmelddata (`data/input_raw/individuele_aanmelddata.csv`)
+
+| Controle | Type | Wat wordt gecheckt |
+|----------|------|-------------------|
+| Bestand bestaat | Waarschuwing | Niet aanwezig → overgeslagen (individueel spoor werkt niet) |
+| Verplichte kolommen | Hard error | `Collegejaar`, `Croho`, `Inschrijfstatus`, `Datum Verzoek Inschr` (via kolomnamen-mapping) |
+| Ontbrekende waarden | Waarschuwing / Soft error | Per verplichte kolom, zelfde drempels als telbestanden |
+
+### Oktober-bestand (`data/input_raw/oktober_bestand.xlsx`)
+
+| Controle | Type | Wat wordt gecheckt |
+|----------|------|-------------------|
+| Bestand bestaat | Waarschuwing | Niet aanwezig → studentaantallen worden niet berekend |
+| Verplichte kolommen | Hard error | `Collegejaar`, `Groepeernaam Croho`, `Aantal eerstejaars croho`, `EER-NL-nietEER`, `Examentype code`, `Aantal Hoofdinschrijvingen` |
+| Collegejaar bereik | Soft error | Zelfde bereikcontrole als telbestanden |
+| Ontbrekende waarden | Waarschuwing / Soft error | Per verplichte kolom |
+
+## Drempels aanpassen
+
+De standaarddrempels voor NaN-percentages en jaarbereiken zijn instelbaar via `configuration.json`. Zie [Configuratie — validation](configuratie.md#validation--validatiedrempels-overschrijven).
+
+## Een validatiefout oplossen
+
+**Hard error — ontbrekende kolommen:**
+De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober`.
+
+**Soft error — onverwacht collegejaar:**
+Controleer of het bestand het juiste studiejaar bevat. Als de afwijking verwacht is (bijv. historische data), kun je `collegejaar_min_offset` verhogen of met `--yes` doorgaan.
+
+**Soft error — ongeldige herkomstwaarden:**
+Jouw instelling gebruikt mogelijk `"ONBEKEND"` of een andere waarde. Voeg die toe aan `validation.telbestand.herkomst_allowed` in je configuratie.
+
+**Waarschuwing — witruimte gestript:**
+De data wordt automatisch gecorrigeerd. Overweeg de brondata te corrigeren om dit te voorkomen.


### PR DESCRIPTION
Alle vijf stub-pagina's uitgewerkt op basis van informatie die al in de repo aanwezig was.

## Wijzigingen

| Pagina | Inhoud |
|--------|--------|
| `aan-de-slag.md` | Data-layout, volledige CLI-referentie, valkuil stille modus-downgrade (#86) |
| `je-data-voorbereiden.md` | Kolomspecificaties per inputbestand, ETL-stappen, institutiespecifieke mapping, valkuil `path_cumulative_new` (#78) |
| `configuratie.md` | Alle `configuration.json` sleutels gedocumenteerd + minimale voorbeeldconfiguratie |
| `validatie.md` | Alle controles per bestandstype (hard/soft/warning), drempels, oplossingsrichtingen |
| `output-begrijpen.md` | Kolomdefinities, MAE/MAPE uitgelegd voor analisten, wanneer een prognose betrouwbaar is |
| `methodologie/sarima.md` | Hardgecodeerde 2021-uitzondering gedocumenteerd (#84) |

Closes #93 #94 #95 #96 #97 #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)