### PR TITLE
fix: initialiseer Skip_prediction kolom bij skip_years > 0 (#109)

### DIFF
--- a/src/studentprognose/strategies/cumulative.py
+++ b/src/studentprognose/strategies/cumulative.py
@@ -229,6 +229,8 @@ class CumulativeStrategy(PredictionStrategy):
 
         data_to_predict["SARIMA_individual"] = np.nan
         data_to_predict["Voorspelde vooraanmelders"] = np.nan
+        if skip_years > 0:
+            data_to_predict["Skip_prediction"] = np.nan
 
         data_to_predict = self.postprocessor.add_predicted_preregistrations(
             data_to_predict, [x[: self.pred_len] for x in self.predicted_data]


### PR DESCRIPTION
Fixes #109

## Oorzaak

`Skip_prediction` werd in `_predict_with_xgboost_extra_year` alleen aangemaakt via `.loc` als twee condities tegelijk golden:
1. `test2_merged` is niet leeg (jaar `predict_year - skip_years` bestaat in de data)
2. `train2` is niet leeg (er zijn trainingsdata vóór `predict_year - (skip_years * 2)`)

Als één van beide condities niet opging (bij te weinig historische data), crashte de postprocessor daarna met:

```
KeyError: "['Skip_prediction'] not in index"
```

## Fix

Initialiseer `Skip_prediction` als `NaN` direct na de andere kolom-initialisaties, vóórdat de XGBoost-loop start. De kolom bestaat nu altijd als `skip_years > 0`, ongeacht of de XGBoost-predicties lukten.

## Gereproduceerd met

```bash
# train2 leeg (predict_year - skip_years*2 < eerste datajaar)
studentprognose -w 6 -y 2022 -d cumulative -sk 4 --noetl --yes

# test2 leeg (predict_year - skip_years niet in data)
studentprognose -w 6 -y 2016 -d cumulative -sk 1 --noetl --yes
```

Beide scenarios draaien nu zonder crash.

## Test plan

- [x] `uv run pytest` — 163 passed
- [x] `-y 2022 -sk 4` lokaal getest (was: crash, nu: Saving output)
- [x] `-y 2016 -sk 1` lokaal getest (was: crash, nu: Saving output)
- [x] `-y 2020 -sk 1` happy path ongewijzigd

🤖 Generated with [Claude Code](https://claude.com/claude-code)