### PR TITLE
feat: maak cpu_count configureerbaar via runtime.cpu_count

### DIFF
--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -14,7 +14,7 @@ De pipeline laadt altijd eerst de **ingebakken standaardwaarden** uit het packag
 - Een ontbrekend veld in jouw bestand valt automatisch terug op de standaardwaarde.
 - Als het configuratiebestand helemaal niet bestaat, worden de standaardwaarden gebruikt en verschijnt er een waarschuwing.
 
-Het bestand heeft de volgende secties: `paths`, `model_config`, `numerus_fixus`, `excluded_data_points`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights` en `columns`.
+Het bestand heeft de volgende secties: `paths`, `runtime`, `model_config`, `numerus_fixus`, `excluded_data_points`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights` en `columns`.
 
 ## `paths` — bestandspaden
 
@@ -35,6 +35,28 @@ Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
 | `path_student_count_higher-years` | `data/input/student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars (DUO) |
 | `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (DUO) |
 | `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
+
+## `runtime` — uitvoerparameters
+
+Instellingen die bepalen hoe de pipeline zich gedraagt tijdens uitvoer (los van de modelkeuze).
+
+### `cpu_count`
+
+Standaard: `null`
+
+Het aantal CPU-cores dat de pipeline gebruikt voor parallelle voorspellingen. De voorspelling van individuele SARIMA-modellen wordt verdeeld over deze cores via `joblib.Parallel`.
+
+| Waarde | Gedrag |
+|--------|--------|
+| `null` | Automatisch — `os.cpu_count()` wordt gebruikt, of `1` als het besturingssysteem geen waarde teruggeeft (kan voorkomen in containers met cgroup-limieten). |
+| Geheel getal `>= 1` | Gebruikt deze waarde. Als de waarde hoger is dan het aantal beschikbare cores, wordt deze automatisch verlaagd naar dat aantal en verschijnt er een waarschuwing. |
+
+Pas dit aan als:
+
+- De pipeline crasht omdat `os.cpu_count()` geen betrouwbare waarde teruggeeft op jouw hardware of in jouw container (achtergrond van [issue #162](https://github.com/cedanl/studentprognose/issues/162)).
+- Je het CPU-gebruik wilt beperken op een gedeelde machine.
+
+Ongeldige waarden (`0`, negatieve getallen, niet-gehele getallen) leiden tot een configuratiefout en stoppen de pipeline direct.
 
 ## `model_config` — modelparameters
 

--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -84,30 +84,18 @@ def get_model_features(config: dict) -> dict:
 def get_cpu_count(config: dict) -> int:
     """Resolve the number of CPU cores to use for parallel work.
 
-    Reads ``runtime.cpu_count`` from the configuration:
+    Pure lookup with no side-effects. The value has already been validated
+    and capped (with a one-time warning) during :func:`_validate_runtime`
+    when the configuration was loaded.
 
-    - ``None`` (or missing): falls back to ``os.cpu_count()``, or ``1`` when
-      the OS does not report a count (e.g. some cgroup-constrained containers).
-    - Integer ``>= 1``: used as-is, capped to the number of cores the OS
-      reports — a higher request is reduced with a warning so the pipeline
-      does not crash on hardware with fewer cores than configured.
-
-    Invalid values are rejected during configuration loading via
-    :func:`_validate_runtime`, so this function trusts its input.
+    - ``runtime.cpu_count`` is ``None`` (or missing): returns ``os.cpu_count()``,
+      or ``1`` when the OS does not report a count (e.g. some
+      cgroup-constrained containers).
+    - Otherwise: returns the configured integer as-is.
     """
-    available = os.cpu_count() or 1
     requested = config.get("runtime", {}).get("cpu_count")
-
     if requested is None:
-        return available
-
-    if requested > available:
-        print(
-            f"Waarschuwing: 'runtime.cpu_count' ({requested}) is hoger dan het aantal "
-            f"beschikbare cores ({available}). Verlaagd naar {available}."
-        )
-        return available
-
+        return os.cpu_count() or 1
     return requested
 
 
@@ -221,3 +209,14 @@ def _validate_runtime(cfg, file_path):
             f"'runtime.cpu_count' is {cpu_count} — moet >= 1 zijn, of null voor automatische detectie."
         )
         sys.exit(1)
+
+    # Cap aan beschikbare cores. Eenmalig hier — geen herhaalde waarschuwing
+    # tijdens predict-loops over (jaar × week)-combinaties.
+    available = os.cpu_count() or 1
+    if cpu_count > available:
+        print(
+            f"Waarschuwing in {file_path}: "
+            f"'runtime.cpu_count' ({cpu_count}) is hoger dan het aantal beschikbare "
+            f"cores ({available}). Verlaagd naar {available}."
+        )
+        cfg["runtime"]["cpu_count"] = available

--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from importlib.resources import files
 from types import SimpleNamespace
@@ -61,6 +62,7 @@ def load_configuration(file_path: str) -> dict:
     if "excluded_data_points" in cfg:
         _validate_excluded_data_points(cfg["excluded_data_points"], file_path)
     _validate_model_config(cfg, file_path)
+    _validate_runtime(cfg, file_path)
     return cfg
 
 
@@ -77,6 +79,36 @@ def get_columns(config: dict) -> SimpleNamespace:
 def get_model_features(config: dict) -> dict:
     """Get model feature lists (numeric / categorical) from configuration."""
     return config.get("model_features", {})
+
+
+def get_cpu_count(config: dict) -> int:
+    """Resolve the number of CPU cores to use for parallel work.
+
+    Reads ``runtime.cpu_count`` from the configuration:
+
+    - ``None`` (or missing): falls back to ``os.cpu_count()``, or ``1`` when
+      the OS does not report a count (e.g. some cgroup-constrained containers).
+    - Integer ``>= 1``: used as-is, capped to the number of cores the OS
+      reports — a higher request is reduced with a warning so the pipeline
+      does not crash on hardware with fewer cores than configured.
+
+    Invalid values are rejected during configuration loading via
+    :func:`_validate_runtime`, so this function trusts its input.
+    """
+    available = os.cpu_count() or 1
+    requested = config.get("runtime", {}).get("cpu_count")
+
+    if requested is None:
+        return available
+
+    if requested > available:
+        print(
+            f"Waarschuwing: 'runtime.cpu_count' ({requested}) is hoger dan het aantal "
+            f"beschikbare cores ({available}). Verlaagd naar {available}."
+        )
+        return available
+
+    return requested
 
 
 def _validate_excluded_data_points(rules, file_path):
@@ -158,5 +190,34 @@ def _validate_model_config(cfg, file_path):
             f"Configuratiefout in {file_path}: "
             f"'model_config.individual_classifier' is '{clf_model}'. "
             f"Geldige opties: {sorted(_VALID_CLASSIFIER_MODELS)}."
+        )
+        sys.exit(1)
+
+
+def _validate_runtime(cfg, file_path):
+    runtime = cfg.get("runtime", {})
+    if not isinstance(runtime, dict):
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'runtime' moet een object zijn, niet {type(runtime).__name__}."
+        )
+        sys.exit(1)
+
+    cpu_count = runtime.get("cpu_count")
+    if cpu_count is None:
+        return
+
+    if isinstance(cpu_count, bool) or not isinstance(cpu_count, int):
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'runtime.cpu_count' moet een geheel getal zijn of null, "
+            f"niet {type(cpu_count).__name__}."
+        )
+        sys.exit(1)
+
+    if cpu_count < 1:
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'runtime.cpu_count' is {cpu_count} — moet >= 1 zijn, of null voor automatische detectie."
         )
         sys.exit(1)

--- a/src/studentprognose/configuration/configuration.json
+++ b/src/studentprognose/configuration/configuration.json
@@ -14,6 +14,9 @@
         "path_raw_telbestanden": "data/input_raw/telbestanden",
         "path_raw_individueel": "data/input_raw/individuele_aanmelddata.csv"
     },
+    "runtime": {
+        "cpu_count": null
+    },
     "model_config": {
         "status_mapping": {
             "Ingeschreven": 1,

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -154,7 +154,7 @@ def run_pipeline_from_dataframes(
             save_output=False,
         )
     """
-    from studentprognose.config import load_defaults
+    from studentprognose.config import load_defaults, _validate_runtime
 
     if week == FINAL_ACADEMIC_WEEK:
         raise ValueError(
@@ -164,6 +164,11 @@ def run_pipeline_from_dataframes(
 
     if configuration is None:
         configuration = load_defaults()
+
+    # Valideer runtime ook in de in-memory pad: gebruikers die een eigen
+    # configuration dict samenstellen (bv. via load_defaults() + handmatige
+    # aanpassing) krijgen dan dezelfde capping + waarschuwing als CLI-gebruikers.
+    _validate_runtime(configuration, "<in-memory configuration>")
 
     if filtering is None:
         filtering = load_defaults_filtering()

--- a/src/studentprognose/strategies/combined.py
+++ b/src/studentprognose/strategies/combined.py
@@ -1,8 +1,8 @@
 import numpy as np
 import joblib
-import os
 import math
 
+from studentprognose.config import get_cpu_count
 from studentprognose.strategies.base import PredictionStrategy
 from studentprognose.strategies.individual import IndividualStrategy
 from studentprognose.strategies.cumulative import CumulativeStrategy, _add_engineered_features
@@ -131,7 +131,7 @@ class CombinedStrategy(PredictionStrategy):
         if len(data_to_predict) == 0:
             return None
 
-        nr_CPU_cores = os.cpu_count()
+        nr_CPU_cores = get_cpu_count(self.configuration)
         chunk_size = math.ceil(len(data_to_predict) / nr_CPU_cores)
         chunks = [
             data_to_predict[i : i + chunk_size] for i in range(0, len(data_to_predict), chunk_size)

--- a/src/studentprognose/strategies/cumulative.py
+++ b/src/studentprognose/strategies/cumulative.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pandas as pd
 import joblib
-import os
 import math
 
 import warnings
 
+from studentprognose.config import get_cpu_count
 from studentprognose.strategies.base import PredictionStrategy
 from studentprognose.utils.weeks import increment_week, compute_pred_len
 from studentprognose.models import create_forecaster, create_regressor
@@ -218,7 +218,7 @@ class CumulativeStrategy(PredictionStrategy):
         if len(data_to_predict) == 0:
             return None
 
-        nr_CPU_cores = os.cpu_count()
+        nr_CPU_cores = get_cpu_count(self.configuration)
         chunk_size = math.ceil(len(data_to_predict) / nr_CPU_cores)
         chunks = [
             data_to_predict[i : i + chunk_size] for i in range(0, len(data_to_predict), chunk_size)

--- a/src/studentprognose/strategies/individual.py
+++ b/src/studentprognose/strategies/individual.py
@@ -2,10 +2,9 @@ import datetime
 import numpy as np
 import pandas as pd
 import joblib
-import os
 import math
 
-from studentprognose.config import get_columns
+from studentprognose.config import get_columns, get_cpu_count
 from studentprognose.strategies.base import PredictionStrategy
 from studentprognose.utils.weeks import get_weeks_list, get_all_weeks_valid, decrement_week, week_sort_key, compute_pred_len
 from studentprognose.data.transforms import transform_data
@@ -186,7 +185,7 @@ class IndividualStrategy(PredictionStrategy):
         if len(data_to_predict) == 0:
             return None
 
-        nr_CPU_cores = os.cpu_count()
+        nr_CPU_cores = get_cpu_count(self.configuration)
         chunk_size = math.ceil(len(data_to_predict) / nr_CPU_cores)
 
         chunks = [

--- a/tests/studentprognose/test_runtime_config.py
+++ b/tests/studentprognose/test_runtime_config.py
@@ -9,7 +9,7 @@ from studentprognose.config import get_cpu_count, load_configuration
 
 
 # ---------------------------------------------------------------------------
-# get_cpu_count — resolution
+# get_cpu_count — pure lookup (no side-effects)
 # ---------------------------------------------------------------------------
 
 class TestGetCpuCount:
@@ -26,6 +26,8 @@ class TestGetCpuCount:
             assert get_cpu_count({}) == 1
 
     def test_explicit_value_used_when_below_available(self):
+        # Note: bound checks happen in _validate_runtime — here we just verify
+        # that whatever sits in cfg is returned as-is.
         with patch("studentprognose.config.os.cpu_count", return_value=8):
             assert get_cpu_count({"runtime": {"cpu_count": 2}}) == 2
 
@@ -33,18 +35,25 @@ class TestGetCpuCount:
         with patch("studentprognose.config.os.cpu_count", return_value=4):
             assert get_cpu_count({"runtime": {"cpu_count": 4}}) == 4
 
-    def test_value_above_available_is_capped_with_warning(self, capsys):
+    def test_returns_cfg_value_verbatim_when_above_available(self):
+        # get_cpu_count itself does NOT cap. Capping is _validate_runtime's job.
+        # This test pins that contract so a future regression doesn't reintroduce
+        # the per-call warning.
         with patch("studentprognose.config.os.cpu_count", return_value=4):
-            result = get_cpu_count({"runtime": {"cpu_count": 16}})
-        assert result == 4
-        captured = capsys.readouterr()
-        assert "Waarschuwing" in captured.out
-        assert "16" in captured.out
-        assert "4" in captured.out
+            assert get_cpu_count({"runtime": {"cpu_count": 99}}) == 99
+
+    def test_no_side_effects_on_repeated_calls(self, capsys):
+        # Repeated calls must NOT print anything — proves there's no per-call
+        # warning regression even when cfg has a high value.
+        cfg = {"runtime": {"cpu_count": 99}}
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            for _ in range(20):
+                get_cpu_count(cfg)
+        assert capsys.readouterr().out == ""
 
 
 # ---------------------------------------------------------------------------
-# load_configuration — runtime validation
+# load_configuration — runtime validation + one-time cap
 # ---------------------------------------------------------------------------
 
 class TestLoadConfigurationRuntime:
@@ -59,7 +68,8 @@ class TestLoadConfigurationRuntime:
         cfg = {"runtime": {"cpu_count": 4}}
         f = tmp_path / "configuration.json"
         f.write_text(json.dumps(cfg))
-        result = load_configuration(str(f))
+        with patch("studentprognose.config.os.cpu_count", return_value=8):
+            result = load_configuration(str(f))
         assert result["runtime"]["cpu_count"] == 4
 
     def test_zero_cpu_count_exits(self, tmp_path):
@@ -103,3 +113,92 @@ class TestLoadConfigurationRuntime:
         with pytest.raises(SystemExit) as exc:
             load_configuration(str(f))
         assert exc.value.code == 1
+
+    def test_value_above_available_is_capped_with_one_time_warning(self, tmp_path, capsys):
+        # Capping happens during load_configuration, not during get_cpu_count.
+        # The warning is printed exactly once — directly tackling the bug
+        # that triggered this refactor.
+        cfg = {"runtime": {"cpu_count": 16}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            result = load_configuration(str(f))
+        assert result["runtime"]["cpu_count"] == 4
+        out = capsys.readouterr().out
+        assert out.count("Verlaagd naar") == 1, (
+            f"Verwacht exact één cap-waarschuwing, kreeg {out.count('Verlaagd naar')}.\n"
+            f"Output: {out!r}"
+        )
+        assert "16" in out
+        assert "4" in out
+
+    def test_capped_value_is_persisted_in_cfg(self, tmp_path, capsys):
+        # Once capped, subsequent get_cpu_count() calls must see the new value
+        # without re-warning — guarantees idempotency across the predict loop.
+        cfg = {"runtime": {"cpu_count": 99}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with patch("studentprognose.config.os.cpu_count", return_value=2):
+            result = load_configuration(str(f))
+            capsys.readouterr()  # leeg na load
+            for _ in range(10):
+                assert get_cpu_count(result) == 2
+        assert capsys.readouterr().out == "", "get_cpu_count mag na load niet meer waarschuwen"
+
+    def test_value_below_available_keeps_value_and_no_warning(self, tmp_path, capsys):
+        cfg = {"runtime": {"cpu_count": 2}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with patch("studentprognose.config.os.cpu_count", return_value=8):
+            result = load_configuration(str(f))
+        assert result["runtime"]["cpu_count"] == 2
+        assert "Verlaagd naar" not in capsys.readouterr().out
+
+    def test_value_equal_to_available_no_warning(self, tmp_path, capsys):
+        cfg = {"runtime": {"cpu_count": 4}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            result = load_configuration(str(f))
+        assert result["runtime"]["cpu_count"] == 4
+        assert "Verlaagd naar" not in capsys.readouterr().out
+
+    def test_os_returns_none_caps_to_one(self, tmp_path, capsys):
+        # Edge case: cgroup-constrained container where os.cpu_count() is None.
+        # Any positive request must cap to 1.
+        cfg = {"runtime": {"cpu_count": 8}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with patch("studentprognose.config.os.cpu_count", return_value=None):
+            result = load_configuration(str(f))
+        assert result["runtime"]["cpu_count"] == 1
+        assert "Verlaagd naar 1" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# In-memory pad: run_pipeline_from_dataframes valideert ook
+# ---------------------------------------------------------------------------
+
+class TestInMemoryConfigValidation:
+    """Verzeker dat het in-memory pad (run_pipeline_from_dataframes) dezelfde
+    capping toepast als de CLI. Anders zou een gebruiker die load_defaults()
+    gebruikt en handmatig cpu_count zet alsnog ongecapt door joblib gaan.
+
+    We mocken hier alleen het stuk waar de validatie wordt aangeroepen — niet
+    de hele pipeline — om snel en focused te blijven.
+    """
+
+    def test_validate_runtime_caps_in_memory_cfg(self, capsys):
+        from studentprognose.config import _validate_runtime, get_cpu_count
+
+        cfg = {"runtime": {"cpu_count": 99}}
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            _validate_runtime(cfg, "<in-memory configuration>")
+        assert cfg["runtime"]["cpu_count"] == 4
+        out = capsys.readouterr().out
+        assert "Verlaagd naar 4" in out
+        assert "<in-memory configuration>" in out
+        # Subsequent get_cpu_count returns capped value zonder side-effect
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            assert get_cpu_count(cfg) == 4
+        assert capsys.readouterr().out == ""

--- a/tests/studentprognose/test_runtime_config.py
+++ b/tests/studentprognose/test_runtime_config.py
@@ -1,0 +1,105 @@
+"""Tests for runtime configuration (cpu_count)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from studentprognose.config import get_cpu_count, load_configuration
+
+
+# ---------------------------------------------------------------------------
+# get_cpu_count — resolution
+# ---------------------------------------------------------------------------
+
+class TestGetCpuCount:
+    def test_none_falls_back_to_os_cpu_count(self):
+        with patch("studentprognose.config.os.cpu_count", return_value=8):
+            assert get_cpu_count({"runtime": {"cpu_count": None}}) == 8
+
+    def test_missing_runtime_falls_back_to_os_cpu_count(self):
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            assert get_cpu_count({}) == 4
+
+    def test_os_returns_none_falls_back_to_one(self):
+        with patch("studentprognose.config.os.cpu_count", return_value=None):
+            assert get_cpu_count({}) == 1
+
+    def test_explicit_value_used_when_below_available(self):
+        with patch("studentprognose.config.os.cpu_count", return_value=8):
+            assert get_cpu_count({"runtime": {"cpu_count": 2}}) == 2
+
+    def test_value_equal_to_available_is_used(self):
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            assert get_cpu_count({"runtime": {"cpu_count": 4}}) == 4
+
+    def test_value_above_available_is_capped_with_warning(self, capsys):
+        with patch("studentprognose.config.os.cpu_count", return_value=4):
+            result = get_cpu_count({"runtime": {"cpu_count": 16}})
+        assert result == 4
+        captured = capsys.readouterr()
+        assert "Waarschuwing" in captured.out
+        assert "16" in captured.out
+        assert "4" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# load_configuration — runtime validation
+# ---------------------------------------------------------------------------
+
+class TestLoadConfigurationRuntime:
+    def test_default_runtime_loads(self, tmp_path):
+        cfg = {"numerus_fixus": {}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        result = load_configuration(str(f))
+        assert result["runtime"]["cpu_count"] is None
+
+    def test_explicit_cpu_count_loads(self, tmp_path):
+        cfg = {"runtime": {"cpu_count": 4}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        result = load_configuration(str(f))
+        assert result["runtime"]["cpu_count"] == 4
+
+    def test_zero_cpu_count_exits(self, tmp_path):
+        cfg = {"runtime": {"cpu_count": 0}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_negative_cpu_count_exits(self, tmp_path):
+        cfg = {"runtime": {"cpu_count": -1}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_non_int_cpu_count_exits(self, tmp_path):
+        cfg = {"runtime": {"cpu_count": "vier"}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_bool_cpu_count_exits(self, tmp_path):
+        # bool is a subclass of int in Python — must be rejected explicitly,
+        # otherwise `True` would silently mean 1 core.
+        cfg = {"runtime": {"cpu_count": True}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_runtime_not_a_dict_exits(self, tmp_path):
+        cfg = {"runtime": "not-a-dict"}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1


### PR DESCRIPTION
Closes #162

## Summary
- Voegt `runtime.cpu_count` toe aan `configuration.json` (default `null` → `os.cpu_count()`)
- Vervangt directe `os.cpu_count()`-aanroepen in de drie strategieën door `get_cpu_count(config)`, met capping + waarschuwing bij te hoge waarde en validatie bij ongeldige input
- Documenteert het gedrag in `docs/configuratie.md` en dekt resolution + validatie af met unit tests

## Waarom
Op hardware/containers waar `os.cpu_count()` geen betrouwbare waarde teruggeeft (bv. cgroup-limieten) crashte de pipeline. Radboud-feedback. Gebruikers kunnen nu handmatig een veilige waarde zetten.

## Test plan
- [ ] `uv run pytest tests/studentprognose/test_runtime_config.py` slaagt (13 tests)
- [ ] Volledige testsuite `uv run pytest` blijft groen
- [ ] Smoke test `scripts/test_package.sh` exitcode 0
- [ ] Handmatig: zet `runtime.cpu_count` op een te hoge waarde → waarschuwing verschijnt, pipeline draait door
- [ ] Handmatig: zet op `0` → configuratiefout, exitcode 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)