### PR TITLE
fix: dashboard crasht niet meer + opt-in via --dashboard

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -108,6 +108,7 @@ studentprognose --help
 | `-sk` | getal | `0` | Skip N jaren (backtesting) |
 | `--noetl` | — | uit | Sla ETL én validatie over |
 | `--yes` | — | uit | Sla validatieprompts over (voor CI/CD) |
+| `--dashboard` | — | uit | Genereer interactieve Plotly-dashboards (`data/output/visualisations/`) |
 | `--ci test N` | getal | — | Testmodus: beperkt tot N opleidingen |
 
 Weekbereiken zijn mogelijk: `-w 8:12` is gelijk aan `-w 8 9 10 11 12`.

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -109,13 +109,22 @@ MAE en MAPE worden berekend **exclusief numerus-fixusopleidingen**. Voor deze op
 
 ## Interactief dashboard
 
-Naast de Excel-bestanden genereert de pipeline interactieve HTML-dashboards onder `data/output/visualisaties/`. Per modus (`-d i`, `-d c`, `-d b`) wordt een apart dashboard aangemaakt met daarin:
+Naast de Excel-bestanden kan de pipeline interactieve HTML-dashboards genereren onder `data/output/visualisaties/`. Per modus (`-d i`, `-d c`, `-d b`) wordt een apart dashboard aangemaakt met daarin:
 
 - **Individueel dashboard**: XGBoost-voorspellingen per opleiding, SARIMA-trajecten, feature importance (classifier).
 - **Cumulatief dashboard**: SARIMA-voorspellingen op cumulatieve teldata, XGBoost-regressorresultaten, feature importance (regressor).
 - **Eindoverzicht**: ensemble-voorspellingen per opleiding, foutmaten, vergelijking met vorige jaren.
 
 De dashboards zijn zelfstandige HTML-bestanden (geen server nodig) en kunnen in elke browser geopend worden.
+
+!!! info "Dashboard is opt-in"
+    Sinds deze versie wordt het dashboard alleen gegenereerd als je expliciet `--dashboard` meegeeft. Een voorbeeld:
+
+    ```bash
+    studentprognose --dashboard -d both -w 10 -y 2025
+    ```
+
+    Mocht dashboard-generatie onverhoopt falen, dan loopt de rest van de pipeline gewoon door en wordt de stack trace weggeschreven naar `data/output/dashboard_error.log`. De Excel-output blijft in dat geval beschikbaar.
 
 !!! note "Dashboard toont alleen de laatste week"
     Bij een multi-week run (bijv. `-w 10:20`) toont het dashboard alleen de prognose van de **laatste week** in de reeks. De Excel-output bevat wel alle weken.

--- a/src/studentprognose/cli.py
+++ b/src/studentprognose/cli.py
@@ -20,6 +20,7 @@ class PipelineConfig:
     ci_test_n: int | None = None
     noetl: bool = False
     yes: bool = False
+    dashboard: bool = False
     command: str | None = None
 
 
@@ -123,6 +124,11 @@ def parse_args(argv):
         action="store_true",
         help="Sla de interactieve validatieprompt over (voor geautomatiseerde runs)",
     )
+    parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="Genereer interactieve Plotly-dashboards in data/output/visualisations/. Standaard uit.",
+    )
 
     args = parser.parse_args(argv[1:])
 
@@ -130,6 +136,7 @@ def parse_args(argv):
     cfg.command = args.command
     cfg.noetl = args.noetl
     cfg.yes = args.yes
+    cfg.dashboard = args.dashboard
 
     # Configuration path — load_configuration handles missing files gracefully
     if args.configuration:

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 from typing import Optional
 
 import pandas as pd
@@ -452,26 +453,41 @@ def _save_results(strategy, cfg):
             print("Saving output...")
             strategy.postprocessor.save_output(cfg.student_year_prediction)
 
-            if len(cfg.weeks) > 1:
-                print(
-                    f"Let op: het dashboard toont alleen de prognose voor week {cfg.weeks[-1]} (laatste week in de reeks)."
-                )
-
-            dd = strategy.get_dashboard_data()
-            dashboard = DashboardBuilder(
-                data=strategy.postprocessor.data,
-                data_option=cfg.data_option,
-                numerus_fixus_list=strategy.postprocessor.numerus_fixus_list,
-                student_year_prediction=cfg.student_year_prediction,
-                ci_test_n=cfg.ci_test_n,
-                cwd=os.getcwd(),
-                predict_week=cfg.weeks[-1] if cfg.weeks else None,
-                data_cumulative=dd["data_cumulative"],
-                data_studentcount=strategy.postprocessor.data_studentcount,
-                data_xgboost_curve=dd["xgboost_curve"],
-                xgb_classifier_importance=dd["xgb_classifier_importance"],
-                xgb_regressor_importance=dd["xgb_regressor_importance"],
-            )
-            dashboard.build_and_save()
+            if cfg.dashboard:
+                _try_build_dashboard(strategy, cfg)
         else:
             print("No data to save. Saving output skipped.")
