### PR TITLE
feat: CLI-regressietests en teststrategie (#73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,30 @@ uv run mkdocs serve
 uv run mkdocs build
 ```
 
+## Teststrategie
+
+### Niveaus
+
+| Niveau | Bestand | Wat het bewaakt |
+|--------|---------|-----------------|
+| Unit | `tests/studentprognose/test_cli.py` | Argument-parsing, vlagcombinaties, exitcodes |
+| Unit | `tests/studentprognose/test_validation.py` | Validatielogica, `_handle_result` exitcodes |
+| Unit | `tests/studentprognose/test_strategies.py` | Strategie-contracten (preprocess return types) |
+| Integratie | `scripts/test_package.sh` | Volledige pipeline met demodata, exitcode 0 |
+
+CI draait alle unit tests + smoke test bij elke push en PR naar `main` (zie `.github/workflows/`).
+
+### Wanneer schrijf je een test?
+
+- **Nieuwe CLI-vlag** → voeg een `parse_args`-test toe in `test_cli.py` die de vlag en de default bewaakt.
+- **Nieuwe validatiecheck** → voeg een test toe in `test_validation.py`. Test minimaal: correcte bevinding bij slechte data, geen bevinding bij geldige data, en het juiste type (hard/soft/warning).
+- **Exitcode-gedrag** → gebruik altijd `pytest.raises(SystemExit) as exc` en assert `exc.value.code` expliciet — `pytest.raises(SystemExit)` zonder codeverificatie vangt ook `sys.exit(0)`.
+- **Nieuwe strategie of model** → voeg een contracttest toe die de return-types van `preprocess()` en `predict_nr_of_students()` bewaakt.
+
+### Wat de unit tests niet doen
+
+De unit tests draaien zonder echte inputdata en zonder de volledige pipeline. Correctheid van voorspellingen en end-to-end uitvoer wordt bewaakt door de smoke test (`scripts/test_package.sh`), niet door pytest.
+
 ## Documentatie-regel (verplicht bij elke PR)
 
 De documentatie in `docs/` is gericht op **analisten en onderzoekers**: niet alleen hoe de tool werkt, maar het **waarom** achter methodologische keuzes — aannames, beperkingen, en wanneer je output kritisch moet interpreteren.

--- a/scripts/test_package.sh
+++ b/scripts/test_package.sh
@@ -8,6 +8,10 @@
 #   4. Integratiepijplijn met repo-demodata — controleert dat de volledige
 #      pipeline tot outputbestand loopt; data wordt gekopieerd vanuit de repo,
 #      NIET meegeleverd in het wheel.
+#   5. --noetl --yes combinatie — pipeline slaagt met al verwerkte data,
+#      ETL en validatie worden overgeslagen
+#   6. -sk (skipyears) vlag — pipeline slaagt met skip_years > 0
+#   7. Exitcode 1 bij harde validatiefout — kapot telbestand triggert sys.exit(1)
 #
 # Gebruik: bash scripts/test_package.sh [--skip-build]
 
@@ -52,6 +56,36 @@ cp    "$REPO_ROOT/data/input_raw/individuele_aanmelddata.csv" data/input_raw/
 cp    "$REPO_ROOT/data/input_raw/oktober_bestand.xlsx"   data/input_raw/
 uv run studentprognose -w 6 -y 2020 --yes > /dev/null
 [ -f data/output/output_first-years_beide.xlsx ] || { echo "FOUT: output ontbreekt"; exit 1; }
+echo "OK"
+
+echo ""
+echo "=== [5] --noetl --yes combinatie ==="
+# Stap 4 heeft de verwerkte inputbestanden al aangemaakt in data/input/.
+# --noetl slaat ETL en validatie over; de pipeline moet slagen op de bestaande data.
+uv run studentprognose -w 6 -y 2020 --noetl --yes > /dev/null
+[ -f data/output/output_first-years_beide.xlsx ] || { echo "FOUT: output ontbreekt na --noetl run"; exit 1; }
+echo "OK"
+
+echo ""
+echo "=== [6] -sk (skipyears) vlag ==="
+# Bewaakt regressie op issue #109: Skip_prediction KeyError bij skip_years > 0.
+uv run studentprognose -w 6 -y 2022 -d cumulative -sk 1 --noetl --yes > /dev/null
+[ -f data/output/output_prelim_cumulatief.xlsx ] || { echo "FOUT: output ontbreekt na -sk run"; exit 1; }
+echo "OK"
+
+echo ""
+echo "=== [7] Exitcode 1 bij harde validatiefout ==="
+# Maak een kapot telbestand aan zonder de vereiste kolommen.
+# De validatie moet een hard error geven en afsluiten met exitcode 1.
+BROKEN_DIR="$(mktemp -d)"
+trap 'rm -rf "$BROKEN_DIR"' EXIT
+mkdir -p "$BROKEN_DIR/data/input_raw/telbestanden"
+echo "col1;col2" > "$BROKEN_DIR/data/input_raw/telbestanden/telbestandY2024W10.csv"
+echo "a;b"       >> "$BROKEN_DIR/data/input_raw/telbestanden/telbestandY2024W10.csv"
+if (cd "$BROKEN_DIR" && uv run --with "$WHEEL" studentprognose -w 10 -y 2024 --yes 2>/dev/null); then
+    echo "FOUT: exitcode 0 verwacht bij harde validatiefout, maar pipeline slaagde"
+    exit 1
+fi
 echo "OK"
 
 echo ""

--- a/tests/studentprognose/test_cli.py
+++ b/tests/studentprognose/test_cli.py
@@ -1,5 +1,6 @@
 import pytest
 from studentprognose.cli import _expand_slices, parse_args
+from studentprognose.utils.weeks import DataOption
 
 
 class TestExpandSlices:
@@ -49,8 +50,9 @@ class TestParseArgs:
         assert cfg.ci_test_n == 5
 
     def test_ci_invalid_raises(self):
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc:
             parse_args(["prog", "--ci", "invalid", "5"])
+        assert exc.value.code != 0
 
     def test_dataset_cumulative(self):
         from studentprognose.utils.weeks import DataOption
@@ -77,3 +79,42 @@ class TestParseArgs:
     def test_years_not_specified_flag(self):
         cfg = parse_args(["prog"])
         assert cfg.years_specified is False
+
+    def test_yes_flag(self):
+        cfg = parse_args(["prog", "--yes"])
+        assert cfg.yes is True
+
+    def test_yes_default_is_false(self):
+        cfg = parse_args(["prog"])
+        assert cfg.yes is False
+
+    def test_noetl_and_yes_combination(self):
+        cfg = parse_args(["prog", "--noetl", "--yes"])
+        assert cfg.noetl is True
+        assert cfg.yes is True
+
+    def test_week_53_accepted(self):
+        cfg = parse_args(["prog", "-w", "53"])
+        assert cfg.weeks == [53]
+        assert cfg.weeks_specified is True
+
+    def test_skipyears_flag(self):
+        cfg = parse_args(["prog", "-sk", "2"])
+        assert cfg.skip_years == 2
+
+    def test_skipyears_default_is_zero(self):
+        cfg = parse_args(["prog"])
+        assert cfg.skip_years == 0
+
+    def test_ci_invalid_exits_nonzero(self):
+        with pytest.raises(SystemExit) as exc:
+            parse_args(["prog", "--ci", "invalid", "5"])
+        assert exc.value.code != 0
+
+    def test_dataset_individual(self):
+        cfg = parse_args(["prog", "-d", "i"])
+        assert cfg.data_option == DataOption.INDIVIDUAL
+
+    def test_dataset_both(self):
+        cfg = parse_args(["prog", "-d", "b"])
+        assert cfg.data_option == DataOption.BOTH_DATASETS


### PR DESCRIPTION
Fixes #73

## Wat er al was

Een CI-workflow (`.github/workflows/ci.yml` + `unit.yml`) die `pytest tests/ -v` draait bij elke push/PR naar `main`. Die infra was compleet — wat ontbrak waren de tests zelf.

## Wat er bij komt

### `tests/studentprognose/test_cli.py`

| Test | Wat het bewaakt |
|---|---|
| `test_yes_flag` | `--yes` zet `cfg.yes = True` |
| `test_yes_default_is_false` | default is `False`, geen stille activatie |
| `test_noetl_and_yes_combination` | vlaggen bijten elkaar niet |
| `test_week_53_accepted` | week 53 via `-w 53` crasht niet |
| `test_skipyears_flag` | `-sk 2` → `cfg.skip_years == 2` |
| `test_skipyears_default_is_zero` | default is 0 |
| `test_ci_invalid_exits_nonzero` | exitcode is expliciet ≠ 0 |
| `test_dataset_individual` / `test_dataset_both` | shortcodes `i` en `b` |

Bestaand: `test_ci_invalid_raises` uitgebreid met `assert exc.value.code != 0` — bewaakt de bug waarbij `pytest.raises(SystemExit)` ook `sys.exit(0)` vangt.

### `CLAUDE.md`

Teststrategie-sectie toegevoegd:
- Overzicht van de vier testniveaus (unit / smoke)
- Wanneer schrijf je welk type test
- Expliciete waarschuwing over exitcode-verificatie

## Test plan

- [x] `uv run pytest tests/studentprognose/test_cli.py -v` — 27 passed
- [x] `uv run pytest tests/ -q` — 172 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)