### PR TITLE
fix: API-correctheid voor cloud-gebruik (save_output, public exports, fail-fast)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -195,6 +195,7 @@ Naast de CLI kun je `studentprognose` ook direct vanuit Python-scripts importere
 ```python
 from studentprognose import (
     load_configuration,            # laad configuration.json (of package defaults)
+    load_defaults,                 # laad package-defaults voor configuration
     load_filtering,                # laad filtering JSON (of package defaults)
     load_data,                     # laad data vanaf schijf als DataFrames
     run_pipeline_cli,              # volledige CLI-pipeline (accepteert argv-lijst)
@@ -232,24 +233,35 @@ from studentprognose import run_pipeline_from_dataframes, DataOption
 
 # Of lokaal voor testen
 df_cum = pd.read_csv("vooraanmeldingen_cumulatief.csv", sep=";", skiprows=[1])
+df_sc = pd.read_excel("student_count_first-years.xlsx")
 
 result = run_pipeline_from_dataframes(
     year=2025,
     week=10,
     data_cumulative=df_cum,
+    data_student_numbers=df_sc,
     dataset=DataOption.CUMULATIVE,
     save_output=False,  # geen lokale uitvoerbestanden aanmaken
 )
 
 if result is not None:
-    print(result[["Croho groepeernaam", "Weighted_ensemble_prediction"]].head())
+    print(
+        result[
+            ["Croho groepeernaam", "Herkomst", "SARIMA_cumulative", "Prognose_ratio"]
+        ].head()
+    )
 ```
