### PR TITLE
feat: init-commando zichtbaar in --help

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -73,6 +73,20 @@ De output verschijnt in `data/output/`.
 
 ## CLI-referentie
 
+Alle subcommando's en vlaggen zijn te bekijken via:
+
+```bash
+studentprognose --help
+```
+
+### Subcommando's
+
+| Commando | Beschrijving |
+|----------|-------------|
+| `init` | Maak een nieuwe projectmap aan met configuratie en mappenstructuur |
+
+### Vlaggen
+
 | Vlag | Waarden | Standaard | Beschrijving |
 |------|---------|-----------|-------------|
 | `-w` | weeknummer(s) | huidige week | Voorspelweek(en), bijv. `-w 10` of `-w 8:12` |

--- a/src/studentprognose/cli.py
+++ b/src/studentprognose/cli.py
@@ -1,6 +1,5 @@
 import argparse
 import datetime
-import os
 from dataclasses import dataclass, field
 
 from studentprognose.utils.weeks import DataOption, StudentYearPrediction
@@ -19,6 +18,7 @@ class PipelineConfig:
     ci_test_n: int | None = None
     noetl: bool = False
     yes: bool = False
+    command: str | None = None
 
 
 def _expand_slices(tokens):
@@ -72,6 +72,12 @@ def parse_args(argv):
     """Parse CLI arguments and return a PipelineConfig."""
     parser = argparse.ArgumentParser(description="Student prognose pipeline")
 
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["init"],
+        help="init  Maak een nieuwe projectmap aan met configuratie en mappenstructuur",
+    )
     parser.add_argument("-w", "-W", "-week", nargs="*", default=None, dest="weeks")
     parser.add_argument("-y", "-Y", "-year", nargs="*", default=None, dest="years")
     parser.add_argument("-d", "-D", "-dataset", choices=list(DATASET_MAP.keys()), default=None, dest="dataset")
@@ -86,6 +92,7 @@ def parse_args(argv):
     args = parser.parse_args(argv[1:])
 
     cfg = PipelineConfig()
+    cfg.command = args.command
     cfg.noetl = args.noetl
     cfg.yes = args.yes
 

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -15,12 +15,12 @@ from studentprognose.utils.constants import FINAL_ACADEMIC_WEEK, WEEKS_PER_YEAR
 
 
 def main(argv):
-    if len(argv) > 1 and argv[1] == "init":
+    cfg = parse_args(argv)
+
+    if cfg.command == "init":
         from studentprognose.init import run_init
         run_init()
         return
-
-    cfg = parse_args(argv)
 
     # Step 0: Validate raw input data, then run ETL (skip both with --noetl)
     print("Loading configuration...")

--- a/tests/studentprognose/test_cli.py
+++ b/tests/studentprognose/test_cli.py
@@ -55,3 +55,15 @@ class TestParseArgs:
         from studentprognose.utils.weeks import DataOption
         cfg = parse_args(["prog", "-d", "c"])
         assert cfg.data_option == DataOption.CUMULATIVE
+
+    def test_init_command_in_parse_args(self):
+        cfg = parse_args(["prog", "init"])
+        assert cfg.command == "init"
+
+    def test_default_command_is_none(self):
+        cfg = parse_args(["prog"])
+        assert cfg.command is None
+
+    def test_init_not_needed_for_flags(self):
+        cfg = parse_args(["prog", "-w", "10"])
+        assert cfg.command is None


### PR DESCRIPTION
## Samenvatting

Sluit #143.

- Voeg `init` toe als optioneel positioneel argument (`nargs="?"`) aan de `argparse`-parser in `cli.py`, zodat `studentprognose --help` het subcommando toont
- Voeg `command: str | None = None` toe aan `PipelineConfig`
- Verwijder de raw `argv[1] == "init"`-check in `main.py` en vervang door `cfg.command == "init"` — backward-compatibel, `studentprognose -w 10 -y 2025` werkt ongewijzigd
- Voeg CLI-referentiesectie toe in `docs/aan-de-slag.md` met subcommando-tabel en verwijzing naar `--help`
- Voeg drie nieuwe tests toe: `test_init_command_in_parse_args`, `test_default_command_is_none`, `test_init_not_needed_for_flags`

## Testplan

- [ ] `uv run pytest tests/` — alle 146 tests slagen
- [ ] `studentprognose --help` toont `{init}` als positional argument
- [ ] `studentprognose init` werkt nog steeds
- [ ] `studentprognose -w 10 -y 2025` werkt nog steeds (geen regressie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)