### PR TITLE
fix: los 4 technische issues op (#68, #63, #66, #82)

### DIFF
--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -2,10 +2,5 @@ import json
 
 
 def load_configuration(file_path):
-    f = open(file_path)
-
-    data = json.load(f)
-
-    f.close()
-
-    return data
+    with open(file_path) as f:
+        return json.load(f)

--- a/src/studentprognose/data/transforms.py
+++ b/src/studentprognose/data/transforms.py
@@ -6,13 +6,6 @@ from tqdm import tqdm
 
 tqdm.pandas()
 
-import warnings
-
-warnings.filterwarnings("ignore", category=RuntimeWarning)
-warnings.filterwarnings("ignore", category=UserWarning)
-
-pd.options.mode.chained_assignment = None  # default='warn'
-
 
 def transform_data(data_input: pd.DataFrame, targ_col: str) -> pd.DataFrame:
     """Makes a certain pivot_wider where it transforms the data from long to wide."""

--- a/src/studentprognose/models/sarima.py
+++ b/src/studentprognose/models/sarima.py
@@ -1,4 +1,3 @@
-import gc
 import numpy as np
 from numpy import linalg as LA
 import statsmodels.api as sm
@@ -53,8 +52,6 @@ def predict_with_sarima_cumulative(data_cumulative, row, predict_year, predict_w
             f"Prediction for {programme}, {herkomst}, year: {predict_year}, week: {predict_week}"
         )
 
-    gc.collect()
-
     data_cumulative = data_cumulative.astype(
         {"Weeknummer": "int32", "Collegejaar": "int32"}
     )
@@ -101,8 +98,6 @@ def predict_with_sarima_individual(data_individual, row, predict_year, predict_w
         print(
             f"Prediction for {programme}, {herkomst}, {examentype}, year: {predict_year}, week: {predict_week}"
         )
-
-    gc.collect()
 
     def filter_data(data, programme, herkomst, examentype, jaar, max_year):
         data = data[data["Herkomst"] == herkomst]

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import os
+import sys
 from statistics import mean
 
 from studentprognose.utils.weeks import (
@@ -33,10 +34,11 @@ class PostProcessor:
                     case StudentYearPrediction.VOLUME:
                         open(f"data/output/output_volume_{mode_suffix}{ci_suffix}.xlsx", "w").close()
         except IOError:
-            input(
-                "Could not open output files because they are (probably) opened by another process. "
-                "Please close Excel. Press Enter to continue."
+            print(
+                "Fout: outputbestand kan niet geopend worden, waarschijnlijk staat het nog open in Excel. "
+                "Sluit het bestand en probeer opnieuw."
             )
+            sys.exit(1)
 
     def __init__(self, configuration, data_latest, ensemble_weights,
                  data_studentcount, cwd, data_option, ci_test_n):


### PR DESCRIPTION
## Samenvatting

- **#68** – `gc.collect()` verwijderd uit SARIMA-voorspellingslus (2 aanroepen) en bijbehorende `import gc`
- **#63** – `input()`-blokkering in `postprocessor.py` vervangen door `sys.exit(1)` met Nederlandstalige foutmelding
- **#66** – `config.py` gebruikt nu een context manager (`with open()`) zodat de file handle niet lekt bij een JSON-fout
- **#82** – Globale `warnings.filterwarnings()` en `pd.options.mode.chained_assignment` verwijderd uit `transforms.py`

Closes #68, #63, #66, #82

## Testplan

- [x] Alle 63 tests slagen (`uv run pytest`)
- [x] Docs-mapping doorlopen — geen docs-updates nodig

🤖 Generated with [Claude Code](https://claude.com/claude-code)