### PR TITLE
feat: maak valid_ingangsdatums configureerbaar (#180)

### DIFF
--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -30,6 +30,11 @@
     "numerus_fixus": {
         "B Opleiding": 0
     },
+    "preprocessing": {
+        "individual": {
+            "valid_ingangsdatums": ["01-09", "01-10"]
+        }
+    },
     "excluded_data_points": [],
     "ensemble_override_cumulative": [
         "B Geneeskunde",

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -14,7 +14,7 @@ De pipeline laadt altijd eerst de **ingebakken standaardwaarden** uit het packag
 - Een ontbrekend veld in jouw bestand valt automatisch terug op de standaardwaarde.
 - Als het configuratiebestand helemaal niet bestaat, worden de standaardwaarden gebruikt en verschijnt er een waarschuwing.
 
-Het bestand heeft de volgende secties: `paths`, `runtime`, `model_config`, `numerus_fixus`, `excluded_data_points`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights` en `columns`.
+Het bestand heeft de volgende secties: `paths`, `runtime`, `model_config`, `numerus_fixus`, `preprocessing`, `excluded_data_points`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights` en `columns`.
 
 ## `paths` — bestandspaden
 
@@ -123,6 +123,31 @@ Een object met opleidingsnamen als sleutels en het maximale inschrijvingsaantal 
 ```
 
 Als de gesommeerde voorspelling over herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Opleidingen die hier niet staan worden niet gecapped.
+
+## `preprocessing` — preprocessing-instellingen
+
+### `individual.valid_ingangsdatums`
+
+Standaard: `["01-09", "01-10"]`
+
+Bepaalt welke ingangsdatums in de individuele aanmelddata worden meegenomen. Rijen waarvan `Ingangsdatum` niet begint met een van deze dag-maand-prefixen worden uit de trainings- en voorspelset gefilterd.
+
+Elke waarde is een dag-maand-prefix in het formaat `"DD-MM"` — de pipeline filtert op `Ingangsdatum` die begint met `"DD-MM-"`. De standaardwaarden (`01-09` en `01-10`) zijn de gangbare academische startdatums op Nederlandse instellingen.
+
+```json
+{
+    "preprocessing": {
+        "individual": {
+            "valid_ingangsdatums": ["01-09", "01-10", "01-02"]
+        }
+    }
+}
+```
+
+Pas dit aan als je instelling afwijkende startdatums hanteert — bijvoorbeeld een februari-instroom voor Master-opleidingen (`"01-02"`) of een semestermoment dat afwijkt van september en oktober. Als je deze instelling weglaat, gelden de standaardwaarden.
+
+!!! warning "Filtert rijen die niet aan de prefix voldoen"
+    Rijen met een `Ingangsdatum` die niet matcht worden stilzwijgend uit de pipeline verwijderd. Controleer voor je deze lijst inkort dat je geen geldige instroommomenten mist.
 
 ## `excluded_data_points` — anomaliejaren uitsluiten van trainingsdata
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -43,7 +43,7 @@ Verplichte kolommen (kanonieke namen — pas aan via `configuration.json` als jo
 |----------------|-------------|
 | `Sleutel` | Unieke studentidentifier |
 | `Datum Verzoek Inschr` | Datum van vooraanmelding |
-| `Ingangsdatum` | Ingangsdatum inschrijving |
+| `Ingangsdatum` | Ingangsdatum inschrijving (`DD-MM-JJJJ`); standaard worden alleen rijen met startdatum 1 september of 1 oktober meegenomen — zie [`preprocessing.individual.valid_ingangsdatums`](configuratie.md#individualvalid_ingangsdatums) om afwijkende startdatums toe te voegen |
 | `Collegejaar` | Collegejaar |
 | `Datum intrekking vooraanmelding` | Weeknummer van intrekking (leeg als niet ingetrokken) |
 | `Inschrijfstatus` | Zie `status_mapping` in configuratie |

--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -63,6 +63,7 @@ def load_configuration(file_path: str) -> dict:
         _validate_excluded_data_points(cfg["excluded_data_points"], file_path)
     _validate_model_config(cfg, file_path)
     _validate_runtime(cfg, file_path)
+    _validate_preprocessing(cfg, file_path)
     return cfg
 
 
@@ -220,3 +221,42 @@ def _validate_runtime(cfg, file_path):
             f"cores ({available}). Verlaagd naar {available}."
         )
         cfg["runtime"]["cpu_count"] = available
+
+
+def _validate_preprocessing(cfg, file_path):
+    preprocessing = cfg.get("preprocessing", {})
+    if not isinstance(preprocessing, dict):
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'preprocessing' moet een object zijn, niet {type(preprocessing).__name__}."
+        )
+        sys.exit(1)
+
+    individual = preprocessing.get("individual", {})
+    if not isinstance(individual, dict):
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'preprocessing.individual' moet een object zijn, niet {type(individual).__name__}."
+        )
+        sys.exit(1)
+
+    valid_ingangsdatums = individual.get("valid_ingangsdatums")
+    if valid_ingangsdatums is None:
+        return
+
+    if not isinstance(valid_ingangsdatums, list) or not valid_ingangsdatums:
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'preprocessing.individual.valid_ingangsdatums' moet een niet-lege lijst "
+            f"van strings zijn (bv. [\"01-09\", \"01-10\"])."
+        )
+        sys.exit(1)
+
+    for i, value in enumerate(valid_ingangsdatums):
+        if not isinstance(value, str) or not value:
+            print(
+                f"Configuratiefout in {file_path}: "
+                f"'preprocessing.individual.valid_ingangsdatums[{i}]' moet een "
+                f"niet-lege string zijn (bv. \"01-09\")."
+            )
+            sys.exit(1)

--- a/src/studentprognose/configuration/configuration.json
+++ b/src/studentprognose/configuration/configuration.json
@@ -31,6 +31,11 @@
         "cumulative_regressor": "xgboost"
     },
     "numerus_fixus": {},
+    "preprocessing": {
+        "individual": {
+            "valid_ingangsdatums": ["01-09", "01-10"]
+        }
+    },
     "excluded_data_points": [],
     "ensemble_override_cumulative": [],
     "exclude_from_combined": [],

--- a/src/studentprognose/strategies/individual.py
+++ b/src/studentprognose/strategies/individual.py
@@ -60,10 +60,16 @@ def preprocess_individual_data(data: pd.DataFrame, numerus_fixus_list: list[str]
 
     data[c.origin] = data.apply(lambda x: get_herkomst(x["Nationaliteit"], x["EER"]), axis=1)
 
-    data = data[
-        data["Ingangsdatum"].str.contains("01-09-")
-        | data["Ingangsdatum"].str.contains("01-10-")
-    ]
+    valid_ingangsdatums = (
+        config.get("preprocessing", {})
+        .get("individual", {})
+        .get("valid_ingangsdatums", ["01-09", "01-10"])
+    )
+    ingangsdatum = data["Ingangsdatum"].astype(str)
+    mask = pd.Series(False, index=data.index)
+    for prefix in valid_ingangsdatums:
+        mask |= ingangsdatum.str.startswith(f"{prefix}-")
+    data = data[mask]
 
     data["is_numerus_fixus"] = (
         data[c.programme].isin(numerus_fixus_list)

--- a/tests/studentprognose/test_preprocessing_config.py
+++ b/tests/studentprognose/test_preprocessing_config.py
@@ -1,0 +1,172 @@
+"""Tests voor preprocessing-configuratie, met name valid_ingangsdatums."""
+
+import json
+
+import pandas as pd
+import pytest
+
+from studentprognose.config import load_configuration
+from studentprognose.strategies.individual import preprocess_individual_data
+
+
+# ---------------------------------------------------------------------------
+# Validatie via load_configuration
+# ---------------------------------------------------------------------------
+
+class TestValidIngangsdatumsValidation:
+    def test_default_loads(self, tmp_path):
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps({}))
+        result = load_configuration(str(f))
+        assert result["preprocessing"]["individual"]["valid_ingangsdatums"] == [
+            "01-09",
+            "01-10",
+        ]
+
+    def test_custom_list_overrides_default(self, tmp_path):
+        f = tmp_path / "configuration.json"
+        f.write_text(
+            json.dumps(
+                {"preprocessing": {"individual": {"valid_ingangsdatums": ["01-02"]}}}
+            )
+        )
+        result = load_configuration(str(f))
+        assert result["preprocessing"]["individual"]["valid_ingangsdatums"] == ["01-02"]
+
+    def test_empty_list_exits(self, tmp_path):
+        f = tmp_path / "configuration.json"
+        f.write_text(
+            json.dumps(
+                {"preprocessing": {"individual": {"valid_ingangsdatums": []}}}
+            )
+        )
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_non_list_exits(self, tmp_path):
+        f = tmp_path / "configuration.json"
+        f.write_text(
+            json.dumps(
+                {"preprocessing": {"individual": {"valid_ingangsdatums": "01-09"}}}
+            )
+        )
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_non_string_element_exits(self, tmp_path):
+        f = tmp_path / "configuration.json"
+        f.write_text(
+            json.dumps(
+                {"preprocessing": {"individual": {"valid_ingangsdatums": [1, 2]}}}
+            )
+        )
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+    def test_preprocessing_not_a_dict_exits(self, tmp_path):
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps({"preprocessing": "not-a-dict"}))
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(str(f))
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Strategy filtert volgens config
+# ---------------------------------------------------------------------------
+
+def _row(ingangsdatum: str, sleutel: int = 1) -> dict:
+    return {
+        "Sleutel": sleutel,
+        "Datum Verzoek Inschr": "03-10-2019",
+        "Ingangsdatum": ingangsdatum,
+        "Collegejaar": 2020,
+        "Datum intrekking vooraanmelding": None,
+        "Inschrijfstatus": "Ingeschreven",
+        "Faculteit": "FSW",
+        "Examentype": "Propedeuse Bachelor",
+        "Croho": "Psychologie",
+        "Croho groepeernaam": "B Psychologie",
+        "Eerstejaars croho jaar": 2020,
+        "Is eerstejaars croho opleiding": 1,
+        "Is hogerejaars": 0,
+        "BBC ontvangen": 0,
+        "Nationaliteit": "Nederlandse",
+        "EER": "N",
+        "Aantal studenten": 1,
+    }
+
+
+def _cfg(valid_ingangsdatums=None):
+    cfg = {
+        "column_roles": {
+            "programme": "Croho groepeernaam",
+            "academic_year": "Collegejaar",
+            "exam_type": "Examentype",
+            "origin": "Herkomst",
+            "faculty": "Faculteit",
+            "week": "Weeknummer",
+            "enrollment_status": "Inschrijfstatus",
+            "cancellation_date": "Datum intrekking vooraanmelding",
+            "student_count": "Aantal_studenten",
+        }
+    }
+    if valid_ingangsdatums is not None:
+        cfg["preprocessing"] = {
+            "individual": {"valid_ingangsdatums": valid_ingangsdatums}
+        }
+    return cfg
+
+
+class TestPreprocessHonorsValidIngangsdatums:
+    def test_default_keeps_september_and_october(self):
+        df = pd.DataFrame(
+            [
+                _row("01-09-2020", sleutel=1),
+                _row("01-10-2020", sleutel=2),
+                _row("01-02-2020", sleutel=3),
+            ]
+        )
+        result = preprocess_individual_data(df, [], _cfg())
+        # default = ["01-09", "01-10"] → februari valt weg
+        assert len(result) == 2
+
+    def test_custom_list_keeps_february(self):
+        df = pd.DataFrame(
+            [
+                _row("01-09-2020", sleutel=1),
+                _row("01-02-2020", sleutel=2),
+            ]
+        )
+        result = preprocess_individual_data(
+            df, [], _cfg(valid_ingangsdatums=["01-02"])
+        )
+        # alleen februari toegelaten
+        assert len(result) == 1
+
+    def test_multiple_prefixes(self):
+        df = pd.DataFrame(
+            [
+                _row("01-09-2020", sleutel=1),
+                _row("01-02-2020", sleutel=2),
+                _row("15-08-2020", sleutel=3),
+            ]
+        )
+        result = preprocess_individual_data(
+            df, [], _cfg(valid_ingangsdatums=["01-09", "01-02"])
+        )
+        assert len(result) == 2
+
+    def test_prefix_matches_only_on_day_month_boundary(self):
+        # "01-09-" mag niet matchen op "11-09-2020" — startswith met '-' suffix.
+        df = pd.DataFrame(
+            [
+                _row("01-09-2020", sleutel=1),
+                _row("11-09-2020", sleutel=2),
+            ]
+        )
+        result = preprocess_individual_data(df, [], _cfg())
+        assert len(result) == 1


### PR DESCRIPTION
## Summary
- Vervangt hardgecodeerde `"01-09-"`/`"01-10-"` filter in `src/studentprognose/strategies/individual.py` door een lookup op `preprocessing.individual.valid_ingangsdatums`.
- Default blijft `["01-09", "01-10"]`; instellingen met afwijkende startdatums (bv. februari-instroom) kunnen dit overschrijven in `configuration.json`.
- Voegt validatie toe in `config.py` (niet-lege lijst van strings) en documenteert de optie in `docs/configuratie.md` + `docs/je-data-voorbereiden.md`.

Closes #180.

## Test plan
- [x] `uv run pytest` — 284 passed (10 nieuwe tests in `test_preprocessing_config.py`)
- [x] `ruff check` — alle gewijzigde files clean
- [x] Default-gedrag bevestigd: september + oktober worden behouden, andere datums vallen weg
- [x] Custom config bevestigd: bv. `["01-02"]` laat alleen februari-instroom door
- [x] Edge case: `"01-09-"` matcht niet meer per ongeluk op `"11-09-2020"` (gebruik `startswith` met `-`-suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)