+
+
+def _try_build_dashboard(strategy, cfg):
+    """Build the Plotly dashboard. A failure here is logged but never crashes the pipeline."""
+    if len(cfg.weeks) > 1:
+        print(
+            f"Let op: het dashboard toont alleen de prognose voor week {cfg.weeks[-1]} (laatste week in de reeks)."
+        )
+
+    try:
+        dd = strategy.get_dashboard_data()
+        dashboard = DashboardBuilder(
+            data=strategy.postprocessor.data,
+            data_option=cfg.data_option,
+            numerus_fixus_list=strategy.postprocessor.numerus_fixus_list,
+            student_year_prediction=cfg.student_year_prediction,
+            ci_test_n=cfg.ci_test_n,
+            cwd=os.getcwd(),
+            predict_week=cfg.weeks[-1] if cfg.weeks else None,
+            data_cumulative=dd["data_cumulative"],
+            data_studentcount=strategy.postprocessor.data_studentcount,
+            data_xgboost_curve=dd["xgboost_curve"],
+            xgb_classifier_importance=dd["xgb_classifier_importance"],
+            xgb_regressor_importance=dd["xgb_regressor_importance"],
+        )
+        dashboard.build_and_save()
+    except Exception:
+        log_path = os.path.join(os.getcwd(), "data", "output", "dashboard_error.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w", encoding="utf-8") as f:
+            f.write(traceback.format_exc())
+        print(
+            f"Waarschuwing: dashboard niet gegenereerd. Zie {log_path} voor details."
+        )

--- a/src/studentprognose/output/dashboard.py
+++ b/src/studentprognose/output/dashboard.py
@@ -2391,6 +2391,10 @@ class DashboardBuilder:
                 prog_traces[prog].append((idx, True))
 
             # ── SARIMA forecast (red dashed) + uncertainty band ──────────
