### PR TITLE
docs: hernoem 'oktoberbestand' naar 'telbestand studenten' (#160)

### DIFF
--- a/data/input_raw/README.md
+++ b/data/input_raw/README.md
@@ -9,7 +9,7 @@ De meegeleverde bestanden bevatten **synthetische demodata**.
 | Bestand | Bron | Beschrijving |
 |---------|------|-------------|
 | `telbestanden/telbestandY{jaar}W{week}.csv` | Studielink | Wekelijkse telbestanden met cumulatieve vooraanmeldingen per opleiding |
-| `oktober_bestand.xlsx` | DUO (1-cijfer HO) | Werkelijke inschrijvingen na 1 oktober (ground truth) |
+| `oktober_bestand.xlsx` | Eigen levering instelling, **in DUO 1cijferHO-formaat** (1cijferHO-vergelijkbaar bestand) | Werkelijke inschrijvingen na 1 oktober (ground truth) |
 | `individuele_aanmelddata.csv` | SIS / datawarehouse instelling | Per-student aanmeldingen met persoonskenmerken |
 
 ## Dataflow
@@ -17,6 +17,7 @@ De meegeleverde bestanden bevatten **synthetische demodata**.
 ```
 telbestanden/*.csv          ──► rowbind + reformat ──► interpolate ──► data/input/vooraanmeldingen_cumulatief.csv
 oktober_bestand.xlsx        ──► calculate_student_count ────────────► data/input/student_count_*.xlsx
+   (1cijferHO-vergelijkbaar bestand)
 individuele_aanmelddata.csv ──► copy ──────────────────────────────► data/input/vooraanmeldingen_individueel.csv
 ```
 

--- a/data/input_raw/README.md
+++ b/data/input_raw/README.md
@@ -9,7 +9,7 @@ De meegeleverde bestanden bevatten **synthetische demodata**.
 | Bestand | Bron | Beschrijving |
 |---------|------|-------------|
 | `telbestanden/telbestandY{jaar}W{week}.csv` | Studielink | Wekelijkse telbestanden met cumulatieve vooraanmeldingen per opleiding |
-| `oktober_bestand.xlsx` | Eigen levering instelling, **in DUO 1cijferHO-formaat** (1cijferHO-vergelijkbaar bestand) | Werkelijke inschrijvingen na 1 oktober (ground truth) |
+| `oktober_bestand.xlsx` | Eigen levering instelling (telbestand studenten) | Werkelijke inschrijvingen per opleiding/herkomst/jaar (ground truth) |
 | `individuele_aanmelddata.csv` | SIS / datawarehouse instelling | Per-student aanmeldingen met persoonskenmerken |
 
 ## Dataflow
@@ -17,7 +17,7 @@ De meegeleverde bestanden bevatten **synthetische demodata**.
 ```
 telbestanden/*.csv          ──► rowbind + reformat ──► interpolate ──► data/input/vooraanmeldingen_cumulatief.csv
 oktober_bestand.xlsx        ──► calculate_student_count ────────────► data/input/student_count_*.xlsx
-   (1cijferHO-vergelijkbaar bestand)
+   (telbestand studenten)
 individuele_aanmelddata.csv ──► copy ──────────────────────────────► data/input/vooraanmeldingen_individueel.csv
 ```
 

--- a/doc/PIPELINE.md
+++ b/doc/PIPELINE.md
@@ -12,8 +12,8 @@ Dit document beschrijft hoe ruwe Studielink-data en instellingsdata worden getra
 |---------|-------------|------|---------------|
 | `vooraanmeldingen_cumulatief.csv` | Gewogen/ongewogen vooraanmelders per opleiding, herkomst, week, jaar | Studielink telbestanden (extern) → ETL stap 1 + 2 | Bij `-d c` of `-d b` (default) |
 | `vooraanmeldingen_individueel.csv` | Een rij per student-aanmelding met persoonskenmerken | Osiris/Usis (intern) → ETL stap 4 | Bij `-d i` of `-d b` (default) |
-| `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Altijd |
-| `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | DUO oktober-bestand 1-cijfer HO (extern) → ETL stap 3 | Alleen bij `-sy v` |
+| `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | 1cijferHO-vergelijkbaar bestand (DUO 1cijferHO-formaat, eigen levering instelling) → ETL stap 3 | Altijd |
+| `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | 1cijferHO-vergelijkbaar bestand (DUO 1cijferHO-formaat, eigen levering instelling) → ETL stap 3 | Alleen bij `-sy v` |
 
 ### Optionele bestanden
 
@@ -46,9 +46,9 @@ flowchart TD
         direction LR
         subgraph bronnen_extern ["Externe bronnen"]
             SL["Studielink Telbestanden<br/><i>telbestandY2024WXX.csv</i><br/><b>Bron: Studielink</b>"]:::bron
-            OKT["Oktober-bestand<br/><i>1-cijfer HO</i><br/><b>Bron: DUO</b>"]:::bron
         end
-        subgraph bronnen_intern ["Interne bronnen"]
+        subgraph bronnen_intern ["Interne bronnen (instelling levert zelf)"]
+            OKT["1cijferHO-vergelijkbaar bestand<br/><i>oktober_bestand.xlsx</i><br/><b>Formaat: DUO 1cijferHO</b>"]:::bron
             SIS["Individuele aanmelddata<br/><i>per student-aanmelding</i><br/><b>Bron: Osiris / Usis</b>"]:::bron
         end
     end
@@ -60,7 +60,7 @@ flowchart TD
         direction LR
         S1["Rowbind + reformat<br/><i>samenvoegen telbestanden</i>"]:::script
         S2["Interpolate<br/><i>ontbrekende weken</i>"]:::script
-        S3["Calculate student count<br/><i>oktober → aantallen</i>"]:::script
+        S3["Calculate student count<br/><i>1cijferHO-vergelijkbaar → aantallen</i>"]:::script
         S4["Copy bestanden<br/><i>individueel</i>"]:::script
     end
 
@@ -183,7 +183,7 @@ Het ETL-script draait standaard en transformeert ruwe data in `data/input_raw/` 
 |------|-------|-------|--------|
 | 1 | Rowbind + reformat | `data/input_raw/telbestanden/*.csv` | Samengevoegd CSV |
 | 2 | Interpolatie | Samengevoegd CSV | `vooraanmeldingen_cumulatief.csv` |
-| 3 | Studentaantallen | Oktober-bestand (1-cijfer HO) | `student_count_*.xlsx`, `student_volume.xlsx` |
+| 3 | Studentaantallen | 1cijferHO-vergelijkbaar bestand (`oktober_bestand.xlsx`) | `student_count_*.xlsx`, `student_volume.xlsx` |
 | 4 | Kopieren | Individuele data | `vooraanmeldingen_individueel.csv` |
 
 ---
@@ -217,8 +217,8 @@ Studielink levert wekelijks telbestanden met geaggregeerde aanmeldcijfers per op
 **Individueel spoor (intern: Osiris/Usis → model)**
 De instelling levert per-student aanmelddata uit Osiris/Usis. Dit bestand wordt via ETL stap 4 gekopieerd naar `vooraanmeldingen_individueel.csv`. Het vormt de basis voor de `SARIMA_individual` voorspelling.
 
-**Studentaantallen (extern: DUO oktober-bestand → ground truth)**
-Het DUO oktober-bestand (1-cijfer HO) bevat de werkelijke inschrijvingen na 1 oktober. Het ETL-script leidt hieruit de ground truth af die het model als referentie gebruikt.
+**Studentaantallen (intern: 1cijferHO-vergelijkbaar bestand → ground truth)**
+Dit is een bestand dat de instelling zelf aanlevert, **in hetzelfde formaat als het DUO 1cijferHO**. Het bevat de werkelijke inschrijvingen na 1 oktober. Het ETL-script leidt hieruit de ground truth af die het model als referentie gebruikt. De bestandsnaam `oktober_bestand.xlsx` is historisch (DUO publiceert 1cijferHO rond 1 oktober) en is ongewijzigd gelaten zodat bestaande installaties blijven werken.
 
 Het prognosemodel combineert beide sporen via ensemble weging om een voorspelling te maken van het verwachte aantal studenten.
 

--- a/doc/PIPELINE.md
+++ b/doc/PIPELINE.md
@@ -12,8 +12,8 @@ Dit document beschrijft hoe ruwe Studielink-data en instellingsdata worden getra
 |---------|-------------|------|---------------|
 | `vooraanmeldingen_cumulatief.csv` | Gewogen/ongewogen vooraanmelders per opleiding, herkomst, week, jaar | Studielink telbestanden (extern) → ETL stap 1 + 2 | Bij `-d c` of `-d b` (default) |
 | `vooraanmeldingen_individueel.csv` | Een rij per student-aanmelding met persoonskenmerken | Osiris/Usis (intern) → ETL stap 4 | Bij `-d i` of `-d b` (default) |
-| `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | 1cijferHO-vergelijkbaar bestand (DUO 1cijferHO-formaat, eigen levering instelling) → ETL stap 3 | Altijd |
-| `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | 1cijferHO-vergelijkbaar bestand (DUO 1cijferHO-formaat, eigen levering instelling) → ETL stap 3 | Alleen bij `-sy v` |
+| `student_count_first-years.xlsx` | Werkelijk aantal eerstejaars per opleiding/herkomst/jaar | Telbestand studenten (eigen levering instelling) → ETL stap 3 | Altijd |
+| `student_volume.xlsx` | Totaal studentvolume per opleiding/herkomst/jaar | Telbestand studenten (eigen levering instelling) → ETL stap 3 | Alleen bij `-sy v` |
 
 ### Optionele bestanden
 
@@ -48,7 +48,7 @@ flowchart TD
             SL["Studielink Telbestanden<br/><i>telbestandY2024WXX.csv</i><br/><b>Bron: Studielink</b>"]:::bron
         end
         subgraph bronnen_intern ["Interne bronnen (instelling levert zelf)"]
-            OKT["1cijferHO-vergelijkbaar bestand<br/><i>oktober_bestand.xlsx</i><br/><b>Formaat: DUO 1cijferHO</b>"]:::bron
+            OKT["Telbestand studenten<br/><i>oktober_bestand.xlsx</i><br/><b>Bron: eigen levering instelling</b>"]:::bron
             SIS["Individuele aanmelddata<br/><i>per student-aanmelding</i><br/><b>Bron: Osiris / Usis</b>"]:::bron
         end
     end
@@ -60,7 +60,7 @@ flowchart TD
         direction LR
         S1["Rowbind + reformat<br/><i>samenvoegen telbestanden</i>"]:::script
         S2["Interpolate<br/><i>ontbrekende weken</i>"]:::script
-        S3["Calculate student count<br/><i>1cijferHO-vergelijkbaar → aantallen</i>"]:::script
+        S3["Calculate student count<br/><i>telbestand → aantallen</i>"]:::script
         S4["Copy bestanden<br/><i>individueel</i>"]:::script
     end
 
@@ -183,7 +183,7 @@ Het ETL-script draait standaard en transformeert ruwe data in `data/input_raw/` 
 |------|-------|-------|--------|
 | 1 | Rowbind + reformat | `data/input_raw/telbestanden/*.csv` | Samengevoegd CSV |
 | 2 | Interpolatie | Samengevoegd CSV | `vooraanmeldingen_cumulatief.csv` |
-| 3 | Studentaantallen | 1cijferHO-vergelijkbaar bestand (`oktober_bestand.xlsx`) | `student_count_*.xlsx`, `student_volume.xlsx` |
+| 3 | Studentaantallen | Telbestand studenten (`oktober_bestand.xlsx`) | `student_count_*.xlsx`, `student_volume.xlsx` |
 | 4 | Kopieren | Individuele data | `vooraanmeldingen_individueel.csv` |
 
 ---
@@ -217,8 +217,8 @@ Studielink levert wekelijks telbestanden met geaggregeerde aanmeldcijfers per op
 **Individueel spoor (intern: Osiris/Usis → model)**
 De instelling levert per-student aanmelddata uit Osiris/Usis. Dit bestand wordt via ETL stap 4 gekopieerd naar `vooraanmeldingen_individueel.csv`. Het vormt de basis voor de `SARIMA_individual` voorspelling.
 
-**Studentaantallen (intern: 1cijferHO-vergelijkbaar bestand → ground truth)**
-Dit is een bestand dat de instelling zelf aanlevert, **in hetzelfde formaat als het DUO 1cijferHO**. Het bevat de werkelijke inschrijvingen na 1 oktober. Het ETL-script leidt hieruit de ground truth af die het model als referentie gebruikt. De bestandsnaam `oktober_bestand.xlsx` is historisch (DUO publiceert 1cijferHO rond 1 oktober) en is ongewijzigd gelaten zodat bestaande installaties blijven werken.
+**Studentaantallen (intern: telbestand studenten → ground truth)**
+Dit is een telbestand met studentaantallen dat de instelling zelf aanlevert. Het bevat de werkelijke inschrijvingen per opleiding, herkomst en collegejaar. Het ETL-script leidt hieruit de ground truth af die het model als referentie gebruikt. De bestandsnaam `oktober_bestand.xlsx` is historisch en is ongewijzigd gelaten zodat bestaande installaties blijven werken.
 
 Het prognosemodel combineert beide sporen via ensemble weging om een voorspelling te maken van het verwachte aantal studenten.
 

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -83,7 +83,7 @@ data/
     │   ├── telbestandY2024W01.csv
     │   └── ...
     ├── individuele_aanmelddata.csv ← Osiris/Usis export
-    └── oktober_bestand.xlsx        ← DUO oktober-bestand
+    └── oktober_bestand.xlsx        ← 1cijferHO-vergelijkbaar bestand
 ```
 
 Zie [Je data voorbereiden](je-data-voorbereiden.md) voor kolomspecificaties per bestand.
@@ -99,7 +99,7 @@ studentprognose --noetl
 Welke bestanden je dan precies in `data/input/` nodig hebt — en in welk formaat — lees je op [ETL overslaan](je-data-voorbereiden.md#etl-overslaan).
 
 !!! warning "Wanneer je `--noetl` níét moet gebruiken"
-    Heb je alleen ruwe bronbestanden (Studielink-telbestanden, Osiris/Usis-export, DUO oktober-bestand)? Laat `--noetl` dan weg, zodat de ingebouwde ETL de verwerkte bestanden voor je aanmaakt.
+    Heb je alleen ruwe bronbestanden (Studielink-telbestanden, Osiris/Usis-export, 1cijferHO-vergelijkbaar bestand)? Laat `--noetl` dan weg, zodat de ingebouwde ETL de verwerkte bestanden voor je aanmaakt.
 
 ## Wat voorspelt `-w 16 -y 2025`?
 

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -83,7 +83,7 @@ data/
     │   ├── telbestandY2024W01.csv
     │   └── ...
     ├── individuele_aanmelddata.csv ← Osiris/Usis export
-    └── oktober_bestand.xlsx        ← 1cijferHO-vergelijkbaar bestand
+    └── oktober_bestand.xlsx        ← telbestand studenten
 ```
 
 Zie [Je data voorbereiden](je-data-voorbereiden.md) voor kolomspecificaties per bestand.
@@ -99,7 +99,7 @@ studentprognose --noetl
 Welke bestanden je dan precies in `data/input/` nodig hebt — en in welk formaat — lees je op [ETL overslaan](je-data-voorbereiden.md#etl-overslaan).
 
 !!! warning "Wanneer je `--noetl` níét moet gebruiken"
-    Heb je alleen ruwe bronbestanden (Studielink-telbestanden, Osiris/Usis-export, 1cijferHO-vergelijkbaar bestand)? Laat `--noetl` dan weg, zodat de ingebouwde ETL de verwerkte bestanden voor je aanmaakt.
+    Heb je alleen ruwe bronbestanden (Studielink-telbestanden, Osiris/Usis-export, telbestand studenten)? Laat `--noetl` dan weg, zodat de ingebouwde ETL de verwerkte bestanden voor je aanmaakt.
 
 ## Wat voorspelt `-w 16 -y 2025`?
 

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -28,11 +28,11 @@ Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
 | `path_latest_cumulative` | `data/input/totaal_cumulatief.xlsx` | Historische cumulatieve voorspellingen (post-processing output) |
 | `path_latest_individual` | `data/input/totaal_individueel.xlsx` | Historische individuele voorspellingen (post-processing output) |
 | `path_ensemble_weights` | `data/input/ensemble_weights.xlsx` | Ensemble-gewichten per opleiding/herkomst/examentype |
-| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | 1cijferHO-vergelijkbaar bestand (ruwe bron in DUO 1cijferHO-formaat). De sleutel heet `_october` om historische reden — DUO publiceert 1cijferHO jaarlijks rond 1 oktober. |
+| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | Telbestand studenten (ruwe bron, eigen levering instelling). De sleutel heet `_october` om historische redenen. |
 | `path_raw_telbestanden` | `data/input_raw/telbestanden` | Map met Studielink telbestanden |
 | `path_raw_individueel` | `data/input_raw/individuele_aanmelddata.csv` | Ruwe individuele aanmelddata |
-| `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (DUO) |
-| `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (DUO) |
+| `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (afgeleid uit telbestand studenten) |
+| `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (afgeleid uit telbestand studenten) |
 | `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
 
 ## `runtime` — uitvoerparameters
@@ -236,11 +236,11 @@ Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
 
 `Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
 
-### `oktober` — 1cijferHO-vergelijkbaar bestand
+### `oktober` — telbestand studenten
 
 `Collegejaar`, `Groepeernaam Croho`, `Aantal eerstejaars croho`, `EER-NL-nietEER`, `Examentype code`, `Aantal Hoofdinschrijvingen`
 
-De sleutel heet `oktober` omdat DUO het 1cijferHO jaarlijks rond 1 oktober publiceert. Inhoudelijk gaat het om een bestand vergelijkbaar met het DUO 1cijferHO — zie [Je data voorbereiden](je-data-voorbereiden.md#1cijferho-vergelijkbaar-bestand).
+De sleutel heet `oktober` om historische redenen — zie [Je data voorbereiden](je-data-voorbereiden.md#telbestand-studenten).
 
 ### `cumulative` — Studielink cumulatieve data
 

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -28,7 +28,7 @@ Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
 | `path_latest_cumulative` | `data/input/totaal_cumulatief.xlsx` | Historische cumulatieve voorspellingen (post-processing output) |
 | `path_latest_individual` | `data/input/totaal_individueel.xlsx` | Historische individuele voorspellingen (post-processing output) |
 | `path_ensemble_weights` | `data/input/ensemble_weights.xlsx` | Ensemble-gewichten per opleiding/herkomst/examentype |
-| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | DUO oktober-bestand (ruwe bron) |
+| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | 1cijferHO-vergelijkbaar bestand (ruwe bron in DUO 1cijferHO-formaat). De sleutel heet `_october` om historische reden — DUO publiceert 1cijferHO jaarlijks rond 1 oktober. |
 | `path_raw_telbestanden` | `data/input_raw/telbestanden` | Map met Studielink telbestanden |
 | `path_raw_individueel` | `data/input_raw/individuele_aanmelddata.csv` | Ruwe individuele aanmelddata |
 | `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (DUO) |
@@ -236,9 +236,11 @@ Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
 
 `Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
 
-### `oktober` — DUO oktober-bestand
+### `oktober` — 1cijferHO-vergelijkbaar bestand
 
 `Collegejaar`, `Groepeernaam Croho`, `Aantal eerstejaars croho`, `EER-NL-nietEER`, `Examentype code`, `Aantal Hoofdinschrijvingen`
+
+De sleutel heet `oktober` omdat DUO het 1cijferHO jaarlijks rond 1 oktober publiceert. Inhoudelijk gaat het om een bestand vergelijkbaar met het DUO 1cijferHO — zie [Je data voorbereiden](je-data-voorbereiden.md#1cijferho-vergelijkbaar-bestand).
 
 ### `cumulative` — Studielink cumulatieve data
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -56,15 +56,15 @@ Verplichte kolommen (kanonieke namen — pas aan via `configuration.json` als jo
 | `Geslacht` | Geslacht |
 | `Type vooropleiding` | Type vooropleiding |
 
-### 1cijferHO-vergelijkbaar bestand
+### Telbestand studenten
 
 Pad: `data/input_raw/oktober_bestand.xlsx`
-Bron: door je instelling zelf aangeleverd, **in hetzelfde formaat als het DUO 1cijferHO**
+Bron: door je instelling zelf aangeleverd
 
-Dit bestand bevat de werkelijke inschrijvingen per opleiding, herkomst en collegejaar — de ground truth waarop het model wordt geëvalueerd en die het ratio-model voedt. De DUO-levering (1cijferHO) is hier de formaat-referentie; de meeste instellingen genereren dit bestand zelf uit hun SIS/datawarehouse (Osiris, Usis, of vergelijkbaar).
+Dit bestand bevat de werkelijke inschrijvingen per opleiding, herkomst en collegejaar — de ground truth waarop het model wordt geëvalueerd en die het ratio-model voedt. De meeste instellingen genereren dit bestand uit hun SIS/datawarehouse (Osiris, Usis, of vergelijkbaar).
 
 !!! note "Waarom heet het bestand `oktober_bestand.xlsx`?"
-    Historisch heette dit bestand zo omdat DUO de 1cijferHO-data jaarlijks rond 1 oktober publiceert. De bestandsnaam en de configuratiesleutels (`path_raw_october`, `columns.oktober`) zijn ongewijzigd gelaten om bestaande installaties niet te breken. Inhoudelijk is het bestand een **1cijferHO-vergelijkbaar bestand**.
+    Historische naam. De bestandsnaam en de configuratiesleutels (`path_raw_october`, `columns.oktober`) zijn ongewijzigd gelaten om bestaande installaties niet te breken. Inhoudelijk is het een **telbestand met studentaantallen**.
 
 | Canonieke naam | Omschrijving |
 |----------------|-------------|
@@ -83,7 +83,7 @@ De ETL draait automatisch bij elke run (tenzij `--noetl` is opgegeven). De stapp
 |------|-------|-------|--------|
 | 1 | Rowbind + reformat | `telbestanden/*.csv` | Samengevoegd cumulatief bestand |
 | 2 | Interpolatie ontbrekende weken | Samengevoegd bestand | `vooraanmeldingen_cumulatief.csv` |
-| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` (1cijferHO-vergelijkbaar bestand) | `student_count_*.xlsx`, `student_volume.xlsx` |
+| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` (telbestand studenten) | `student_count_*.xlsx`, `student_volume.xlsx` |
 | 4 | Kopiëren individuele data | `individuele_aanmelddata.csv` | `vooraanmeldingen_individueel.csv` |
 
 ## ETL overslaan

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -56,10 +56,15 @@ Verplichte kolommen (kanonieke namen — pas aan via `configuration.json` als jo
 | `Geslacht` | Geslacht |
 | `Type vooropleiding` | Type vooropleiding |
 
-### Oktober-bestand (DUO 1-cijfer HO)
+### 1cijferHO-vergelijkbaar bestand
 
 Pad: `data/input_raw/oktober_bestand.xlsx`
-Bron: DUO
+Bron: door je instelling zelf aangeleverd, **in hetzelfde formaat als het DUO 1cijferHO**
+
+Dit bestand bevat de werkelijke inschrijvingen per opleiding, herkomst en collegejaar — de ground truth waarop het model wordt geëvalueerd en die het ratio-model voedt. De DUO-levering (1cijferHO) is hier de formaat-referentie; de meeste instellingen genereren dit bestand zelf uit hun SIS/datawarehouse (Osiris, Usis, of vergelijkbaar).
+
+!!! note "Waarom heet het bestand `oktober_bestand.xlsx`?"
+    Historisch heette dit bestand zo omdat DUO de 1cijferHO-data jaarlijks rond 1 oktober publiceert. De bestandsnaam en de configuratiesleutels (`path_raw_october`, `columns.oktober`) zijn ongewijzigd gelaten om bestaande installaties niet te breken. Inhoudelijk is het bestand een **1cijferHO-vergelijkbaar bestand**.
 
 | Canonieke naam | Omschrijving |
 |----------------|-------------|
@@ -78,7 +83,7 @@ De ETL draait automatisch bij elke run (tenzij `--noetl` is opgegeven). De stapp
 |------|-------|-------|--------|
 | 1 | Rowbind + reformat | `telbestanden/*.csv` | Samengevoegd cumulatief bestand |
 | 2 | Interpolatie ontbrekende weken | Samengevoegd bestand | `vooraanmeldingen_cumulatief.csv` |
-| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` | `student_count_*.xlsx`, `student_volume.xlsx` |
+| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` (1cijferHO-vergelijkbaar bestand) | `student_count_*.xlsx`, `student_volume.xlsx` |
 | 4 | Kopiëren individuele data | `individuele_aanmelddata.csv` | `vooraanmeldingen_individueel.csv` |
 
 ## ETL overslaan

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -15,7 +15,7 @@ Bij het starten van de validatie toont de pipeline een overzichtstabel met de st
   ──────────────────────────────────────────────────────────────────
   data/input_raw/telbestanden                 ✓         -d cumulative, -d both
   data/input_raw/individuele_aanmelddata.csv  ✗         -d individual, -d both
-  data/input_raw/oktober_bestand.xlsx         ✓         studentaantallen (optioneel, 1cijferHO-vergelijkbaar bestand)
+  data/input_raw/oktober_bestand.xlsx         ✓         studentaantallen (optioneel, telbestand studenten)
 
   Beschikbare modi:
     -d cumulative      ✓
@@ -62,9 +62,9 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 | Verplichte kolommen | Hard error | `Collegejaar`, `Croho`, `Inschrijfstatus`, `Datum Verzoek Inschr` (via kolomnamen-mapping) |
 | Ontbrekende waarden | Waarschuwing / Soft error | Per verplichte kolom, zelfde drempels als telbestanden |
 
-### 1cijferHO-vergelijkbaar bestand (`data/input_raw/oktober_bestand.xlsx`)
+### Telbestand studenten (`data/input_raw/oktober_bestand.xlsx`)
 
-Dit is het bestand vergelijkbaar met het DUO 1cijferHO — zie [Je data voorbereiden](je-data-voorbereiden.md#1cijferho-vergelijkbaar-bestand). De bestandsnaam heet historisch `oktober_bestand.xlsx`.
+Telbestand met studentaantallen, door de instelling zelf aangeleverd — zie [Je data voorbereiden](je-data-voorbereiden.md#telbestand-studenten). De bestandsnaam heet historisch `oktober_bestand.xlsx`.
 
 | Controle | Type | Wat wordt gecheckt |
 |----------|------|-------------------|
@@ -135,7 +135,7 @@ De standaarddrempels voor NaN-percentages en jaarbereiken zijn instelbaar via `c
 ## Een validatiefout oplossen
 
 **Hard error — ontbrekende kolommen:**
-De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober` (de mapping voor het 1cijferHO-vergelijkbare bestand).
+De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober` (de mapping voor het telbestand studenten).
 
 **Soft error — onverwacht collegejaar:**
 Controleer of het bestand het juiste studiejaar bevat. Als de afwijking verwacht is (bijv. historische data), kun je `collegejaar_min_offset` verhogen of met `--yes` doorgaan.

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -15,7 +15,7 @@ Bij het starten van de validatie toont de pipeline een overzichtstabel met de st
   ──────────────────────────────────────────────────────────────────
   data/input_raw/telbestanden                 ✓         -d cumulative, -d both
   data/input_raw/individuele_aanmelddata.csv  ✗         -d individual, -d both
-  data/input_raw/oktober_bestand.xlsx         ✓         studentaantallen (optioneel)
+  data/input_raw/oktober_bestand.xlsx         ✓         studentaantallen (optioneel, 1cijferHO-vergelijkbaar bestand)
 
   Beschikbare modi:
     -d cumulative      ✓
@@ -62,7 +62,9 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 | Verplichte kolommen | Hard error | `Collegejaar`, `Croho`, `Inschrijfstatus`, `Datum Verzoek Inschr` (via kolomnamen-mapping) |
 | Ontbrekende waarden | Waarschuwing / Soft error | Per verplichte kolom, zelfde drempels als telbestanden |
 
-### Oktober-bestand (`data/input_raw/oktober_bestand.xlsx`)
+### 1cijferHO-vergelijkbaar bestand (`data/input_raw/oktober_bestand.xlsx`)
+
+Dit is het bestand vergelijkbaar met het DUO 1cijferHO — zie [Je data voorbereiden](je-data-voorbereiden.md#1cijferho-vergelijkbaar-bestand). De bestandsnaam heet historisch `oktober_bestand.xlsx`.
 
 | Controle | Type | Wat wordt gecheckt |
 |----------|------|-------------------|
@@ -133,7 +135,7 @@ De standaarddrempels voor NaN-percentages en jaarbereiken zijn instelbaar via `c
 ## Een validatiefout oplossen
 
 **Hard error — ontbrekende kolommen:**
-De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober`.
+De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober` (de mapping voor het 1cijferHO-vergelijkbare bestand).
 
 **Soft error — onverwacht collegejaar:**
 Controleer of het bestand het juiste studiejaar bevat. Als de afwijking verwacht is (bijv. historische data), kun je `collegejaar_min_offset` verhogen of met `--yes` doorgaan.

--- a/src/studentprognose/data/etl.py
+++ b/src/studentprognose/data/etl.py
@@ -33,7 +33,7 @@ def run_etl(configuration):
     else:
         print("[2/4] Skipping interpolation (no cumulative file)")
 
-    # Step 3: Calculate student counts from 1cijferHO-vergelijkbaar bestand
+    # Step 3: Calculate student counts from telbestand studenten
     path_october_rel = paths.get("path_raw_october", "")
     if not path_october_rel:
         print("[3/4] Skipping student counts (path_raw_october not configured)")
@@ -44,7 +44,7 @@ def run_etl(configuration):
             print("[3/4] Calculating student counts...     → data/input/student_count_*.xlsx")
             _calculate_student_counts(path_october, cwd, oktober_columns)
         else:
-            print(f"[3/4] Skipping student counts (1cijferHO-vergelijkbaar bestand not found: {path_october_rel})")
+            print(f"[3/4] Skipping student counts (telbestand studenten not found: {path_october_rel})")
 
     # Step 4: Copy direct files (raw → canonical input paths)
     copied = _copy_direct_files(cwd, paths, output_individual)
@@ -284,7 +284,7 @@ def _interpolate(data, year, start_week, end_week, max_week=52):
 
 
 def _calculate_student_count(data, volume):
-    """Calculate student counts from the 1cijferHO-vergelijkbaar bestand.
+    """Calculate student counts from the telbestand studenten.
 
     Returns a DataFrame with columns: Collegejaar, Croho groepeernaam,
     Herkomst, Aantal_studenten, Examentype.
@@ -349,7 +349,7 @@ def _calculate_student_count(data, volume):
 
 
 def _calculate_student_counts(path_october, cwd, oktober_columns=None):
-    """Calculate student count files from the 1cijferHO-vergelijkbaar bestand.
+    """Calculate student count files from the telbestand studenten.
 
     oktober_columns maps canonical column names to institution-specific names,
     matching the structure of configuration["columns"]["oktober"]. Columns are

--- a/src/studentprognose/data/etl.py
+++ b/src/studentprognose/data/etl.py
@@ -33,7 +33,7 @@ def run_etl(configuration):
     else:
         print("[2/4] Skipping interpolation (no cumulative file)")
 
-    # Step 3: Calculate student counts from oktober-bestand
+    # Step 3: Calculate student counts from 1cijferHO-vergelijkbaar bestand
     path_october_rel = paths.get("path_raw_october", "")
     if not path_october_rel:
         print("[3/4] Skipping student counts (path_raw_october not configured)")
@@ -44,7 +44,7 @@ def run_etl(configuration):
             print("[3/4] Calculating student counts...     → data/input/student_count_*.xlsx")
             _calculate_student_counts(path_october, cwd, oktober_columns)
         else:
-            print(f"[3/4] Skipping student counts (oktober-bestand not found: {path_october_rel})")
+            print(f"[3/4] Skipping student counts (1cijferHO-vergelijkbaar bestand not found: {path_october_rel})")
 
     # Step 4: Copy direct files (raw → canonical input paths)
     copied = _copy_direct_files(cwd, paths, output_individual)
@@ -284,7 +284,7 @@ def _interpolate(data, year, start_week, end_week, max_week=52):
 
 
 def _calculate_student_count(data, volume):
-    """Calculate student counts from oktober-bestand (1-cijfer HO).
+    """Calculate student counts from the 1cijferHO-vergelijkbaar bestand.
 
     Returns a DataFrame with columns: Collegejaar, Croho groepeernaam,
     Herkomst, Aantal_studenten, Examentype.
@@ -349,7 +349,7 @@ def _calculate_student_count(data, volume):
 
 
 def _calculate_student_counts(path_october, cwd, oktober_columns=None):
-    """Calculate student count files from the oktober-bestand.
+    """Calculate student count files from the 1cijferHO-vergelijkbaar bestand.
 
     oktober_columns maps canonical column names to institution-specific names,
     matching the structure of configuration["columns"]["oktober"]. Columns are

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -15,8 +15,9 @@ Tolerantie voor institutie-specifieke data
 Elke instelling kan kolomnamen en lichte type-afwijkingen hebben.
 Dit module probeert data te normaliseren voordat het valideert:
 
-- **Kolomnamen** voor ``individuele_aanmelddata`` en ``oktober_bestand``
-  worden opgezocht via ``configuration["columns"]["individual"]`` en
+- **Kolomnamen** voor ``individuele_aanmelddata`` en het 1cijferHO-vergelijkbare
+  bestand (``oktober_bestand.xlsx``) worden opgezocht via
+  ``configuration["columns"]["individual"]`` en
   ``configuration["columns"]["oktober"]``. Pas die mapping aan in
   ``configuration.json`` als jouw instelling andere namen gebruikt.
   Telbestanden komen van Studielink en zijn gestandaardiseerd; die
@@ -218,7 +219,7 @@ def _check_file_presence(cwd, paths):
     return [
         (telbestanden_rel, telbestanden_ok, "-d cumulative, -d both"),
         (individueel_rel, individueel_ok, "-d individual, -d both"),
-        (oktober_rel, oktober_ok, "studentaantallen (optioneel)"),
+        (oktober_rel, oktober_ok, "studentaantallen (optioneel, 1cijferHO-vergelijkbaar bestand)"),
     ]
 
 

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -15,8 +15,8 @@ Tolerantie voor institutie-specifieke data
 Elke instelling kan kolomnamen en lichte type-afwijkingen hebben.
 Dit module probeert data te normaliseren voordat het valideert:
 
-- **Kolomnamen** voor ``individuele_aanmelddata`` en het 1cijferHO-vergelijkbare
-  bestand (``oktober_bestand.xlsx``) worden opgezocht via
+- **Kolomnamen** voor ``individuele_aanmelddata`` en het telbestand studenten
+  (``oktober_bestand.xlsx``) worden opgezocht via
   ``configuration["columns"]["individual"]`` en
   ``configuration["columns"]["oktober"]``. Pas die mapping aan in
   ``configuration.json`` als jouw instelling andere namen gebruikt.
@@ -219,7 +219,7 @@ def _check_file_presence(cwd, paths):
     return [
         (telbestanden_rel, telbestanden_ok, "-d cumulative, -d both"),
         (individueel_rel, individueel_ok, "-d individual, -d both"),
-        (oktober_rel, oktober_ok, "studentaantallen (optioneel, 1cijferHO-vergelijkbaar bestand)"),
+        (oktober_rel, oktober_ok, "studentaantallen (optioneel, telbestand studenten)"),
     ]
 
 

--- a/src/studentprognose/init.py
+++ b/src/studentprognose/init.py
@@ -13,7 +13,7 @@ Plaats hier je ruwe Studielink-exportbestanden:
 |---|---|
 | `telbestanden/` | Wekelijkse Studielink-telbestanden (`telbestandY<jaar>W<week>.csv`) |
 | `individuele_aanmelddata.csv` | Individuele vooraanmeldingen per student |
-| `oktober_bestand.xlsx` | 1cijferHO-vergelijkbaar bestand (zelfde formaat als DUO 1cijferHO, eigen levering instelling — voor studentaantallen) |
+| `oktober_bestand.xlsx` | Telbestand studenten (eigen levering instelling — voor studentaantallen) |
 
 Draai daarna `studentprognose` om de ETL te starten en voorspellingen te genereren.
 """
@@ -60,10 +60,10 @@ Volgende stappen:
   1. Plaats je telbestanden in:     data/input_raw/telbestanden/
                                     (bestandsnamen: telbestandY<jaar>W<week>.csv)
   2. Plaats je individuele data in: data/input_raw/individuele_aanmelddata.csv
-  3. Optioneel — 1cijferHO-vergelijkbaar bestand:
+  3. Optioneel — telbestand studenten:
                                     data/input_raw/oktober_bestand.xlsx
-                                    (eigen levering in DUO 1cijferHO-formaat,
-                                    voor berekening van studentaantallen)
+                                    (eigen levering instelling, voor
+                                    berekening van studentaantallen)
 
   Draaien:
     studentprognose -w <week> -y <jaar>

--- a/src/studentprognose/init.py
+++ b/src/studentprognose/init.py
@@ -13,7 +13,7 @@ Plaats hier je ruwe Studielink-exportbestanden:
 |---|---|
 | `telbestanden/` | Wekelijkse Studielink-telbestanden (`telbestandY<jaar>W<week>.csv`) |
 | `individuele_aanmelddata.csv` | Individuele vooraanmeldingen per student |
-| `oktober_bestand.xlsx` | 1-cijfer HO oktober-telling (voor studentaantallen) |
+| `oktober_bestand.xlsx` | 1cijferHO-vergelijkbaar bestand (zelfde formaat als DUO 1cijferHO, eigen levering instelling — voor studentaantallen) |
 
 Draai daarna `studentprognose` om de ETL te starten en voorspellingen te genereren.
 """
@@ -60,8 +60,10 @@ Volgende stappen:
   1. Plaats je telbestanden in:     data/input_raw/telbestanden/
                                     (bestandsnamen: telbestandY<jaar>W<week>.csv)
   2. Plaats je individuele data in: data/input_raw/individuele_aanmelddata.csv
-  3. Optioneel — oktober-bestand:  data/input_raw/oktober_bestand.xlsx
-                                    (voor berekening van studentaantallen)
+  3. Optioneel — 1cijferHO-vergelijkbaar bestand:
+                                    data/input_raw/oktober_bestand.xlsx
+                                    (eigen levering in DUO 1cijferHO-formaat,
+                                    voor berekening van studentaantallen)
 
   Draaien:
     studentprognose -w <week> -y <jaar>


### PR DESCRIPTION
Resolves #160.

## Summary

De term **"oktoberbestand"** suggereerde dat het bestand voor de studentaantallen rechtstreeks van DUO kwam. Na review-feedback van @Tomeriko96 (zie review hieronder) is duidelijk dat dit bestand **niet** het DUO 1cijferHO is, en ook niet het "oktobertelbestand". Het is simpelweg een **telbestand met studentaantallen** dat de instelling zelf aanlevert. De documentatie, het mermaid-diagram in `doc/PIPELINE.md` en de user-facing prints/foutmeldingen noemen het bestand nu inhoudelijk: een **telbestand studenten** (eigen levering instelling).

## Wat verandert er voor gebruikers

- **Niets aan het draaien van de pipeline** — bestandsnaam `oktober_bestand.xlsx` en configuratiesleutels (`path_raw_october`, `columns.oktober`) blijven ongewijzigd, zodat bestaande installaties blijven werken.
- **Wel duidelijker in de docs**: een korte uitleg dat de bestandsnaam historisch zo heet.

## Wijzigingen t.o.v. eerdere versie van deze PR

De eerste versie van deze PR introduceerde de term **"1cijferHO-vergelijkbaar bestand"**. Op basis van review-feedback is dat alsnog ingetrokken: claimen dat het in DUO 1cijferHO-formaat is, was feitelijk niet juist. De huidige versie gebruikt de neutrale term **"telbestand studenten"**.

## Bestanden geraakt vs CLAUDE.md docs-regel

| Wijziging | Bijbehorende docs-pagina(s) bijgewerkt? |
|-----------|----------------------------------------|
| Validatie-prints | ✅ `docs/validatie.md` (bestandsoverzicht + sectienaam + foutoplossing) |
| ETL-prints / docstrings | ✅ `docs/je-data-voorbereiden.md` (sectie hernoemd + uitleg bestandsnaam) |
| Pad/kolommen-config | ✅ `docs/configuratie.md` (`path_raw_october`-rij + `columns.oktober`-sectie) |
| Mapboom + tip | ✅ `docs/aan-de-slag.md` |
| Pipeline-overzicht | ✅ `doc/PIPELINE.md` (mermaid-node + bronnen-tabel + tekstuele uitleg) |
| `studentprognose init`-output | ✅ `src/studentprognose/init.py` (interactieve uitleg + scaffolded README) |
| Raw input README | ✅ `data/input_raw/README.md` |

## Niet in scope

- Hernoemen van `oktober_bestand.xlsx` / `path_raw_october` / `columns.oktober` (zou bestaande installaties breken)

## Test plan

- [x] Mkdocs build (`uv run mkdocs build`) groen
- [x] Pytest-suite (`uv run pytest`) groen — 274 passed
- [ ] Smoke test (`scripts/test_package.sh`) groen — verifieert dat de ETL nog steeds werkt met de ongewijzigde bestandsnaam
- [ ] Visuele check van het mermaid-diagram in `doc/PIPELINE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
