### PR TITLE
docs: verwijder higher-years vermeldingen uit documentatie (#159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Zie de [documentatie](https://cedanl.github.io/studentprognose/aan-de-slag/#cli-
 | **cumulative** | Aantal aanmeldingen per opleiding, herkomst, jaar, week en herinschrijving. Wordt gebruikt voor de SARIMA_cumulative voorspelling. Verkregen via Studielink. |
 | **latest** | Per opleiding, herkomst, jaar en week: aanmeldingen, voorspellingen en foutwaarden (MAE/MAPE). |
 | **student_count_first-years** | Werkelijk aantal eerstejaars studenten per jaar, opleiding en herkomst. |
-| **student_count_higher-years** | Werkelijk aantal hogerjaars studenten per jaar, opleiding en herkomst (alleen nodig bij `-sy h`). |
 | **student_volume** | Werkelijk totaal aantal ingeschreven studenten per jaar, opleiding en herkomst (alleen nodig bij `-sy v`). |
 | **weighted_ensemble** | Gewichten per model voor de ensemble-voorspelling. |
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ Zie de [documentatie](https://cedanl.github.io/studentprognose/aan-de-slag/#cli-
 | Bestand | Beschrijving |
 |---------|-------------|
 | **individual** | Individuele (voor)aanmeldingen per student. Wordt gebruikt voor de SARIMA_individual voorspelling. |
-| **cumulative** | Aantal aanmeldingen per opleiding, herkomst, jaar, week en herinschrijving/hogerejaars. Wordt gebruikt voor de SARIMA_cumulative voorspelling. Verkregen via Studielink. |
-| **latest** | Per opleiding, herkomst, jaar en week: aanmeldingen, voorspellingen en foutwaarden (MAE/MAPE). Wordt gebruikt voor volume- en hogerjaarsvoorspellingen. |
+| **cumulative** | Aantal aanmeldingen per opleiding, herkomst, jaar, week en herinschrijving. Wordt gebruikt voor de SARIMA_cumulative voorspelling. Verkregen via Studielink. |
+| **latest** | Per opleiding, herkomst, jaar en week: aanmeldingen, voorspellingen en foutwaarden (MAE/MAPE). |
 | **student_count_first-years** | Werkelijk aantal eerstejaars studenten per jaar, opleiding en herkomst. |
-| **student_count_higher-years** | Werkelijk aantal hogerjaars studenten per jaar, opleiding en herkomst. |
-| **student_volume** | Werkelijk totaal aantal studenten (eerstejaars + hogerjaars) per jaar, opleiding en herkomst. |
+| **student_count_higher-years** | Werkelijk aantal hogerjaars studenten per jaar, opleiding en herkomst (alleen nodig bij `-sy h`). |
+| **student_volume** | Werkelijk totaal aantal ingeschreven studenten per jaar, opleiding en herkomst (alleen nodig bij `-sy v`). |
 | **weighted_ensemble** | Gewichten per model voor de ensemble-voorspelling. |
 
 ### Output
@@ -142,7 +142,7 @@ Zie de [documentatie](https://cedanl.github.io/studentprognose/aan-de-slag/#cli-
 |---------|-------------|
 | **output_prelim.xlsx** | Voorlopige output met alle voorspellingen van de huidige run. |
 | **output_first-years.xlsx** | Volledige output met voorspellingen voor eerstejaars studenten. |
-| **output_higher-years.xlsx** | Volledige output met voorspellingen voor hogerjaars studenten. |
+| **output_higher-years.xlsx** | Voorspellingen voor hogerjaars studenten (alleen bij `-sy h`). |
 | **output_volume.xlsx** | Volledige output met volume-voorspellingen (totaal). |
 
 ---

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Zie de [documentatie](https://cedanl.github.io/studentprognose/aan-de-slag/#cli-
 |---------|-------------|
 | **output_prelim.xlsx** | Voorlopige output met alle voorspellingen van de huidige run. |
 | **output_first-years.xlsx** | Volledige output met voorspellingen voor eerstejaars studenten. |
-| **output_higher-years.xlsx** | Voorspellingen voor hogerjaars studenten (alleen bij `-sy h`). |
 | **output_volume.xlsx** | Volledige output met volume-voorspellingen (totaal). |
 
 ---

--- a/doc/ActivityDiagram/activity_diagram_plantuml.txt
+++ b/doc/ActivityDiagram/activity_diagram_plantuml.txt
@@ -36,8 +36,6 @@ repeat
 
     #palegreen:Postprocessing;
 
-    #orchid:Predict nr of higher years students using XGBoost and ratio;
-
   repeat while (Forecast another week) is (yes) not (no)
 
 repeat while (Forecast another year) is (yes) not (no)

--- a/doc/ClassDiagram/class_diagram_plantuml.txt
+++ b/doc/ClassDiagram/class_diagram_plantuml.txt
@@ -72,13 +72,6 @@ class DataTotal {
   +save_output(student_year_prediction)
 }
 
-class HigherYears {
-  data_student_numbers_first_years
-  data_student_numbers_higher_years
-  data_student_numbers_volume
-  predict_nr_of_students(first_year_data, all_data, predict_year, predict_week, skip_years)
-}
-
 BothDatasets -down-> Individual
 BothDatasets -down-> Cumulative
 
@@ -91,7 +84,5 @@ AvailableData --> DataTotal
 Main ..> LoadData
 Main --> AvailableData
 Main ..> DataTotal
-
-Main --> HigherYears
 
 @enduml

--- a/doc/ClassDiagramSimple/class_diagram_simple_plantuml.txt
+++ b/doc/ClassDiagramSimple/class_diagram_simple_plantuml.txt
@@ -16,8 +16,6 @@ class LoadData << (P,orchid) >>
 
 class DataTotal
 
-class HigherYears
-
 BothDatasets -down-> Individual
 BothDatasets -down-> Cumulative
 
@@ -30,7 +28,5 @@ AvailableData --> DataTotal
 Main ..> LoadData
 Main --> AvailableData
 Main ..> DataTotal
-
-Main --> HigherYears
 
 @enduml

--- a/doc/PIPELINE.md
+++ b/doc/PIPELINE.md
@@ -13,7 +13,6 @@ Dit document beschrijft hoe ruwe Studielink-data en instellingsdata worden getra
 | `vooraanmeldingen_cumulatief.csv` | Gewogen/ongewogen vooraanmelders per opleiding, herkomst, week, jaar | Studielink telbestanden (extern) → ETL stap 1 + 2 | Bij `-d c` of `-d b` (default) |
 | `vooraanmeldingen_individueel.csv` | Een rij per student-aanmelding met persoonskenmerken | Osiris/Usis (intern) → ETL stap 4 | Bij `-d i` of `-d b` (default) |
 | `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Altijd |
-| `student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Alleen bij `-sy h` of `-sy v` |
 | `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Alleen bij `-sy v` |
 
 ### Optionele bestanden
@@ -73,7 +72,7 @@ flowchart TD
         VC["vooraanmeldingen_cumulatief.csv"]:::verplicht
         VI["vooraanmeldingen_individueel.csv"]:::verplicht
         SC["student_count_first-years.xlsx"]:::verplicht
-        SCH["student_count_higher-years.xlsx<br/>student_volume.xlsx<br/><i>alleen bij -sy h / -sy v</i>"]:::optioneel
+        SCV["student_volume.xlsx<br/><i>alleen bij -sy v</i>"]:::optioneel
     end
 
     %% ══════════════════════════════════════

--- a/doc/PIPELINE.md
+++ b/doc/PIPELINE.md
@@ -130,7 +130,7 @@ flowchart TD
     %% ══════════════════════════════════════
     S10A -.-> OUT_PRELIM
     OUT_PRELIM["<b>data/output/</b><br/><i>output_prelim_*.xlsx</i><br/>(tussenresultaat)"]:::output
-    OUT["<b>data/output/</b><br/><br/>output_first-years_*.xlsx<br/><i>output_higher-years_*.xlsx (bij -sy h)</i><br/><i>output_volume_*.xlsx (bij -sy v)</i>"]:::output
+    OUT["<b>data/output/</b><br/><br/>output_first-years_*.xlsx<br/><i>output_volume_*.xlsx (bij -sy v)</i>"]:::output
 
     %% ══════════════════════════════════════
     %% LAAG 6 — Post-processing (archive/)
@@ -241,7 +241,6 @@ Na een model-run kunnen de volgende scripts worden gedraaid om de input voor de 
 |---------|------|-------------|
 | `output_prelim_*.xlsx` | Tussenresultaat (stap 12) | Voorlopige voorspellingen, vóór ratio/ensemble/foutmaten |
 | `output_first-years_*.xlsx` | Eindresultaat (stap 15) | Eerstejaars voorspellingen |
-| `output_higher-years_*.xlsx` | Eindresultaat (stap 15) | Hogerjaars voorspellingen (alleen bij `-sy h`) |
 | `output_volume_*.xlsx` | Eindresultaat (stap 15) | Volume-voorspellingen (alleen bij `-sy v`) |
 
 ### Kolommen in output

--- a/doc/PIPELINE.md
+++ b/doc/PIPELINE.md
@@ -13,8 +13,8 @@ Dit document beschrijft hoe ruwe Studielink-data en instellingsdata worden getra
 | `vooraanmeldingen_cumulatief.csv` | Gewogen/ongewogen vooraanmelders per opleiding, herkomst, week, jaar | Studielink telbestanden (extern) → ETL stap 1 + 2 | Bij `-d c` of `-d b` (default) |
 | `vooraanmeldingen_individueel.csv` | Een rij per student-aanmelding met persoonskenmerken | Osiris/Usis (intern) → ETL stap 4 | Bij `-d i` of `-d b` (default) |
 | `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Altijd |
-| `student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Altijd |
-| `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Altijd |
+| `student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Alleen bij `-sy h` of `-sy v` |
+| `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Alleen bij `-sy v` |
 
 ### Optionele bestanden
 
@@ -72,7 +72,8 @@ flowchart TD
         direction LR
         VC["vooraanmeldingen_cumulatief.csv"]:::verplicht
         VI["vooraanmeldingen_individueel.csv"]:::verplicht
-        SC["student_count_first-years.xlsx<br/>student_count_higher-years.xlsx<br/>student_volume.xlsx"]:::verplicht
+        SC["student_count_first-years.xlsx"]:::verplicht
+        SCH["student_count_higher-years.xlsx<br/>student_volume.xlsx<br/><i>alleen bij -sy h / -sy v</i>"]:::optioneel
     end
 
     %% ══════════════════════════════════════
@@ -130,7 +131,7 @@ flowchart TD
     %% ══════════════════════════════════════
     S10A -.-> OUT_PRELIM
     OUT_PRELIM["<b>data/output/</b><br/><i>output_prelim_*.xlsx</i><br/>(tussenresultaat)"]:::output
-    OUT["<b>data/output/</b><br/><br/>output_first-years_*.xlsx<br/>output_higher-years_*.xlsx<br/>output_volume_*.xlsx"]:::output
+    OUT["<b>data/output/</b><br/><br/>output_first-years_*.xlsx<br/><i>output_higher-years_*.xlsx (bij -sy h)</i><br/><i>output_volume_*.xlsx (bij -sy v)</i>"]:::output
 
     %% ══════════════════════════════════════
     %% LAAG 6 — Post-processing (archive/)
@@ -241,8 +242,8 @@ Na een model-run kunnen de volgende scripts worden gedraaid om de input voor de 
 |---------|------|-------------|
 | `output_prelim_*.xlsx` | Tussenresultaat (stap 12) | Voorlopige voorspellingen, vóór ratio/ensemble/foutmaten |
 | `output_first-years_*.xlsx` | Eindresultaat (stap 15) | Eerstejaars voorspellingen |
-| `output_higher-years_*.xlsx` | Eindresultaat (stap 15) | Hogerjaars voorspellingen |
-| `output_volume_*.xlsx` | Eindresultaat (stap 15) | Volume-voorspellingen (totaal) |
+| `output_higher-years_*.xlsx` | Eindresultaat (stap 15) | Hogerjaars voorspellingen (alleen bij `-sy h`) |
+| `output_volume_*.xlsx` | Eindresultaat (stap 15) | Volume-voorspellingen (alleen bij `-sy v`) |
 
 ### Kolommen in output
 

--- a/doc/SequenceDiagram/sequence_diagram_plantuml.txt
+++ b/doc/SequenceDiagram/sequence_diagram_plantuml.txt
@@ -36,13 +36,6 @@ loop for specified years and weeks
   end
 
   Main -> DataTotal: postprocess(postprocess_subset, year, week)
-
-  alt predict higher years or volume
-    Main -> HigherYears: predict_nr_of_students(data, data_latest, year, week)
-    activate HigherYears
-    HigherYears --> Main: data
-    deactivate HigherYears
-  end
 end
 
 Main -> DataTotal: save_output()

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -71,13 +71,12 @@ Bestaat een bestand al, dan wordt het overgeslagen. Je kunt `init` dus veilig op
 
 Zet je inputbestanden in de juiste mappen voordat je de pipeline start:
 
-``` { .text hl_lines="8" }
+```text
 data/
 ├── input/                          ← verwerkte inputbestanden (na ETL)
 │   ├── vooraanmeldingen_cumulatief.csv
 │   ├── vooraanmeldingen_individueel.csv
 │   ├── student_count_first-years.xlsx
-│   ├── student_count_higher-years.xlsx
 │   └── student_volume.xlsx
 └── input_raw/                      ← ruwe bronbestanden (NIET nodig met --noetl)
     ├── telbestanden/               ← Studielink telbestanden
@@ -183,6 +182,9 @@ studentprognose --help
 | `--ci test N` | getal | — | Testmodus: beperkt tot N opleidingen |
 
 Weekbereiken zijn mogelijk: `-w 8:12` is gelijk aan `-w 8 9 10 11 12`.
+
+!!! note "Eerstejaars als focus"
+    De tool draait standaard op `-sy f` (eerstejaars). De modi `-sy h` (hogerejaars) en `-sy v` (volume) zijn vervolgstappen — gebruik die pas als je eerstejaarsvoorspelling op orde is.
 
 ## Gebruik als Python-package
 

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -172,7 +172,7 @@ studentprognose --help
 | `-w` | weeknummer(s) | laatste week in data | Voorspelweek(en), bijv. `-w 10` of `-w 8:12` |
 | `-y` | jaar(en) | laatste jaar in data | Voorspeljaar(en), bijv. `-y 2025` of `-y 2024 2025` |
 | `-d` | `b` / `c` / `i` | `b` | Dataset: `both`, `cumulative`, `individual` |
-| `-sy` | `f` / `h` / `v` | `f` | Studentjaar: `first-years`, `higher-years`, `volume` |
+| `-sy` | `f` / `v` | `f` | Studentjaar: `first-years` (standaard), `volume` |
 | `-c` | pad | `configuration/configuration.json` | Configuratiebestand |
 | `-f` | pad | `configuration/filtering/base.json` | Filterbestand |
 | `-sk` | getal | `0` | Skip N jaren (backtesting) |
@@ -184,7 +184,7 @@ studentprognose --help
 Weekbereiken zijn mogelijk: `-w 8:12` is gelijk aan `-w 8 9 10 11 12`.
 
 !!! note "Eerstejaars als focus"
-    De tool draait standaard op `-sy f` (eerstejaars). De modi `-sy h` (hogerejaars) en `-sy v` (volume) zijn vervolgstappen — gebruik die pas als je eerstejaarsvoorspelling op orde is.
+    De tool draait standaard op `-sy f` (eerstejaars). De modus `-sy v` (volume) is een vervolgstap — gebruik die pas als je eerstejaarsvoorspelling op orde is.
 
 ## Gebruik als Python-package
 
@@ -201,7 +201,7 @@ from studentprognose import (
     run_pipeline_from_dataframes,  # pipeline met DataFrames in-memory
     PipelineConfig,                # configuratie-dataclass voor de pipeline
     DataOption,                    # enum: INDIVIDUAL / CUMULATIVE / BOTH_DATASETS
-    StudentYearPrediction,         # enum: FIRST_YEARS / HIGHER_YEARS / VOLUME
+    StudentYearPrediction,         # enum: FIRST_YEARS / VOLUME
 )
 ```
 

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -32,7 +32,6 @@ Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
 | `path_raw_telbestanden` | `data/input_raw/telbestanden` | Map met Studielink telbestanden |
 | `path_raw_individueel` | `data/input_raw/individuele_aanmelddata.csv` | Ruwe individuele aanmelddata |
 | `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (DUO) |
-| `path_student_count_higher-years` | `data/input/student_count_higher-years.xlsx` | Werkelijk aantal hogerjaars (DUO) |
 | `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (DUO) |
 | `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
 
@@ -213,7 +212,7 @@ Maakt het mogelijk dat instellingen andere kolomnamen gebruiken dan de kanonieke
 
 Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
 
-`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `Is hogerejaars`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
+`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
 
 ### `oktober` — DUO oktober-bestand
 
@@ -221,7 +220,7 @@ Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
 
 ### `cumulative` — Studielink cumulatieve data
 
-`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Hogerejaars`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
+`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
 
 ## `validation` — validatiedrempels overschrijven
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -25,7 +25,6 @@ Scheidingsteken: `;`
 | `Aantal` | int | Aantal vooraanmelders |
 | `meercode_V` | int | Weegfactor; mag niet 0 zijn (leidt tot deling door nul in ETL) |
 | `Herinschrijving` | str | `J` of `N` |
-| `Hogerejaars` | str | `J` of `N` |
 | `Herkomst` | str | `N` (Nederland), `E` (EER), `R` (rest) |
 
 ### Individuele aanmelddata

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -97,8 +97,8 @@ Dit zijn de bestanden die het model direct inleest. Ze worden aangemaakt door de
 | `vooraanmeldingen_cumulatief.csv` | `-d c` of `-d b` | ETL stap 1+2 |
 | `vooraanmeldingen_individueel.csv` | `-d i` of `-d b` | ETL stap 4 |
 | `student_count_first-years.xlsx` | Altijd | ETL stap 3 |
-| `student_count_higher-years.xlsx` | Altijd | ETL stap 3 |
-| `student_volume.xlsx` | Altijd | ETL stap 3 |
+| `student_count_higher-years.xlsx` | Alleen bij `-sy h` of `-sy v` | ETL stap 3 |
+| `student_volume.xlsx` | Alleen bij `-sy v` | ETL stap 3 |
 | `ensemble_weights.xlsx` | Optioneel | `archive/calculate_ensemble_weights.py` |
 | `totaal_cumulatief.xlsx` | Optioneel | `archive/append_studentcount_and_compute_errors.py` |
 | `totaal_individueel.xlsx` | Optioneel | `archive/append_studentcount_and_compute_errors.py` |

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -97,7 +97,6 @@ Dit zijn de bestanden die het model direct inleest. Ze worden aangemaakt door de
 | `vooraanmeldingen_cumulatief.csv` | `-d c` of `-d b` | ETL stap 1+2 |
 | `vooraanmeldingen_individueel.csv` | `-d i` of `-d b` | ETL stap 4 |
 | `student_count_first-years.xlsx` | Altijd | ETL stap 3 |
-| `student_count_higher-years.xlsx` | Alleen bij `-sy h` of `-sy v` | ETL stap 3 |
 | `student_volume.xlsx` | Alleen bij `-sy v` | ETL stap 3 |
 | `ensemble_weights.xlsx` | Optioneel | `archive/calculate_ensemble_weights.py` |
 | `totaal_cumulatief.xlsx` | Optioneel | `archive/append_studentcount_and_compute_errors.py` |

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -8,8 +8,8 @@ De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvo
 |---------|------|-------------|
 | `output_prelim_{modus}.xlsx` | Tussenresultaat | Voorlopige voorspellingen vóór ratio-model, ensemble en foutmaten. Nuttig voor debugging. |
 | `output_first-years_{modus}.xlsx` | Eindresultaat | Eerstejaars voorspellingen per opleiding/herkomst/week |
-| `output_higher-years_{modus}.xlsx` | Eindresultaat | Hogerjaars voorspellingen |
-| `output_volume_{modus}.xlsx` | Eindresultaat | Totaal studentvolume-voorspellingen |
+| `output_higher-years_{modus}.xlsx` | Eindresultaat | Hogerjaars voorspellingen (alleen bij `-sy h`) |
+| `output_volume_{modus}.xlsx` | Eindresultaat | Totaal studentvolume-voorspellingen (alleen bij `-sy v`) |
 
 `{modus}` is `cumulatief`, `individueel` of `beide`, afhankelijk van de gebruikte `-d` vlag.
 

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -8,7 +8,6 @@ De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvo
 |---------|------|-------------|
 | `output_prelim_{modus}.xlsx` | Tussenresultaat | Voorlopige voorspellingen vóór ratio-model, ensemble en foutmaten. Nuttig voor debugging. |
 | `output_first-years_{modus}.xlsx` | Eindresultaat | Eerstejaars voorspellingen per opleiding/herkomst/week |
-| `output_higher-years_{modus}.xlsx` | Eindresultaat | Hogerjaars voorspellingen (alleen bij `-sy h`) |
 | `output_volume_{modus}.xlsx` | Eindresultaat | Totaal studentvolume-voorspellingen (alleen bij `-sy v`) |
 
 `{modus}` is `cumulatief`, `individueel` of `beide`, afhankelijk van de gebruikte `-d` vlag.

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -43,12 +43,11 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 |----------|------|-------------------|
 | Map bestaat | Hard error | `data/input_raw/telbestanden/` moet bestaan |
 | Bestanden aanwezig | Hard error | Minimaal één bestand met patroon `telbestandY{jaar}W{week}.csv` |
-| Verplichte kolommen | Hard error | `Studiejaar`, `Isatcode`, `Groepeernaam`, `Aantal`, `meercode_V`, `Herinschrijving`, `Hogerejaars`, `Herkomst` |
+| Verplichte kolommen | Hard error | `Studiejaar`, `Isatcode`, `Groepeernaam`, `Aantal`, `meercode_V`, `Herinschrijving`, `Herkomst` |
 | Weeknummer in bestandsnaam | Hard error | Weeknummer moet tussen 1 en 53 liggen |
 | Collegejaar bereik | Soft error | `Studiejaar` buiten `[huidig jaar − 15, huidig jaar + 2]` |
 | Herkomst geldige waarden | Soft error | Elke waarde in `Herkomst` moet `N`, `E` of `R` zijn |
 | Herinschrijving geldige waarden | Soft error | Elke waarde moet `J` of `N` zijn |
-| Hogerejaars geldige waarden | Soft error | Elke waarde moet `J` of `N` zijn |
 | meercode_V = 0 | Soft error | Leidt tot deling door nul in ETL |
 | Aantal < 0 | Soft error | Negatieve aantallen zijn inhoudelijk onjuist |
 | Ontbrekende waarden `Aantal` | Waarschuwing / Soft error | > 5% ontbrekend → waarschuwing; > 30% → soft error |


### PR DESCRIPTION
## Summary

Sluit #159. Volledige sweep door alle markdown-documentatie om `higher-years` / `hogerejaars` / `HIGHER_YEARS` te verwijderen — radboud feedback wees op verstorende vermeldingen die de eerstejaars-focus onderbraken.

- **Verstorende proza weggehaald** uit `docs/`, `README.md`, `doc/PIPELINE.md` en UML-bronnen
- **Stale input/output documentatie** geschrapt (`student_count_higher-years.xlsx`, `output_higher-years_*.xlsx`)
- **Technische referentietabellen** opgeschoond — `Hogerejaars` / `Is hogerejaars` uit kolomlijsten in `configuratie.md`, `validatie.md`, `je-data-voorbereiden.md`
- **CLI-flag tabel** in `aan-de-slag.md`: `-sy` toont nu alleen `f`/`v`

Code blijft het hogerejaars-spoor ondersteunen (`-sy h` CLI-vlag, `HIGHER_YEARS` enum, validatie van `Hogerejaars`-kolom) — bewuste keuze om docs simpel te houden rond de eerstejaars-focus.

Verificatie: `grep -ri "higher-years\|hogerejaars\|higher_years\|HIGHER_YEARS" --include="*.md"` geeft 0 hits.

## Test plan

- [x] MkDocs build succesvol (`uv run mkdocs serve`) — geen nieuwe warnings, 3 anchor-warnings zijn pre-existing op main
- [x] Alle CLI-vlaggen gerookt (`-d`, `-sy`, `-w`, `-y`, `-c`, `-f`, `--noetl`, `--yes`, `--dashboard`, `--ci test`)
- [x] `-sy h` faalt netjes met duidelijke foutmelding (vereist eerst first-years run) — code-pad werkt zoals afgesproken
- [x] Geen code aangeraakt — alleen `.md` en PlantUML-bronnen

## Known stale (out-of-scope)

- `doc/ClassDiagram/class_diagram.{svg,png}` tonen nog `HigherYears`-klasse. PlantUML-source is al schoon (commit 2a40c93d); regeneratie vereist plantuml binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)