+            # data_cumulative may contain programmes that were filtered out of self.data
+            # (e.g. by min_training_year, filtering rules). In that case the aggregation
+            # below is empty and pandas can drop the Weeknummer column on the empty
+            # groupby result, so we guard explicitly before sorting.
             if "Voorspelde vooraanmelders" in self.data.columns:
                 sarima_sub = (
                     self.data[
@@ -2400,6 +2404,10 @@ class DashboardBuilder:
                     .groupby("Weeknummer")["Voorspelde vooraanmelders"].sum().reset_index()
                     .dropna(subset=["Voorspelde vooraanmelders"])
                 )
+            else:
+                sarima_sub = pd.DataFrame()
+
+            if not sarima_sub.empty and "Weeknummer" in sarima_sub.columns:
                 # Only weeks after predict_week
                 if self.predict_week is not None:
                     pw_key = week_sort_key(self.predict_week)

--- a/tests/studentprognose/test_cli.py
+++ b/tests/studentprognose/test_cli.py
@@ -88,6 +88,14 @@ class TestParseArgs:
         cfg = parse_args(["prog"])
         assert cfg.yes is False
 
+    def test_dashboard_flag(self):
+        cfg = parse_args(["prog", "--dashboard"])
+        assert cfg.dashboard is True
+
+    def test_dashboard_default_is_false(self):
+        cfg = parse_args(["prog"])
+        assert cfg.dashboard is False
+
     def test_noetl_and_yes_combination(self):
         cfg = parse_args(["prog", "--noetl", "--yes"])
         assert cfg.noetl is True

--- a/tests/studentprognose/test_dashboard.py
+++ b/tests/studentprognose/test_dashboard.py
@@ -1,0 +1,116 @@
+"""Resilience tests voor dashboard-generatie.
+
+Een fout in de dashboard-stap mag de rest van de pipeline niet laten falen — de
+voorspelling zelf moet alsnog beschikbaar zijn. Deze tests pinnen dat gedrag vast.
+"""
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+import studentprognose.main as main_module
+from studentprognose.cli import PipelineConfig
+
+
+def _make_strategy_stub():
+    postprocessor = SimpleNamespace(
+        data=pd.DataFrame({"Croho groepeernaam": ["X"], "Collegejaar": [2024], "Weeknummer": [10]}),
+        numerus_fixus_list={},
+        data_studentcount=None,
+    )
+    return SimpleNamespace(
+        postprocessor=postprocessor,
+        get_dashboard_data=lambda: {
+            "data_cumulative": None,
+            "xgboost_curve": None,
+            "xgb_classifier_importance": None,
+            "xgb_regressor_importance": None,
+        },
+    )
+
+
+def test_dashboard_failure_is_logged_to_file(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    class _BoomDashboard:
+        def __init__(self, **_kwargs):
+            pass
+
+        def build_and_save(self):
+            raise RuntimeError("synthetic dashboard failure")
+
+    monkeypatch.setattr(main_module, "DashboardBuilder", _BoomDashboard)
+
+    cfg = PipelineConfig(weeks=[10], years=[2024], dashboard=True)
+
+    main_module._try_build_dashboard(_make_strategy_stub(), cfg)
+
+    log_path = tmp_path / "data" / "output" / "dashboard_error.log"
+    assert log_path.exists(), "dashboard_error.log moet zijn aangemaakt bij een crash"
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert "synthetic dashboard failure" in log_contents
+    assert "Traceback" in log_contents
+
+    captured = capsys.readouterr()
+    assert "Waarschuwing: dashboard niet gegenereerd" in captured.out
+    assert str(log_path) in captured.out
+
+
+def test_dashboard_failure_does_not_raise(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    class _BoomDashboard:
+        def __init__(self, **_kwargs):
+            raise RuntimeError("crash in __init__")
+
+    monkeypatch.setattr(main_module, "DashboardBuilder", _BoomDashboard)
+
+    cfg = PipelineConfig(weeks=[10], years=[2024], dashboard=True)
+
+    try:
+        main_module._try_build_dashboard(_make_strategy_stub(), cfg)
+    except Exception as exc:  # pragma: no cover - vangnet test
+        pytest.fail(f"_try_build_dashboard mag niet propageren: {exc!r}")
+
+
+def test_save_results_skips_dashboard_by_default(monkeypatch):
+    """Zonder --dashboard mag _save_results de dashboard-builder niet aanroepen."""
+    called = {"n": 0}
+
+    def _spy(strategy, cfg):
+        called["n"] += 1
+
+    monkeypatch.setattr(main_module, "_try_build_dashboard", _spy)
+
+    postprocessor = SimpleNamespace(
+        data=pd.DataFrame({"x": [1]}),
+        save_output=lambda _pred: None,
+    )
+    strategy = SimpleNamespace(postprocessor=postprocessor)
+    cfg = PipelineConfig(weeks=[10], years=[2024])  # dashboard=False (default)
+
+    main_module._save_results(strategy, cfg)
+
+    assert called["n"] == 0, "dashboard mag niet draaien zonder --dashboard"
+
+
+def test_save_results_runs_dashboard_when_enabled(monkeypatch):
+    """Met --dashboard moet _save_results de dashboard-builder triggeren."""
+    called = {"n": 0}
+
+    def _spy(strategy, cfg):
+        called["n"] += 1
+
+    monkeypatch.setattr(main_module, "_try_build_dashboard", _spy)
+
+    postprocessor = SimpleNamespace(
+        data=pd.DataFrame({"x": [1]}),
+        save_output=lambda _pred: None,
+    )
+    strategy = SimpleNamespace(postprocessor=postprocessor)
+    cfg = PipelineConfig(weeks=[10], years=[2024], dashboard=True)
+
+    main_module._save_results(strategy, cfg)
+
+    assert called["n"] == 1, "dashboard moet draaien met --dashboard"


### PR DESCRIPTION
## Summary

- **Root cause fix**: vroege `empty`/kolom-guard in `_yearly_trend` lost de `KeyError: 'Weeknummer'` op die Radboud zag wanneer `data_cumulative` opleidingen bevat die niet in `self.data` voorkomen (gefilterd uit de voorspelling). De SARIMA-trace wordt voor die opleidingen overgeslagen; de historische lijnen blijven gewoon zichtbaar.
- **Opt-in dashboard**: nieuwe `--dashboard`-vlag (default uit). Gebruikers die alleen Excel-output willen ervaren geen onverwachte dashboard-crashes meer.
- **Pipeline-robuustheid**: dashboard-aanroep zit nu in een `try/except`. Bij een fout: stack trace naar `data/output/dashboard_error.log`, waarschuwing op stdout, **pipeline-exitcode blijft 0** zodat de Excel-output beschikbaar blijft.

Closes #163. Gerelateerd aan #158 (Radboud feedback).

## Stack trace die dit oplost

```
File "...dashboard.py", line 2409, in _yearly_trend
    sarima_sub = sarima_sub.sort_values("Weeknummer", key=_sort_weeks_series)
KeyError: 'Weeknummer'
```

De outer loop itereert over alle opleidingen uit `data_cumulative`. Voor opleidingen die uit de voorspelling zijn gefilterd, levert de aggregatie een lege DataFrame op — pandas drop op lege groupby-resultaten met mixed dtypes soms de groep-kolom, waarna `sort_values` crasht.

## Test plan

- [x] `uv run pytest` → 232 passed (incl. 2 nieuwe CLI-tests + 4 resilience-tests in `test_dashboard.py`)
- [x] Smoke zonder vlag: `uv run studentprognose --ci test 2 -d both -w 12 -y 2024` → exit 0, geen `visualisations*/`-map
- [ ] Reviewer: handmatige run zonder `--ci` met `--dashboard` op echte data → dashboards gegenereerd onder `data/output/visualisations/`


🤖 Generated with [Claude Code](https://claude.com/claude-code)