### PR TITLE
fix: vervang fragiele CI-modus string-sniffing door ci_test_n check (#83)

### DIFF
--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -38,7 +38,7 @@ def main(argv):
     strategy = create_strategy(cfg, datasets, configuration, cwd)
 
     PostProcessor.check_output_writable(
-        cfg.data_option, cfg.student_year_prediction, cfg.ci_test_n, cfg.filtering_path,
+        cfg.data_option, cfg.student_year_prediction, cfg.ci_test_n,
     )
 
     # Step 3: Preprocess (feature engineering)

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -170,7 +170,7 @@ def _predict_and_postprocess(strategy, cfg, data_cumulative, year, week):
 
 
 def _save_results(strategy, cfg):
-    if "test" not in cfg.filtering_path:
+    if cfg.ci_test_n is None:
         if strategy.postprocessor.data is not None:
             print("Saving output...")
             strategy.postprocessor.save_output(cfg.student_year_prediction)

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -25,7 +25,7 @@ class PostProcessor:
         ci_suffix = f"_ci_test_N{ci_test_n}" if ci_test_n is not None else ""
         try:
             open(f"data/output/output_prelim_{mode_suffix}{ci_suffix}.xlsx", "w").close()
-            if "test" not in filtering_path:
+            if ci_test_n is None:
                 match student_year_prediction:
                     case StudentYearPrediction.FIRST_YEARS:
                         open(f"data/output/output_first-years_{mode_suffix}{ci_suffix}.xlsx", "w").close()

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -19,7 +19,7 @@ class PostProcessor:
     """
 
     @staticmethod
-    def check_output_writable(data_option, student_year_prediction, ci_test_n, filtering_path):
+    def check_output_writable(data_option, student_year_prediction, ci_test_n):
         """Verify output files can be written (not locked by Excel)."""
         mode_suffix = data_option.filename_suffix
         ci_suffix = f"_ci_test_N{ci_test_n}" if ci_test_n is not None else ""


### PR DESCRIPTION
## Samenvatting

Fixes #83

- `main.py:173` en `postprocessor.py:28` checkten of het woord `"test"` in het bestandspad zat om CI-modus te detecteren — dit is fragiel en kan stilletjes mislopen bij paden die toevallig `"test"` bevatten
- Vervangen door `ci_test_n is None`, wat al op andere plekken in de codebase als CI-indicator wordt gebruikt

## Wijzigingen

| Bestand | Wijziging |
|---------|-----------|
| `src/studentprognose/main.py` | `"test" not in cfg.filtering_path` → `cfg.ci_test_n is None` |
| `src/studentprognose/output/postprocessor.py` | `"test" not in filtering_path` → `ci_test_n is None` |

## Testplan

- [ ] Normale run (zonder `--ci`) slaat output nog steeds op
- [ ] CI-run (`--ci test 3`) slaat output nog steeds over
- [ ] Pad met "test" erin gedraagt zich als normale run

🤖 Generated with [Claude Code](https://claude.com/claude-code)