+
+!!! note "Welke voorspellingskolom?"
+    De beschikbare kolommen hangen af van `dataset`. Voor `DataOption.CUMULATIVE`
+    krijg je `SARIMA_cumulative`, `Prognose_ratio` en `Baseline`. Voor
+    `DataOption.BOTH_DATASETS` komt daar `Weighted_ensemble_prediction` bij —
+    de ensemble-combinatie van het cumulatieve en individuele spoor.
 
 De functie accepteert ook een eigen configuratiedict, zodat je geen bestandssysteem nodig hebt:
 
 ```python
-from studentprognose import run_pipeline_from_dataframes, DataOption
-from studentprognose.config import load_defaults
+from studentprognose import run_pipeline_from_dataframes, DataOption, load_defaults
 
 # Begin met package-defaults en pas aan
 config = load_defaults()
@@ -259,6 +271,7 @@ result = run_pipeline_from_dataframes(
     year=2025,
     week=10,
     data_cumulative=df_cum,
+    data_student_numbers=df_sc,
     configuration=config,
     dataset=DataOption.CUMULATIVE,
 )

--- a/src/studentprognose/__init__.py
+++ b/src/studentprognose/__init__.py
@@ -1,4 +1,9 @@
-from studentprognose.config import load_configuration, load_defaults_filtering, load_filtering
+from studentprognose.config import (
+    load_configuration,
+    load_defaults,
+    load_defaults_filtering,
+    load_filtering,
+)
 from studentprognose.data.loader import load_data
 from studentprognose.main import run_pipeline_cli, run_pipeline_from_dataframes
 from studentprognose.cli import PipelineConfig
@@ -6,6 +11,7 @@ from studentprognose.utils.weeks import DataOption, StudentYearPrediction
 
 __all__ = [
     "load_configuration",
+    "load_defaults",
     "load_filtering",
     "load_defaults_filtering",
     "load_data",

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -163,6 +163,29 @@ def run_pipeline_from_dataframes(
             f"Kies een eerdere week, bijvoorbeeld week {FINAL_ACADEMIC_WEEK - 1}."
         )
 
+    if dataset in (DataOption.CUMULATIVE, DataOption.BOTH_DATASETS) and data_cumulative is None:
+        raise ValueError(
+            f"dataset={dataset.name} vereist data_cumulative, maar dat is None. "
+            "Geef een cumulatief vooraanmeld-DataFrame mee."
+        )
+
+    if dataset in (DataOption.INDIVIDUAL, DataOption.BOTH_DATASETS) and data_individual is None:
+        raise ValueError(
+            f"dataset={dataset.name} vereist data_individual, maar dat is None. "
+            "Geef een individueel aanmeld-DataFrame mee."
+        )
+
+    if (
+        student_year_prediction == StudentYearPrediction.FIRST_YEARS
+        and data_student_numbers is None
+    ):
+        raise ValueError(
+            "data_student_numbers is None, maar SARIMA en de ratio-modellen hebben "
+            "historische realisatie (eerstejaars per opleiding × jaar) nodig om te trainen. "
+            "Geef een DataFrame mee met kolommen "
+            "['Croho groepeernaam', 'Collegejaar', 'Herkomst', 'Examentype', 'Aantal_studenten']."
+        )
+
     if configuration is None:
         configuration = load_defaults()
 
@@ -203,6 +226,7 @@ def _run_pipeline_core(cfg, datasets, configuration, filtering, cwd, save_output
     """
     # Step 2: Initialize strategy (Individual / Cumulative / Combined)
     strategy = create_strategy(cfg, datasets, configuration, cwd)
+    strategy.postprocessor.save_outputs_to_disk = save_output
 
     if save_output:
         PostProcessor.check_output_writable(

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -60,6 +60,7 @@ class PostProcessor:
         self.data_option = data_option
         self.ci_test_n = ci_test_n
         self.data = None
+        self.save_outputs_to_disk = True
 
     def add_predicted_preregistrations(self, data, predicted_preregistrations):
         dict = {
@@ -197,9 +198,12 @@ class PostProcessor:
                 how="left",
             )
 
-        ci_suffix = f"_ci_test_N{self.ci_test_n}" if self.ci_test_n is not None else ""
-        output_path = os.path.join(self.CWD, "data", "output", f"output_prelim_{self.data_option.filename_suffix}{ci_suffix}.xlsx")
-        self.data.to_excel(output_path, index=False)
+        if self.save_outputs_to_disk:
+            ci_suffix = f"_ci_test_N{self.ci_test_n}" if self.ci_test_n is not None else ""
+            output_dir = os.path.join(self.CWD, "data", "output")
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(output_dir, f"output_prelim_{self.data_option.filename_suffix}{ci_suffix}.xlsx")
+            self.data.to_excel(output_path, index=False)
 
     def predict_with_ratio(self, data_cumulative, predict_year):
         self.data = _predict_with_ratio(


### PR DESCRIPTION
## Summary

Vervolg op review-cluster rond #170/#171 (Tomeriko). Vier samenhangende fixes zodat `run_pipeline_from_dataframes` betrouwbaar werkt in cloud-omgevingen zonder lokale schrijfrechten en met duidelijke foutmeldingen.

### Wat verandert

1. **`save_output=False` onderdrukt nu álle disk-writes.**
   `PostProcessor.prepare_data_for_output_prelim` schreef `output_prelim_*.xlsx` onvoorwaardelijk — ook bij `save_output=False`, wat #171 dwong tot een `tempfile.TemporaryDirectory`-workaround. Bewaakt nu via `self.save_outputs_to_disk`, geplumbd vanuit `_run_pipeline_core`.

2. **`load_defaults` toegevoegd aan `studentprognose.__all__`.**
   Werd in `docs/aan-de-slag.md` als publiek voorbeeld getoond (`from studentprognose.config import load_defaults`) maar zat alleen op een deep-path. Nu top-level importeerbaar.

3. **Docs-voorbeeld Cloud-gebruik gecorrigeerd.**
   Het voorbeeld toonde `Weighted_ensemble_prediction` (alleen aanwezig bij `BOTH_DATASETS`) voor een `CUMULATIVE`-run. Vervangen door `SARIMA_cumulative` + `Prognose_ratio`, met admonition die de kolomkeuze per dataset uitlegt.

4. **Fail-fast bij ontbrekende verplichte data.**
   `run_pipeline_from_dataframes` raiset nu `ValueError` met duidelijke uitleg bij ontbrekende `data_cumulative` / `data_individual` / `data_student_numbers`, in plaats van een `TypeError: 'float' object is not subscriptable` diep in SARIMA.

### Follow-up voor #171

Na merge kan de `tempfile.TemporaryDirectory`-workaround uit `notebooks/implementatie.ipynb` verwijderd worden — niet onderdeel van deze PR om #171 niet op te houden.

## Test plan

- [x] `uv run pytest tests/studentprognose/` — 254 passed
- [x] `bash scripts/test_package.sh` — alle 7 smoke-stappen OK
- [x] Handmatig: `run_pipeline_from_dataframes(save_output=False)` buiten projectroot maakt geen `data/output/` meer aan
- [x] Handmatig: ontbrekende `data_student_numbers` geeft heldere `ValueError` i.p.v. `TypeError`
- [ ] Reviewer: check dat geen bestaande call site impliciet op de oude unconditional write leunde

🤖 Generated with [Claude Code](https://claude.com/claude-code)