### PR TITLE
fix: verplaats hardgecodeerde Radboud-opleidingsnamen naar configuratie (#77)

### DIFF
--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -28,6 +28,14 @@
     "numerus_fixus": {
         "B Opleiding": 0
     },
+    "ensemble_override_cumulative": [
+        "B Geneeskunde",
+        "B Biomedische Wetenschappen",
+        "B Tandheelkunde"
+    ],
+    "exclude_from_combined": [
+        "M Educatie in de Mens- en Maatschappijwetenschappen"
+    ],
     "columns": {
         "individual": {
             "Sleutel": "Sleutel",

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -62,6 +62,36 @@ Een object met opleidingsnamen als sleutels en het maximale inschrijvingsaantal 
 
 Als de gesommeerde voorspelling over herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Opleidingen die hier niet staan worden niet gecapped.
 
+## `ensemble_override_cumulative` — ensemble-uitzondering per opleiding
+
+Een lijst van opleidingsnamen (op `Croho groepeernaam`) waarvoor de ensemble-logica altijd het SARIMA-cumulatief model gebruikt, ongeacht weeknummer of examentype.
+
+```json
+{
+    "ensemble_override_cumulative": [
+        "B Geneeskunde",
+        "B Biomedische Wetenschappen",
+        "B Tandheelkunde"
+    ]
+}
+```
+
+Gebruik dit voor opleidingen met een numerus fixus of een sterk afwijkend aanmeldpatroon waarbij het cumulatieve SARIMA-model aantoonbaar beter presteert. Lege lijst (`[]`) schakelt de uitzondering uit. Standaard: de bovenstaande drie opleidingen (Radboud-referentiewaarden).
+
+## `exclude_from_combined` — uitsluiting van combined-modus
+
+Een lijst van opleidingsnamen (op `Croho groepeernaam`) die worden overgeslagen in de combined-modus (`-d both`). Opleidingen op deze lijst worden niet meegenomen in de combined-voorspelling.
+
+```json
+{
+    "exclude_from_combined": [
+        "M Educatie in de Mens- en Maatschappijwetenschappen"
+    ]
+}
+```
+
+Gebruik dit voor opleidingen waarvoor de combined-modus aantoonbaar slechter werkt dan het cumulatieve spoor alleen. Lege lijst schakelt de uitsluiting uit. Standaard: bovenstaande opleiding (Radboud-referentiewaarde).
+
 ## `columns` — kolomnamen mapping
 
 Maakt het mogelijk dat instellingen andere kolomnamen gebruiken dan de kanonieke namen die de pipeline intern hanteert. Specificeer alleen de namen die afwijken — ontbrekende sleutels vallen terug op de kanonieke naam.

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -76,7 +76,9 @@ Een lijst van opleidingsnamen (op `Croho groepeernaam`) waarvoor de ensemble-log
 }
 ```
 
-Gebruik dit voor opleidingen met een numerus fixus of een sterk afwijkend aanmeldpatroon waarbij het cumulatieve SARIMA-model aantoonbaar beter presteert. Lege lijst (`[]`) schakelt de uitzondering uit. Standaard: de bovenstaande drie opleidingen (Radboud-referentiewaarden).
+Gebruik dit voor opleidingen met een numerus fixus of een sterk afwijkend aanmeldpatroon waarbij het cumulatieve SARIMA-model aantoonbaar beter presteert. Lege lijst (`[]`) schakelt de uitzondering uit voor alle opleidingen.
+
+De waarden in de demo-configuratie zijn Radboud-specifiek. **Vervang of maak deze lijst leeg voor je eigen instelling.**
 
 ## `exclude_from_combined` — uitsluiting van combined-modus
 
@@ -90,7 +92,9 @@ Een lijst van opleidingsnamen (op `Croho groepeernaam`) die worden overgeslagen 
 }
 ```
 
-Gebruik dit voor opleidingen waarvoor de combined-modus aantoonbaar slechter werkt dan het cumulatieve spoor alleen. Lege lijst schakelt de uitsluiting uit. Standaard: bovenstaande opleiding (Radboud-referentiewaarde).
+Gebruik dit voor opleidingen waarvoor de combined-modus aantoonbaar slechter werkt dan het cumulatieve spoor alleen. Lege lijst schakelt de uitsluiting uit.
+
+De waarde in de demo-configuratie is Radboud-specifiek. **Vervang of maak deze lijst leeg voor je eigen instelling.**
 
 ## `columns` — kolomnamen mapping
 

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -46,6 +46,7 @@ class PostProcessor:
         self.ensemble_weights = ensemble_weights
         self.data_studentcount = data_studentcount
         self.numerus_fixus_list = configuration["numerus_fixus"]
+        self.ensemble_override_cumulative = configuration.get("ensemble_override_cumulative", [])
         self.CWD = cwd
         self.data_option = data_option
         self.ci_test_n = ci_test_n
@@ -334,11 +335,7 @@ class PostProcessor:
         sarima_cumulative = convert_nan_to_zero(row["SARIMA_cumulative"])
         sarima_individual = convert_nan_to_zero(row["SARIMA_individual"])
 
-        if row["Croho groepeernaam"] in [
-            "B Geneeskunde",
-            "B Biomedische Wetenschappen",
-            "B Tandheelkunde",
-        ]:
+        if row["Croho groepeernaam"] in self.ensemble_override_cumulative:
             return sarima_cumulative
         elif row["Weeknummer"] in range(17, 24) and row["Examentype"] == "Master":
             return sarima_individual * 0.2 + sarima_cumulative * 0.8

--- a/src/studentprognose/strategies/combined.py
+++ b/src/studentprognose/strategies/combined.py
@@ -99,13 +99,11 @@ class CombinedStrategy(PredictionStrategy):
 
         self.skip_years = skip_years
 
+        exclude_from_combined = self.configuration.get("exclude_from_combined", [])
         data_to_predict = self.cumulative.data_cumulative[
             (self.cumulative.data_cumulative["Collegejaar"] == self.predict_year)
             & (self.cumulative.data_cumulative["Weeknummer"] == self.predict_week)
-            & (
-                self.cumulative.data_cumulative["Croho groepeernaam"]
-                != "M Educatie in de Mens- en Maatschappijwetenschappen"
-            )
+            & (~self.cumulative.data_cumulative["Croho groepeernaam"].isin(exclude_from_combined))
         ]
         if self.programme_filtering != []:
             data_to_predict = data_to_predict[

--- a/src/studentprognose/strategies/combined.py
+++ b/src/studentprognose/strategies/combined.py
@@ -36,6 +36,7 @@ class CombinedStrategy(PredictionStrategy):
                 f"Selected years {years} not found in individual dataset. Proceeding with cumulative dataset."
             )
         self.years = years
+        self.exclude_from_combined = configuration.get("exclude_from_combined", [])
 
     def preprocess(self):
         print("Preprocessing individual data...")
@@ -99,11 +100,10 @@ class CombinedStrategy(PredictionStrategy):
 
         self.skip_years = skip_years
 
-        exclude_from_combined = self.configuration.get("exclude_from_combined", [])
         data_to_predict = self.cumulative.data_cumulative[
             (self.cumulative.data_cumulative["Collegejaar"] == self.predict_year)
             & (self.cumulative.data_cumulative["Weeknummer"] == self.predict_week)
-            & (~self.cumulative.data_cumulative["Croho groepeernaam"].isin(exclude_from_combined))
+            & (~self.cumulative.data_cumulative["Croho groepeernaam"].isin(self.exclude_from_combined))
         ]
         if self.programme_filtering != []:
             data_to_predict = data_to_predict[


### PR DESCRIPTION
## Samenvatting

Fixes #77

Twee plekken met Radboud-specifieke opleidingsnamen hardgecodeerd in gedeelde code zijn verplaatst naar `configuration.json`. Voor andere instellingen hadden deze namen nooit effect (namen kwamen nooit voor), maar de code was misleidend en niet aanpasbaar.

## Wijzigingen

| Bestand | Wijziging |
|---------|-----------|
| `configuration/configuration.json` | Nieuwe sleutels `ensemble_override_cumulative` en `exclude_from_combined` |
| `src/studentprognose/output/postprocessor.py` | `__init__` leest `ensemble_override_cumulative` uit config; `_get_normal_ensemble` gebruikt de lijst |
| `src/studentprognose/strategies/combined.py` | Uitsluiting in `predict_nr_of_students` leest uit `exclude_from_combined` in config |
| `docs/configuratie.md` | Documentatie voor beide nieuwe config-sleutels |

## Gedrag

- Radboud-installaties: vullen de lijsten met hun eigen namen → identiek gedrag als voor de wijziging
- Andere instellingen: lege lijst als default → geen effect, geen stille incorrecte prognoses meer
- Alle instellingen kunnen nu hun eigen uitzonderingen instellen zonder code te wijzigen

## Testplan

- [ ] Demo-run met gevulde lijsten produceert identieke output
- [ ] Demo-run met lege lijsten werkt zonder fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)