### PR TITLE
fix: promoveer meercode_V = 0 van soft- naar hard-error

### DIFF
--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -48,7 +48,7 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 | Collegejaar bereik | Soft error | `Studiejaar` buiten `[huidig jaar − 15, huidig jaar + 2]` |
 | Herkomst geldige waarden | Soft error | Elke waarde in `Herkomst` moet `N`, `E` of `R` zijn |
 | Herinschrijving geldige waarden | Soft error | Elke waarde moet `J` of `N` zijn |
-| meercode_V = 0 | Soft error | Leidt tot deling door nul in ETL |
+| meercode_V = 0 | Hard error | Leidt tot deling door nul in ETL (`inf`/`NaN` in `Gewogen vooraanmelders`) — niet omzeilbaar met `--yes` |
 | Aantal < 0 | Soft error | Negatieve aantallen zijn inhoudelijk onjuist |
 | Ontbrekende waarden `Aantal` | Waarschuwing / Soft error | > 5% ontbrekend → waarschuwing; > 30% → soft error |
 | Gaten tussen weken | Waarschuwing | Gat van > 2 weken binnen een jaar |

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -377,10 +377,11 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result, required=True):
         zero_meercode = df[meercode_v == 0]
         if not zero_meercode.empty:
             programmes = zero_meercode["Groepeernaam"].dropna().unique()
-            result.soft_errors.append(
-                f"{filename}: meercode_V = 0 (deling door nul in ETL) voor "
+            result.hard_errors.append(
+                f"{filename}: meercode_V = 0 leidt tot deling door nul in ETL voor "
                 f"{len(programmes)} opleiding(en): "
                 + _format_programmes(programmes)
+                + " — corrigeer of verwijder deze rijen in het bronbestand."
             )
 
         neg_aantal = df[df["Aantal"] < 0]

--- a/tests/studentprognose/test_validation.py
+++ b/tests/studentprognose/test_validation.py
@@ -405,7 +405,7 @@ class TestValidateRawDataIntegration:
         with pytest.raises(SystemExit):
             validate_raw_data(cfg, yes=True)
 
-    def test_zero_meercode_triggers_soft_error_yes_passes(self, tmp_path, monkeypatch):
+    def test_zero_meercode_is_hard_error_not_bypassable_with_yes(self, tmp_path, monkeypatch):
         telbestanden_dir = tmp_path / "telbestanden"
         telbestanden_dir.mkdir()
         df = pd.DataFrame({
@@ -421,7 +421,9 @@ class TestValidateRawDataIntegration:
         df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
         cfg = _make_configuration(tmp_path, telbestanden_dir)
         monkeypatch.chdir(tmp_path)
-        validate_raw_data(cfg, yes=True, data_option=DataOption.CUMULATIVE)
+        with pytest.raises(SystemExit) as exc:
+            validate_raw_data(cfg, yes=True, data_option=DataOption.CUMULATIVE)
+        assert exc.value.code == 1
 
     def test_invalid_herkomst_prompts_and_n_exits(self, tmp_path, monkeypatch):
         telbestanden_dir = tmp_path / "telbestanden"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description of Changes

`src/studentprognose/data/etl.py:79` deelt door `meercode_V` zonder zero-guard. De validatie markeerde `meercode_V == 0` als **soft error** (te omzeilen met `--yes`), wat inconsistent is met het ETL-gedrag: bij `0` produceert pandas `inf`/`NaN` in `Gewogen vooraanmelders`, en die waarden propageren stil naar interpolatie, cumulatieve sommen en modelinput.

Deze PR promoveert de check naar **hard error** — de pipeline kan hier niet zinvol mee verder, dus we falen vroeg met een duidelijke melding in plaats van de gebruiker een omzeilbare prompt te geven die alsnog leidt tot silent failures downstream.

**Wijzigingen:**
- `src/studentprognose/data/validation.py`: `result.soft_errors.append(...)` → `result.hard_errors.append(...)` voor `meercode_V == 0`, met aangevulde boodschap (\"corrigeer of verwijder deze rijen in het bronbestand\").
- `docs/validatie.md`: tabel telbestanden geüpdatet — \"Soft error\" → \"Hard error\", inclusief uitleg dat het niet omzeilbaar is met `--yes`.
- `tests/studentprognose/test_validation.py`: bestaande test omgedraaid — bewaakt nu dat `meercode_V = 0` `SystemExit(1)` veroorzaakt, ook met `yes=True`.

## Related Issues

Fixes #183

## Before / After

### Before
- Validatie: \`[PROBLEEM] meercode_V = 0 (deling door nul in ETL)\` (soft, omzeilbaar)
- Met \`--yes\`: pipeline loopt door, ETL produceert \`inf\`/\`NaN\` in \`Gewogen vooraanmelders\`, silent failures downstream.

### After
- Validatie: \`[FOUT] meercode_V = 0 leidt tot deling door nul in ETL ... — corrigeer of verwijder deze rijen in het bronbestand.\`
- Pipeline stopt direct met exit code 1, ook met \`--yes\`.

## Checklist
- [x] I have tested these changes locally (\`uv run pytest tests/studentprognose/test_validation.py\` — 68/68 groen)
- [x] My code follows the project's coding standards
- [x] Documentatie (\`docs/validatie.md\`) bijgewerkt conform de docs-regel in CLAUDE.md