### PR TITLE
Filter status A-rijen in ETL om deling door nul te voorkomen

### DIFF
--- a/data/input_raw/telbestanden/telbestandY2016W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;30;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;29;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;4;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;20;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;24;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;19;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;16;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;17;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;3;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;9;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;3;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;5;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;24;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;14;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;9;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;5;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;7;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;5;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;2;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;30;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;29;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;4;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;20;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;24;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;19;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;16;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;17;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;3;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;9;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;3;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;5;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;24;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;14;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;9;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;5;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;7;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;5;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;2;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;33;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;6;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;3;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;36;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;5;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;28;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;23;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;18;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;20;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;10;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;3;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;7;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;6;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;7;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;28;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;17;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;9;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;6;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;12;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;8;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;5;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;3;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;33;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;6;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;3;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;36;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;5;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;28;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;23;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;18;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;20;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;10;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;3;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;7;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;6;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;7;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;28;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;17;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;9;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;6;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;12;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;8;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;5;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;3;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;46;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;9;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;4;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;38;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;5;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;3;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;36;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;28;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;24;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;22;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;13;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;3;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;8;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;11;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;7;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;8;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;31;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;18;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;19;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;11;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;6;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;9;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;6;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;3;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;46;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;9;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;4;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;38;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;5;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;3;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;36;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;28;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;24;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;22;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;13;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;3;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;8;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;11;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;7;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;8;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;31;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;18;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;19;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;11;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;6;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;9;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;6;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;3;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;51;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;9;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;4;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;49;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;3;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;40;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;35;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;26;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;5;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;16;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;3;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;10;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;5;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;10;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;9;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;36;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;22;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;21;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;12;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;7;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;10;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;7;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;3;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;51;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;9;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;4;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;49;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;3;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;40;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;35;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;26;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;5;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;16;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;3;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;10;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;5;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;10;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;9;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;36;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;22;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;21;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;12;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;7;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;10;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;7;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;3;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;60;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;10;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;5;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;50;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;9;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;4;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;37;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;16;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;39;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;31;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;31;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;7;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;3;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;19;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;4;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;12;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;6;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;11;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;3;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;11;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;24;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;24;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;14;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;8;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;11;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;7;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;4;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;60;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;10;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;5;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;50;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;9;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;4;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;37;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;16;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;39;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;31;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;31;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;7;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;3;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;19;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;4;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;12;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;6;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;11;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;3;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;11;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;24;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;24;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;14;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;8;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;11;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;7;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;4;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;69;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;13;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;6;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;63;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;10;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;4;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;46;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;20;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;52;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;36;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;33;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;8;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;3;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;23;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;5;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;16;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;7;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;17;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;13;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;3;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;11;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;42;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;25;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;26;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;15;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;9;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;12;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;8;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;4;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;69;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;13;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;6;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;63;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;10;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;4;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;46;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;20;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;52;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;36;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;33;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;8;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;3;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;23;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;5;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;16;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;7;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;17;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;13;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;3;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;11;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;42;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;25;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;26;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;15;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;9;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;12;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;8;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;4;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;85;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;13;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;71;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;12;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;5;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;52;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;21;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;57;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;50;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;43;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;40;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;8;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;4;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;25;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;5;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;17;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;8;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;19;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;15;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;4;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;13;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;48;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;28;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;28;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;17;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;9;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;9;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;5;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;85;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;13;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;71;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;12;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;5;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;52;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;21;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;57;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;50;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;43;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;40;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;8;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;4;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;25;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;5;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;17;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;8;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;19;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;15;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;4;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;13;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;1;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;48;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;28;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;28;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;17;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;9;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;9;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;5;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;92;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;16;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;79;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;13;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;6;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;60;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;67;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;56;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;47;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;45;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;10;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;4;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;29;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;6;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;21;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;9;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;17;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;4;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;16;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;31;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;19;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;11;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;15;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;10;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;5;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;92;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;16;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;79;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;13;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;6;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;60;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;67;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;56;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;47;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;45;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;10;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;4;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;29;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;6;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;21;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;9;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;17;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;4;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;16;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;31;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;19;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;11;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;15;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;10;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;5;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;104;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;19;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;9;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;90;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;15;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;7;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;71;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;27;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;72;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;64;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;53;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;48;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;11;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;4;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;34;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;6;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;22;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;10;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;25;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;19;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;5;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;17;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;58;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;34;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;21;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;11;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;16;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;11;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;5;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;104;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;19;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;9;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;90;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;15;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;7;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;71;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;27;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;72;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;64;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;53;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;48;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;11;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;4;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;34;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;6;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;22;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;10;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;25;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;19;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;5;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;17;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;58;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;34;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;21;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;11;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;16;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;11;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;5;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;118;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;21;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;10;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;100;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;17;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;7;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;73;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;84;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;29;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;72;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;57;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;12;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;5;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;37;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;7;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;27;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;11;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;26;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;21;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;5;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;19;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;4;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;63;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;28;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;36;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;22;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;12;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;17;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;11;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;6;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;118;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;21;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;10;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;100;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;17;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;7;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;73;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;84;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;29;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;72;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;57;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;12;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;5;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;37;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;7;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;27;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;11;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;26;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;21;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;5;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;19;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;4;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;63;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;28;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;36;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;22;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;12;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;17;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;11;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;6;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;134;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;24;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;11;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;110;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;19;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;9;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;84;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;38;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;93;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;31;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;82;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;67;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;60;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;14;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;6;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;41;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;8;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;31;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;13;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;25;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;6;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;21;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;4;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;68;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;40;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;39;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;23;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;13;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;18;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;12;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;7;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;134;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;24;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;11;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;110;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;19;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;9;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;84;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;38;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;93;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;31;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;82;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;67;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;60;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;14;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;6;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;41;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;8;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;31;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;13;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;25;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;6;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;21;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;4;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;2;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;68;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;40;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;39;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;23;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;13;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;18;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;12;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;7;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;149;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;27;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;12;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;124;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;22;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;9;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;94;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;41;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;105;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;88;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;75;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;68;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;15;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;6;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;46;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;9;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;35;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;14;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;6;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;27;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;7;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;23;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;73;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;41;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;25;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;14;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;32;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;20;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;7;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;149;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;27;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;12;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;124;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;22;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;9;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;94;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;41;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;105;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;88;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;75;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;68;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;15;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;6;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;46;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;9;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;35;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;14;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;6;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;27;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;7;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;23;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;73;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;41;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;25;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;14;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;32;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;20;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;7;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;164;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;30;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;13;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;136;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;24;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;10;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;102;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;47;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;113;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;40;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;97;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;82;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;74;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;17;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;7;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;52;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;10;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;3;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;37;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;15;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;35;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;29;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;8;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;4;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;26;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;78;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;47;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;44;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;27;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;15;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;21;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;8;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;164;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;30;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;13;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;136;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;24;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;10;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;102;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;47;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;113;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;40;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;97;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;82;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;74;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;17;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;7;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;52;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;10;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;3;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;37;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;15;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;35;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;29;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;8;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;4;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;26;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;78;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;47;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;44;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;27;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;15;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;21;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;8;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;181;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;33;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;15;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;153;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;26;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;12;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;114;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;49;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;26;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;121;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;105;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;89;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;84;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;19;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;8;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;58;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;11;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;3;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;41;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;17;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;32;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;9;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;29;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;6;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;81;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;49;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;36;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;47;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;28;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;16;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;22;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;15;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;8;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;181;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;33;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;15;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;153;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;26;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;12;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;114;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;49;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;26;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;121;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;105;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;89;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;84;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;19;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;8;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;58;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;11;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;3;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;41;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;17;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;32;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;9;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;29;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;6;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;81;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;49;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;36;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;47;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;28;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;16;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;22;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;15;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;8;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;203;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;37;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;16;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;163;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;29;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;13;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;121;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;55;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;29;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;133;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;47;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;117;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;97;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;88;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;21;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;8;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;65;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;11;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;3;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;45;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;18;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;8;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;43;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;36;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;9;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;32;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;7;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;88;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;38;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;49;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;30;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;17;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;24;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;16;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;8;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;203;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;37;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;16;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;163;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;29;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;13;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;121;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;55;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;29;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;133;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;47;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;117;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;97;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;88;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;21;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;8;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;65;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;11;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;3;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;45;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;18;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;8;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;43;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;36;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;9;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;32;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;7;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;3;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;88;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;38;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;49;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;30;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;17;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;24;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;16;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;8;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;213;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;41;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;18;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;182;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;31;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;14;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;138;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;59;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;140;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;52;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;128;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;95;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;23;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;9;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;68;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;12;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;50;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;20;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;8;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;47;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;39;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;10;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;33;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;7;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;92;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;52;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;32;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;18;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;40;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;25;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;17;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;9;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;213;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;41;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;18;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;182;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;31;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;14;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;138;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;59;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;140;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;52;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;128;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;95;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;23;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;9;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;68;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;12;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;50;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;20;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;8;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;47;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;39;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;10;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;33;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;7;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;92;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;52;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;32;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;18;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;40;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;25;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;17;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;9;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;231;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;43;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;19;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;193;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;35;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;15;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;145;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;65;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;34;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;152;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;139;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;16;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;112;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;105;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;24;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;10;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;75;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;13;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;54;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;21;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;9;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;51;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;42;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;11;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;6;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;36;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;8;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;98;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;54;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;34;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;19;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;43;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;27;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;18;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;10;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;231;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;43;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;19;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;193;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;35;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;15;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;145;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;65;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;34;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;152;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;139;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;16;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;112;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;105;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;24;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;10;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;75;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;13;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;54;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;21;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;9;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;51;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;42;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;11;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;6;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;36;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;8;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;98;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;54;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;34;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;19;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;43;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;27;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;18;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;10;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;249;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;46;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;21;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;210;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;38;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;16;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;161;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;71;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;36;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;166;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;60;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;147;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;122;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;112;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;26;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;11;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;81;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;15;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;60;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;23;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;10;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;55;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;44;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;12;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;6;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;39;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;9;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;105;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;57;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;36;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;20;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;37;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;27;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;19;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;10;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;249;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;46;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;21;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;210;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;38;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;16;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;161;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;71;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;36;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;166;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;60;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;147;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;122;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;112;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;26;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;11;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;81;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;15;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;60;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;23;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;10;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;55;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;44;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;12;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;6;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;39;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;9;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;105;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;57;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;36;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;20;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;37;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;27;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;19;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;10;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;273;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;51;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;22;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;226;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;40;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;17;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;170;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;77;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;174;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;64;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;158;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;130;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;119;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;28;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;11;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;89;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;15;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;5;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;65;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;25;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;11;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;59;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;49;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;13;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;43;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;9;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;110;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;64;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;47;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;60;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;37;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;21;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;29;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;20;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;11;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;273;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;51;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;22;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;226;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;40;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;17;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;170;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;77;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;174;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;64;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;158;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;130;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;119;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;28;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;11;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;89;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;15;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;5;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;65;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;25;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;11;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;59;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;49;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;13;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;43;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;9;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;4;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;110;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;64;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;47;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;60;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;37;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;21;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;29;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;20;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;11;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;294;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;54;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;23;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;248;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;44;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;19;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;184;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;81;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;43;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;189;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;168;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;139;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;130;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;30;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;12;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;94;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;16;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;5;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;69;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;26;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;11;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;62;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;52;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;14;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;45;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;10;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;5;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;114;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;62;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;39;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;21;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;30;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;21;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;11;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;294;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;54;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;23;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;248;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;44;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;19;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;184;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;81;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;43;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;189;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;168;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;139;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;130;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;30;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;12;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;94;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;16;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;5;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;69;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;26;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;11;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;62;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;52;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;14;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;45;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;10;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;5;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;114;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;62;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;39;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;21;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;30;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;21;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;11;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;310;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;59;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;25;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;262;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;46;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;20;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;194;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;87;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;45;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;200;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;27;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;180;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;147;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;135;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;32;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;13;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;101;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;17;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;5;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;75;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;28;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;12;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;67;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;55;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;15;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;7;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;48;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;11;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;5;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;119;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;71;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;65;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;40;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;23;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;42;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;52;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;32;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;21;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;11;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;310;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;59;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;25;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;262;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;46;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;20;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;194;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;87;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;45;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;200;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;27;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;180;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;147;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;135;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;32;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;13;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;101;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;17;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;5;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;75;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;28;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;12;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;67;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;55;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;15;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;7;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;48;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;11;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;5;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;119;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;71;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;65;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;40;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;23;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;42;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;52;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;32;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;21;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;11;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;328;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;62;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;27;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;278;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;50;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;21;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;206;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;93;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;214;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;78;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;191;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;157;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;145;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;34;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;14;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;107;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;19;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;6;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;80;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;30;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;13;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;70;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;59;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;16;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;8;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;51;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;12;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;123;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;53;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;68;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;42;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;24;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;33;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;22;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;12;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;328;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;62;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;27;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;278;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;50;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;21;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;206;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;93;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;214;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;78;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;191;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;157;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;145;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;34;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;14;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;107;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;19;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;6;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;80;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;30;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;13;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;70;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;59;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;16;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;8;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;51;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;12;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;123;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;53;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;68;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;42;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;24;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;33;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;22;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;12;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;349;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;67;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;29;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;297;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;53;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;23;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;218;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;100;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;224;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;83;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;201;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;168;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;154;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;36;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;15;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;116;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;20;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;6;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;86;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;32;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;14;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;76;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;61;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;17;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;9;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;54;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;12;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;128;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;70;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;44;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;24;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;56;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;34;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;23;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;12;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;349;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;67;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;29;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;297;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;53;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;23;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;218;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;100;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;224;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;83;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;201;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;168;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;154;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;36;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;15;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;116;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;20;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;6;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;86;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;32;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;14;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;76;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;61;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;17;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;9;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;54;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;12;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;128;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;70;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;44;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;24;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;56;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;34;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;23;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;12;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;374;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;70;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;30;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;308;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;56;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;24;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;231;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;108;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;239;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;88;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;213;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;177;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;164;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;38;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;15;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;122;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;21;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;6;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;90;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;33;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;15;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;78;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;66;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;18;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;9;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;56;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;13;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;134;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;79;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;72;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;45;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;25;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;35;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;24;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;13;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;374;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;70;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;30;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;308;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;56;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;24;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;231;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;108;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;239;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;88;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;213;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;177;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;164;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;38;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;15;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;122;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;21;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;6;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;90;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;33;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;15;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;78;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;66;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;18;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;9;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;56;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;13;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;134;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;79;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;72;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;45;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;25;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;35;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;24;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;13;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;394;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;75;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;32;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;330;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;59;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;25;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;244;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;113;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;251;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;224;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;186;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;173;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;41;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;16;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;129;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;22;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;7;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;95;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;35;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;15;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;83;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;69;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;19;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;9;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;60;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;14;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;82;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;59;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;74;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;47;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;26;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;60;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;36;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;25;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;13;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;394;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;75;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;32;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;330;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;59;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;25;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;244;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;113;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;251;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;224;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;186;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;173;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;41;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;16;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;129;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;22;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;7;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;95;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;35;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;15;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;83;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;69;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;19;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;9;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;60;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;14;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;6;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;82;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;59;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;74;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;47;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;26;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;60;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;36;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;25;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;13;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;414;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;79;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;34;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;352;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;63;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;27;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;254;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;116;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;59;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;265;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;234;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;29;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;196;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;181;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;42;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;17;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;136;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;23;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;7;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;101;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;37;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;16;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;86;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;72;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;20;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;10;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;63;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;14;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;7;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;140;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;61;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;76;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;48;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;27;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;37;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;25;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;14;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;414;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;79;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;34;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;352;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;63;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;27;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;254;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;116;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;59;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;265;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;234;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;29;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;196;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;181;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;42;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;17;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;136;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;23;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;7;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;101;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;37;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;16;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;86;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;72;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;20;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;10;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;63;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;14;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;7;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;140;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;61;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;76;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;48;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;27;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;37;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;25;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;14;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;431;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;82;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;35;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;365;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;65;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;28;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;267;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;125;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;275;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;102;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;244;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;204;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;188;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;45;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;18;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;144;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;24;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;7;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;106;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;38;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;17;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;91;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;76;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;21;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;11;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;65;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;15;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;7;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;146;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;79;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;49;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;27;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;51;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;39;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;26;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;14;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;431;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;82;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;35;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;365;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;65;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;28;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;267;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;125;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;275;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;102;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;244;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;204;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;188;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;45;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;18;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;144;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;24;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;7;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;106;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;38;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;17;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;91;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;76;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;21;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;11;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;65;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;15;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;7;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;146;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;79;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;49;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;27;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;51;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;39;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;26;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;14;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;453;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;86;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;37;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;381;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;68;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;29;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;278;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;130;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;285;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;40;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;258;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;215;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;193;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;46;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;18;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;149;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;25;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;8;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;112;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;40;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;18;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;95;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;78;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;22;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;11;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;68;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;16;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;7;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;148;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;88;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;80;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;51;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;28;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;65;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;39;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;27;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;14;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;453;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;86;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;37;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;381;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;68;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;29;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;278;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;130;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;285;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;40;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;258;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;215;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;193;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;46;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;18;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;149;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;25;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;8;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;112;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;40;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;18;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;95;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;78;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;22;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;11;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;68;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;16;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;7;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;148;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;88;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;80;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;51;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;28;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;65;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;39;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;27;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;14;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;471;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;90;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;38;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;399;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;72;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;30;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;294;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;134;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;67;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;297;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;111;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;269;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;222;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;204;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;49;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;19;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;156;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;26;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;8;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;116;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;42;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;19;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;98;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;82;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;23;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;11;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;71;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;17;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;154;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;90;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;81;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;52;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;29;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;40;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;27;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;15;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;471;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;90;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;38;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;399;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;72;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;30;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;294;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;134;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;67;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;297;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;111;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;269;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;222;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;204;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;49;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;19;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;156;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;26;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;8;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;116;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;42;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;19;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;98;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;82;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;23;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;11;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;71;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;17;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;154;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;90;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;81;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;52;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;29;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;40;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;27;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;15;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;490;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;94;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;40;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;416;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;74;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;32;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;301;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;140;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;305;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;272;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;231;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;213;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;51;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;20;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;164;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;27;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;8;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;121;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;43;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;19;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;85;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;24;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;12;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;73;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;17;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;83;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;53;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;29;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;68;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;41;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;28;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;15;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;490;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;94;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;40;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;416;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;74;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;32;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;301;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;140;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;305;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;272;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;231;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;213;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;51;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;20;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;164;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;27;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;8;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;121;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;43;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;19;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;85;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;24;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;12;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;73;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;17;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;83;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;53;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;29;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;68;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;41;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;28;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;15;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;509;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;97;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;41;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;423;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;77;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;33;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;314;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;318;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;119;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;281;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;238;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;219;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;52;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;21;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;169;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;28;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;127;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;45;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;20;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;106;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;87;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;25;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;12;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;76;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;18;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;85;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;54;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;30;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;42;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;28;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;16;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;509;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;97;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;41;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;423;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;77;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;33;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;314;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;318;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;119;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;281;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;238;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;219;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;52;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;21;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;169;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;28;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;127;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;45;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;20;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;106;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;87;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;25;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;12;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;76;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;18;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;85;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;54;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;30;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;42;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;28;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;16;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;523;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;101;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;42;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;438;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;80;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;34;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;320;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;74;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;327;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;289;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;243;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;224;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;54;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;21;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;175;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;29;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;132;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;46;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;20;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;108;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;90;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;25;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;78;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;18;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;163;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;95;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;86;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;55;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;30;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;56;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;42;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;29;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;16;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;523;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;101;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;42;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;438;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;80;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;34;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;320;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;74;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;327;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;289;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;243;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;224;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;54;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;21;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;175;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;29;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;132;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;46;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;20;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;108;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;90;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;25;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;78;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;18;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;8;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;163;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;95;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;86;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;55;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;30;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;56;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;42;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;29;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;16;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;540;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;104;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;43;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;456;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;82;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;34;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;329;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;154;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;76;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;339;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;128;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;298;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;251;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;228;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;55;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;22;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;180;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;30;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;133;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;47;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;21;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;111;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;93;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;26;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;80;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;19;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;97;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;70;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;88;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;31;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;43;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;29;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;16;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;540;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;104;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;43;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;456;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;82;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;34;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;329;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;154;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;76;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;339;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;128;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;298;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;251;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;228;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;55;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;22;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;180;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;30;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;133;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;47;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;21;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;111;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;93;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;26;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;80;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;19;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;97;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;70;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;88;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;31;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;43;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;29;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;16;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;551;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;108;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;45;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;466;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;84;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;36;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;334;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;160;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;340;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;306;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;255;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;234;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;57;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;22;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;185;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;30;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;139;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;49;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;22;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;114;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;95;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;27;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;81;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;20;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;166;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;88;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;43;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;551;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;108;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;45;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;466;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;84;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;36;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;334;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;160;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;340;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;306;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;255;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;234;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;57;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;22;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;185;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;30;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;9;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;139;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;49;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;22;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;114;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;95;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;27;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;81;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;20;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;166;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;88;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;43;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;563;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;108;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;45;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;481;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;87;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;37;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;341;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;347;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;133;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;310;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;261;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;241;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;58;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;22;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;189;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;31;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;142;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;49;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;22;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;96;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;28;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;83;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;20;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;170;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;88;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;563;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;108;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;45;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;481;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;87;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;37;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;341;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;347;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;133;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;310;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;261;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;241;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;58;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;22;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;189;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;31;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;142;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;49;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;22;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;96;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;28;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;13;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;83;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;20;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;170;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;88;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;573;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;111;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;46;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;486;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;88;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;37;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;347;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;350;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;135;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;313;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;264;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;241;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;59;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;23;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;193;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;31;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;144;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;50;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;22;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;97;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;28;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;14;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;84;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;20;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;170;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;89;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;573;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;111;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;46;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;486;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;88;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;37;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;347;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;350;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;135;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;313;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;264;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;241;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;59;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;23;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;193;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;31;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;144;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;50;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;22;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;97;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;28;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;14;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;84;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;20;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;170;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;89;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;56;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;574;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;112;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;47;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;488;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;89;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;38;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;354;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;137;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;315;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;267;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;241;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;59;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;23;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;196;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;32;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;147;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;50;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;23;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;117;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;99;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;28;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;14;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;85;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;21;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;170;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;89;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;57;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;574;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;112;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;47;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;488;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;89;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;38;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;354;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;137;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;315;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;267;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;241;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;59;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;23;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;196;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;32;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;147;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;50;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;23;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;117;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;99;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;28;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;14;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;85;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;21;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;170;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;89;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;57;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;580;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;114;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;47;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;494;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;91;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;38;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;354;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;138;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;315;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;267;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;244;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;60;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;23;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;198;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;32;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;147;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;50;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;23;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;118;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;99;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;29;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;14;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;85;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;21;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;171;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;89;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;57;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;580;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;114;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;47;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;494;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;91;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;38;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;354;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;138;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;315;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;267;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;244;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;60;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;23;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;198;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;32;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;10;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;147;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;50;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;23;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;118;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;99;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;29;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;14;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;85;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;21;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;9;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;171;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;89;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;57;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;32;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;44;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;30;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;5;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;5;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;3;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;3;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;3;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;7;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;3;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;12;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;4;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;4;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;2;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;12;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;4;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;4;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;2;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;7;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;12;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;6;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;4;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;3;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;7;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;12;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;6;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;4;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;3;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;9;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;1;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;12;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;6;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;7;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;3;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;2;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;9;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;12;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;0;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;6;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;0;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;7;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;3;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;2;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;10;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;2;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;1;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;17;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;15;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;7;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;10;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;7;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;8;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;4;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;3;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;10;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;17;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;15;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;7;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;2;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;10;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;7;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;8;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;4;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;3;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;17;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;2;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;17;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;4;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;12;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;7;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;5;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;3;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;15;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;10;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;6;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;3;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;4;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;17;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;17;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;4;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;12;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;7;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;5;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;2;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;3;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;15;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;10;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;6;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;3;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;4;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;19;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;2;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;21;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;3;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;15;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;11;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;5;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;3;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;4;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;9;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;11;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;6;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;4;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;5;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;3;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;2;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;19;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;21;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;3;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;15;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;11;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;5;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;1;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;3;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;0;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;4;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;0;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;9;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;11;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;6;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;4;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;5;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;3;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;2;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2016W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2016W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2016;B;56604;B Psychologie;SOW;N;N;N;21;1.29
-21PB;2016;B;56604;B Psychologie;SOW;E;N;N;3;1.29
-21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;24;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;4;1.29
-21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.29
-21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.29
-21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29
-21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29
-21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29
-21PB;2016;B;56981;B Politicologie;MAN;N;N;N;12;1.29
-21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29
-21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;8;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;2;1.29
-21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;4;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;3;1.29
-21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;7;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.29
-21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;4;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;1;1.29
-21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;N;N;N;5;1.29
-21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29
-21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1
-21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;12;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.1
-21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.1
-21PB;2016;M;60300;M Informatica;SOW;N;N;N;12;1.1
-21PB;2016;M;60300;M Informatica;SOW;E;N;N;7;1.1
-21PB;2016;M;60300;M Informatica;SOW;R;N;N;4;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1
-21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.1
-21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;6;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;4;1.1
-21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;2;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2016;B;56604;B Psychologie;SOW;N;N;N;21;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;E;N;N;3;1.29;V
+21PB;2016;B;56604;B Psychologie;SOW;R;N;N;2;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;N;N;N;24;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;E;N;N;4;1.29;V
+21PB;2016;B;56551;B Geneeskunde;MED;R;N;N;1;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.29;V
+21PB;2016;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.29;V
+21PB;2016;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.29;V
+21PB;2016;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.29;V
+21PB;2016;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;N;N;N;12;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;E;N;N;2;1.29;V
+21PB;2016;B;56981;B Politicologie;MAN;R;N;N;1;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;N;N;N;8;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;E;N;N;2;1.29;V
+21PB;2016;B;56034;B Geschiedenis;FdL;R;N;N;0;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;N;N;N;4;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;E;N;N;3;1.29;V
+21PB;2016;B;56980;B Wiskunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;N;N;N;7;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.29;V
+21PB;2016;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;N;N;N;4;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;E;N;N;1;1.29;V
+21PB;2016;B;56857;B Scheikunde;FNWI;R;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;N;N;N;5;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;E;N;N;1;1.29;V
+21PB;2016;B;56081;B Filosofie;FdL;R;N;N;0;1.29;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1;V
+21PB;2016;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;N;N;N;12;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.1;V
+21PB;2016;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;N;N;N;12;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;E;N;N;7;1.1;V
+21PB;2016;M;60300;M Informatica;SOW;R;N;N;4;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1;V
+21PB;2016;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.1;V
+21PB;2016;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;N;N;N;6;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;E;N;N;4;1.1;V
+21PB;2016;M;60815;M Linguistiek;FdL;R;N;N;2;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2017W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;19;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;6;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;2;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;33;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;4;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;17;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;16;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;22;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;10;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;10;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;3;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;11;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;10;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;3;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;6;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;4;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;30;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;17;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;10;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;6;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;8;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;5;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;3;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;19;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;6;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;2;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;33;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;4;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;17;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;16;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;22;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;10;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;10;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;3;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;11;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;10;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;3;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;6;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;4;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;30;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;17;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;10;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;6;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;8;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;5;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;3;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;26;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;8;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;3;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;47;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;6;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;3;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;29;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;22;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;22;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;12;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;4;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;15;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;11;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;3;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;7;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;6;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;21;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;18;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;11;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;6;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;12;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;9;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;5;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;3;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;26;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;8;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;3;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;47;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;6;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;3;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;29;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;22;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;22;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;12;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;4;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;15;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;11;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;3;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;7;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;6;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;21;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;18;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;11;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;6;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;12;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;9;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;5;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;3;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;37;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;10;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;3;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;50;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;6;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;3;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;31;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;26;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;25;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;16;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;5;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;15;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;14;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;7;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;7;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;25;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;21;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;13;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;8;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;10;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;6;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;4;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;37;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;10;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;3;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;50;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;6;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;3;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;31;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;26;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;25;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;16;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;5;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;15;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;14;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;7;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;7;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;25;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;21;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;13;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;8;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;10;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;6;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;4;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;43;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;12;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;4;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;61;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;8;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;4;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;40;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;14;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;30;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;13;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;26;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;17;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;5;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;19;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;3;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;15;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;5;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;9;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;7;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;43;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;27;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;23;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;15;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;8;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;12;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;8;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;4;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;43;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;12;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;4;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;61;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;8;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;4;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;40;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;14;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;30;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;13;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;26;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;17;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;5;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;19;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;3;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;15;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;5;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;9;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;7;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;43;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;27;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;23;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;15;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;8;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;12;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;8;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;4;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;53;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;13;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;5;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;69;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;9;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;4;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;50;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;15;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;35;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;34;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;23;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;22;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;7;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;3;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;21;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;3;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;19;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;6;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;3;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;17;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;10;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;3;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;9;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;26;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;16;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;9;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;8;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;4;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;53;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;13;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;5;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;69;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;9;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;4;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;50;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;15;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;35;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;34;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;23;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;22;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;7;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;3;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;21;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;3;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;19;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;6;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;3;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;17;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;10;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;3;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;9;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;26;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;16;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;9;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;8;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;4;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;59;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;15;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;6;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;78;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;11;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;5;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;51;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;41;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;38;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;26;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;8;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;3;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;24;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;4;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;21;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;7;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;3;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;11;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;3;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;11;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;54;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;36;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;28;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;18;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;10;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;9;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;5;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;59;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;15;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;6;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;78;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;11;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;5;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;51;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;41;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;38;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;26;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;8;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;3;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;24;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;4;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;21;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;7;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;3;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;11;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;3;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;11;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;54;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;36;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;28;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;18;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;10;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;9;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;5;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;71;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;18;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;6;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;92;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;13;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;6;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;59;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;22;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;47;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;33;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;30;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;9;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;4;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;28;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;5;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;26;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;8;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;12;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;4;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;12;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;59;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;38;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;31;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;20;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;11;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;15;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;10;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;5;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;71;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;18;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;6;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;92;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;13;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;6;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;59;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;22;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;47;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;33;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;30;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;9;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;4;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;28;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;5;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;26;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;8;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;12;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;4;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;12;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;1;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;59;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;38;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;31;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;20;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;11;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;15;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;10;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;5;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;83;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;20;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;8;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;100;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;14;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;7;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;68;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;24;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;23;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;48;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;38;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;35;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;10;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;4;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;35;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;5;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;27;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;10;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;22;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;15;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;4;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;14;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;4;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;64;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;34;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;22;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;12;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;17;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;11;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;6;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;83;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;20;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;8;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;100;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;14;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;7;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;68;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;24;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;23;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;48;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;38;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;35;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;10;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;4;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;35;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;5;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;27;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;10;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;22;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;15;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;4;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;14;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;4;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;64;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;34;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;22;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;12;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;17;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;11;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;6;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;92;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;22;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;9;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;108;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;17;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;7;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;79;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;59;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;57;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;42;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;39;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;11;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;5;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;37;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;6;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;31;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;10;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;5;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;16;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;5;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;15;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;4;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;69;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;45;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;36;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;23;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;13;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;18;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;12;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;6;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;92;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;22;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;9;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;108;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;17;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;7;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;79;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;59;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;57;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;42;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;39;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;11;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;5;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;37;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;6;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;31;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;10;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;5;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;16;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;5;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;15;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;4;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;69;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;45;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;36;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;23;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;13;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;18;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;12;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;6;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;106;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;25;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;10;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;123;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;18;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;9;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;86;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;71;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;30;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;60;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;50;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;47;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;13;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;5;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;41;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;6;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;36;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;12;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;5;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;30;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;19;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;5;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;18;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;5;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;39;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;26;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;14;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;20;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;7;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;106;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;25;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;10;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;123;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;18;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;9;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;86;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;71;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;30;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;60;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;50;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;47;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;13;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;5;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;41;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;6;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;36;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;12;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;5;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;30;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;19;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;5;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;18;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;5;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;39;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;26;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;14;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;20;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;7;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;116;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;28;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;11;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;141;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;21;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;9;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;96;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;35;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;75;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;71;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;56;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;52;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;14;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;6;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;44;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;7;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;38;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;13;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;6;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;33;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;21;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;6;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;19;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;5;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;79;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;53;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;41;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;28;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;15;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;21;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;7;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;116;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;28;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;11;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;141;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;21;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;9;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;96;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;35;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;75;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;71;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;56;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;52;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;14;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;6;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;44;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;7;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;38;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;13;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;6;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;33;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;21;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;6;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;19;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;5;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;2;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;79;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;53;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;41;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;28;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;15;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;21;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;7;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;131;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;31;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;12;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;155;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;24;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;11;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;111;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;40;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;86;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;37;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;77;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;63;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;59;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;16;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;6;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;50;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;8;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;42;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;15;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;7;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;36;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;24;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;7;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;22;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;6;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;85;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;57;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;44;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;30;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;16;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;22;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;15;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;8;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;131;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;31;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;12;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;155;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;24;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;11;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;111;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;40;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;86;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;37;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;77;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;63;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;59;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;16;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;6;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;50;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;8;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;3;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;42;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;15;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;7;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;36;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;24;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;7;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;22;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;6;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;85;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;57;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;44;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;30;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;16;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;22;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;15;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;8;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;146;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;33;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;13;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;165;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;26;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;11;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;121;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;44;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;94;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;41;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;83;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;70;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;63;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;17;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;7;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;56;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;9;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;46;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;15;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;7;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;26;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;7;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;4;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;23;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;7;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;91;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;60;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;32;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;47;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;32;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;17;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;24;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;16;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;8;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;146;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;33;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;13;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;165;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;26;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;11;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;121;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;44;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;94;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;41;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;83;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;70;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;63;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;17;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;7;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;56;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;9;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;46;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;15;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;7;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;26;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;7;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;4;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;23;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;7;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;91;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;60;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;32;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;47;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;32;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;17;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;24;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;16;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;8;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;159;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;37;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;15;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;183;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;29;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;13;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;127;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;48;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;26;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;107;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;96;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;77;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;69;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;20;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;8;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;61;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;9;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;52;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;17;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;8;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;45;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;29;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;8;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;5;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;25;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;7;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;94;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;62;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;19;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;50;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;34;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;18;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;25;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;17;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;9;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;159;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;37;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;15;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;183;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;29;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;13;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;127;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;48;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;26;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;107;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;96;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;77;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;69;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;20;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;8;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;61;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;9;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;52;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;17;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;8;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;45;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;29;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;8;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;5;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;25;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;7;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;94;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;62;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;19;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;50;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;34;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;18;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;25;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;17;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;9;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;180;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;41;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;16;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;199;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;31;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;14;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;142;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;54;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;29;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;112;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;47;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;102;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;82;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;78;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;21;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;9;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;67;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;10;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;54;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;19;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;9;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;48;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;31;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;9;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;5;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;28;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;8;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;101;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;38;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;53;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;36;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;19;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;27;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;18;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;9;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;180;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;41;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;16;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;199;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;31;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;14;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;142;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;54;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;29;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;112;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;47;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;102;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;82;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;78;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;21;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;9;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;67;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;10;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;54;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;19;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;9;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;48;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;31;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;9;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;5;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;28;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;8;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;3;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;101;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;38;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;53;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;36;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;19;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;27;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;18;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;9;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;194;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;44;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;18;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;217;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;33;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;15;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;161;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;57;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;31;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;123;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;54;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;114;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;83;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;23;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;9;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;71;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;11;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;5;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;60;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;21;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;10;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;53;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;35;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;10;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;6;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;30;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;9;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;4;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;106;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;71;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;55;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;38;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;20;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;28;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;19;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;10;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;194;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;44;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;18;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;217;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;33;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;15;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;161;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;57;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;31;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;123;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;54;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;114;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;83;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;23;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;9;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;71;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;11;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;5;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;60;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;21;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;10;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;53;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;35;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;10;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;6;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;30;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;9;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;4;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;106;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;71;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;55;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;38;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;20;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;28;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;19;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;10;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;213;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;48;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;19;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;232;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;37;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;16;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;172;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;63;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;34;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;134;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;122;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;100;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;90;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;25;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;10;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;80;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;12;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;5;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;65;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;23;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;10;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;57;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;20;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;36;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;11;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;6;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;33;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;9;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;4;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;113;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;59;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;40;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;21;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;30;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;20;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;10;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;213;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;48;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;19;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;232;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;37;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;16;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;172;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;63;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;34;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;134;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;122;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;100;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;90;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;25;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;10;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;80;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;12;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;5;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;65;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;23;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;10;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;57;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;20;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;36;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;11;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;6;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;33;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;9;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;4;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;113;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;59;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;40;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;21;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;30;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;20;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;10;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;232;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;51;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;21;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;251;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;40;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;17;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;184;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;69;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;37;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;147;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;62;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;129;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;108;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;99;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;27;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;11;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;87;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;13;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;6;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;70;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;24;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;11;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;62;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;40;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;12;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;6;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;35;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;10;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;4;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;115;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;80;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;62;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;41;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;22;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;32;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;21;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;11;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;232;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;51;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;21;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;251;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;40;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;17;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;184;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;69;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;37;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;147;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;62;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;129;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;108;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;99;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;27;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;11;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;87;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;13;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;6;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;70;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;24;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;11;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;62;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;40;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;12;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;6;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;35;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;10;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;4;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;115;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;80;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;62;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;41;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;22;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;32;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;21;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;11;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;251;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;56;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;22;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;269;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;43;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;18;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;199;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;74;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;156;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;66;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;140;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;104;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;29;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;12;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;94;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;15;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;6;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;74;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;26;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;12;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;42;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;13;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;7;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;39;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;11;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;121;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;64;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;44;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;23;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;33;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;22;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;11;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;251;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;56;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;22;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;269;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;43;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;18;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;199;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;74;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;156;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;66;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;140;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;104;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;29;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;12;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;94;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;15;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;6;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;74;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;26;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;12;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;42;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;13;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;7;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;39;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;11;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;121;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;64;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;44;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;23;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;33;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;22;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;11;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;270;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;60;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;24;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;292;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;47;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;20;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;214;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;79;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;42;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;169;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;71;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;150;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;125;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;114;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;32;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;13;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;97;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;16;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;6;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;81;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;27;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;13;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;71;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;46;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;13;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;7;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;41;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;12;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;125;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;47;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;66;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;45;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;24;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;34;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;23;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;12;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;270;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;60;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;24;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;292;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;47;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;20;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;214;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;79;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;42;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;169;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;71;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;150;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;125;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;114;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;32;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;13;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;97;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;16;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;6;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;81;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;27;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;13;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;71;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;46;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;13;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;7;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;41;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;12;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;125;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;47;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;66;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;45;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;24;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;34;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;23;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;12;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;287;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;63;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;26;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;311;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;49;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;22;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;231;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;86;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;45;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;178;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;75;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;162;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;137;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;122;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;34;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;13;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;105;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;17;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;7;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;86;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;29;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;13;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;74;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;49;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;14;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;8;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;45;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;12;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;132;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;91;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;69;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;47;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;25;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;36;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;24;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;12;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;287;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;63;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;26;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;311;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;49;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;22;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;231;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;86;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;45;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;178;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;75;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;162;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;137;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;122;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;34;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;13;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;105;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;17;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;7;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;86;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;29;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;13;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;74;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;49;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;14;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;8;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;45;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;12;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;132;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;91;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;69;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;47;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;25;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;36;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;24;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;12;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;306;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;67;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;27;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;327;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;53;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;23;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;241;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;91;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;48;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;195;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;80;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;171;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;146;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;131;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;36;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;14;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;111;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;17;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;7;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;90;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;31;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;14;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;79;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;52;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;15;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;8;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;47;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;13;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;139;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;72;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;50;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;26;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;57;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;38;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;25;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;13;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;306;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;67;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;27;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;327;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;53;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;23;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;241;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;91;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;48;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;195;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;80;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;171;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;146;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;131;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;36;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;14;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;111;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;17;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;7;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;90;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;31;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;14;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;79;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;52;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;15;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;8;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;47;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;13;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;5;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;139;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;72;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;50;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;26;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;57;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;38;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;25;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;13;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;327;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;70;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;29;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;346;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;56;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;24;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;258;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;97;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;206;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;83;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;181;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;154;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;139;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;38;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;15;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;119;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;19;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;8;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;98;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;33;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;15;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;84;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;55;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;16;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;9;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;50;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;14;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;6;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;142;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;53;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;74;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;51;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;27;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;51;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;39;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;27;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;13;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;327;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;70;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;29;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;346;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;56;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;24;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;258;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;97;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;206;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;83;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;181;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;154;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;139;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;38;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;15;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;119;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;19;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;8;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;98;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;33;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;15;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;84;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;55;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;16;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;9;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;50;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;14;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;6;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;142;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;53;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;74;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;51;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;27;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;51;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;39;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;27;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;13;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;342;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;74;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;31;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;366;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;60;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;25;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;276;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;103;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;54;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;217;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;89;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;191;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;161;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;147;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;40;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;16;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;125;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;19;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;8;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;102;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;35;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;16;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;90;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;58;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;17;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;9;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;54;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;15;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;6;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;147;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;100;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;76;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;52;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;28;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;40;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;27;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;14;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;342;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;74;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;31;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;366;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;60;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;25;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;276;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;103;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;54;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;217;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;89;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;191;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;161;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;147;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;40;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;16;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;125;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;19;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;8;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;102;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;35;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;16;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;90;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;58;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;17;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;9;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;54;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;15;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;6;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;147;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;100;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;76;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;52;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;28;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;40;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;27;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;14;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;363;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;79;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;33;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;382;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;65;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;27;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;290;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;108;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;57;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;234;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;93;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;202;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;169;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;154;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;43;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;17;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;134;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;21;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;8;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;108;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;37;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;17;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;95;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;62;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;18;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;10;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;56;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;15;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;7;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;103;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;79;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;55;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;29;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;41;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;28;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;14;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;363;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;79;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;33;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;382;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;65;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;27;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;290;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;108;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;57;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;234;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;93;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;202;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;169;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;154;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;43;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;17;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;134;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;21;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;8;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;108;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;37;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;17;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;95;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;62;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;18;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;10;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;56;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;15;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;7;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;103;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;79;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;55;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;29;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;41;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;28;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;14;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;383;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;82;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;34;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;400;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;67;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;28;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;307;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;114;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;242;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;97;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;214;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;182;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;161;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;45;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;18;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;139;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;22;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;9;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;113;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;39;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;18;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;98;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;65;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;20;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;10;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;59;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;16;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;7;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;155;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;106;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;57;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;81;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;56;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;30;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;43;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;29;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;14;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;383;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;82;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;34;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;400;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;67;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;28;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;307;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;114;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;242;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;97;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;214;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;182;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;161;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;45;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;18;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;139;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;22;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;9;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;113;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;39;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;18;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;98;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;65;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;20;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;10;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;59;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;16;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;7;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;155;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;106;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;57;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;81;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;56;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;30;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;43;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;29;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;14;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;403;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;87;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;36;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;418;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;70;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;30;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;318;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;120;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;258;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;103;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;223;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;190;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;172;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;48;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;19;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;146;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;23;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;9;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;118;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;41;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;19;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;68;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;20;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;11;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;62;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;17;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;7;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;159;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;59;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;84;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;57;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;31;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;44;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;30;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;15;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;403;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;87;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;36;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;418;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;70;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;30;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;318;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;120;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;258;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;103;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;223;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;190;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;172;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;48;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;19;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;146;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;23;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;9;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;118;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;41;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;19;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;68;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;20;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;11;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;62;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;17;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;7;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;159;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;59;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;84;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;57;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;31;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;44;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;30;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;15;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;426;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;92;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;38;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;437;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;73;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;31;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;337;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;124;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;267;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;232;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;198;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;176;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;49;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;19;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;154;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;24;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;10;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;121;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;43;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;19;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;106;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;71;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;21;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;11;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;65;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;18;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;8;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;163;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;84;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;59;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;31;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;44;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;30;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;15;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;426;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;92;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;38;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;437;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;73;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;31;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;337;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;124;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;267;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;232;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;198;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;176;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;49;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;19;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;154;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;24;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;10;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;121;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;43;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;19;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;106;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;71;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;21;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;11;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;65;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;18;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;8;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;163;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;84;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;59;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;31;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;44;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;30;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;15;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;442;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;94;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;40;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;452;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;76;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;33;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;353;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;130;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;69;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;283;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;110;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;242;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;209;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;184;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;52;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;20;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;158;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;25;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;10;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;128;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;45;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;20;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;112;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;73;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;22;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;12;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;68;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;18;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;8;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;87;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;60;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;32;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;46;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;31;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;15;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;442;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;94;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;40;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;452;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;76;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;33;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;353;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;130;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;69;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;283;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;110;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;242;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;209;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;184;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;52;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;20;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;158;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;25;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;10;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;128;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;45;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;20;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;112;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;73;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;22;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;12;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;68;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;18;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;8;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;87;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;60;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;32;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;46;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;31;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;15;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;461;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;97;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;42;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;472;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;79;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;33;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;365;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;138;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;293;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;251;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;215;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;193;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;53;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;21;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;165;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;26;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;10;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;132;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;47;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;21;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;115;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;76;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;23;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;12;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;70;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;19;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;8;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;169;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;88;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;61;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;32;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;46;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;32;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;461;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;97;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;42;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;472;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;79;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;33;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;365;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;138;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;293;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;251;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;215;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;193;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;53;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;21;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;165;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;26;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;10;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;132;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;47;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;21;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;115;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;76;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;23;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;12;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;70;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;19;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;8;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;169;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;88;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;61;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;32;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;46;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;32;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;483;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;101;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;42;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;489;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;82;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;35;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;378;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;142;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;75;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;301;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;259;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;224;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;202;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;55;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;21;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;169;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;27;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;11;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;137;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;48;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;22;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;121;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;79;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;24;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;12;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;73;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;20;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;173;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;90;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;63;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;33;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;48;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;33;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;483;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;101;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;42;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;489;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;82;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;35;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;378;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;142;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;75;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;301;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;259;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;224;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;202;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;55;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;21;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;169;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;27;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;11;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;137;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;48;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;22;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;121;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;79;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;24;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;12;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;73;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;20;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;173;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;90;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;63;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;33;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;48;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;33;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;495;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;105;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;44;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;496;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;85;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;35;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;390;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;145;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;312;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;121;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;268;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;232;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;207;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;58;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;22;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;174;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;28;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;11;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;141;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;49;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;22;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;122;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;82;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;25;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;13;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;76;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;20;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;175;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;91;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;64;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;48;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;33;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;495;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;105;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;44;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;496;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;85;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;35;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;390;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;145;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;312;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;121;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;268;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;232;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;207;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;58;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;22;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;174;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;28;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;11;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;141;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;49;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;22;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;122;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;82;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;25;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;13;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;76;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;20;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;175;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;91;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;64;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;48;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;33;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;513;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;106;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;46;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;513;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;89;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;37;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;400;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;149;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;324;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;124;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;279;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;237;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;214;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;59;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;23;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;179;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;29;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;11;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;143;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;51;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;23;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;127;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;83;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;26;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;13;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;78;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;21;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;178;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;92;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;65;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;48;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;33;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;513;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;106;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;46;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;513;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;89;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;37;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;400;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;149;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;324;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;124;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;279;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;237;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;214;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;59;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;23;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;179;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;29;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;11;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;143;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;51;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;23;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;127;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;83;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;26;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;13;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;78;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;21;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;178;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;92;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;65;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;48;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;33;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;16;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;522;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;109;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;47;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;523;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;91;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;37;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;412;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;154;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;332;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;127;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;284;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;245;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;215;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;60;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;23;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;186;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;29;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;148;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;53;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;23;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;129;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;86;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;26;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;13;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;81;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;21;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;179;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;93;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;65;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;49;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;34;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;522;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;109;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;47;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;523;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;91;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;37;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;412;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;154;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;332;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;127;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;284;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;245;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;215;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;60;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;23;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;186;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;29;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;148;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;53;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;23;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;129;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;86;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;26;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;13;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;81;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;21;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;9;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;179;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;93;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;65;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;49;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;34;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;537;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;112;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;48;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;533;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;93;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;38;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;424;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;83;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;340;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;128;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;291;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;252;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;222;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;62;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;23;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;188;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;30;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;150;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;53;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;87;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;27;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;82;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;180;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;94;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;34;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;537;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;112;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;48;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;533;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;93;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;38;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;424;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;83;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;340;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;128;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;291;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;252;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;222;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;62;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;23;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;188;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;30;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;150;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;53;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;87;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;27;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;82;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;180;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;94;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;34;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;34;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;545;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;112;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;49;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;538;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;94;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;39;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;429;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;349;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;291;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;256;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;224;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;63;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;24;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;191;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;30;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;152;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;54;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;133;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;88;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;27;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;83;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;181;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;94;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;35;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;35;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;545;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;112;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;49;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;538;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;94;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;39;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;429;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;349;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;291;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;256;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;224;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;63;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;24;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;191;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;30;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;152;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;54;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;133;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;88;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;27;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;83;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;181;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;94;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;35;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;35;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;555;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;113;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;50;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;538;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;96;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;39;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;433;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;351;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;299;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;261;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;230;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;64;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;24;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;192;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;30;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;154;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;55;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;90;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;28;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;86;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;181;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;95;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;35;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;35;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;555;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;113;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;50;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;538;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;96;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;39;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;433;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;351;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;299;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;261;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;230;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;64;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;24;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;192;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;30;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;154;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;55;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;90;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;28;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;86;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;181;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;95;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;35;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;35;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;563;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;114;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;50;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;538;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;97;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;39;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;437;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;86;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;356;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;300;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;263;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;230;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;64;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;24;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;194;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;31;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;155;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;55;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;90;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;28;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;86;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;181;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;95;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;35;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;35;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;563;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;114;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;50;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;538;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;97;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;39;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;437;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;86;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;356;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;300;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;263;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;230;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;64;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;24;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;194;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;31;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;12;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;155;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;55;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;24;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;90;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;28;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;14;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;86;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;22;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;10;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;181;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;95;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;66;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;35;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;50;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;35;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;17;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;3;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;3;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;4;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;4;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;5;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;0;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;6;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;4;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;6;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;4;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;8;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;4;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;5;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;3;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;2;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;8;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;4;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;5;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;3;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;2;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;3;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;12;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;2;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;6;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;3;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;3;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;12;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;0;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;0;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;2;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;6;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;3;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;3;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;3;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;12;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;1;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;3;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;7;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;8;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;5;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;4;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;2;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;3;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;3;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;12;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;1;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;3;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;7;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;8;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;5;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;4;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;2;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;4;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;3;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;21;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;1;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;4;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;5;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;15;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;9;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;5;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;3;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;4;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;4;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;3;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;21;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;1;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;4;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;5;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;0;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;15;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;9;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;5;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;3;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;4;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;1;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;11;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;3;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;21;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;2;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;1;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;6;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;6;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;4;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;2;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;19;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;10;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;7;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;4;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;5;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;2;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;11;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;3;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;21;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;2;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;1;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;6;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;6;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;0;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;4;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;2;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;19;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;10;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;7;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;4;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;5;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;2;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;12;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;4;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;26;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;2;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;13;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;12;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;6;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;6;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;6;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;3;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;23;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;13;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;8;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;5;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;6;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;3;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;2;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;12;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;4;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;26;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;2;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;13;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;12;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;6;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;6;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;6;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;3;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;23;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;13;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;8;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;5;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;6;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;3;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;2;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2017W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2017W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2017;B;56604;B Psychologie;SOW;N;N;N;14;1.31
-21PB;2017;B;56604;B Psychologie;SOW;E;N;N;5;1.31
-21PB;2017;B;56604;B Psychologie;SOW;R;N;N;2;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;26;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;4;1.31
-21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;2;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;17;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.31
-21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.31
-21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.31
-21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;10;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.31
-21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31
-21PB;2017;B;56981;B Politicologie;MAN;N;N;N;9;1.31
-21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31
-21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;10;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31
-21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;8;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31
-21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;5;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31
-21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31
-21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31
-21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;26;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.08
-21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.08
-21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.08
-21PB;2017;M;60300;M Informatica;SOW;N;N;N;14;1.08
-21PB;2017;M;60300;M Informatica;SOW;E;N;N;9;1.08
-21PB;2017;M;60300;M Informatica;SOW;R;N;N;5;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.08
-21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.08
-21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;7;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;4;1.08
-21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;2;1.08
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2017;B;56604;B Psychologie;SOW;N;N;N;14;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;E;N;N;5;1.31;V
+21PB;2017;B;56604;B Psychologie;SOW;R;N;N;2;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;N;N;N;26;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;E;N;N;4;1.31;V
+21PB;2017;B;56551;B Geneeskunde;MED;R;N;N;2;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;17;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.31;V
+21PB;2017;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.31;V
+21PB;2017;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.31;V
+21PB;2017;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;N;N;N;10;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.31;V
+21PB;2017;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;N;N;N;9;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;E;N;N;2;1.31;V
+21PB;2017;B;56981;B Politicologie;MAN;R;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;N;N;N;10;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56034;B Geschiedenis;FdL;R;N;N;1;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;N;N;N;8;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56980;B Wiskunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.31;V
+21PB;2017;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;N;N;N;5;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;E;N;N;1;1.31;V
+21PB;2017;B;56857;B Scheikunde;FNWI;R;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;N;N;N;3;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;E;N;N;1;1.31;V
+21PB;2017;B;56081;B Filosofie;FdL;R;N;N;0;1.31;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;26;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.08;V
+21PB;2017;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.08;V
+21PB;2017;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;N;N;N;14;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;E;N;N;9;1.08;V
+21PB;2017;M;60300;M Informatica;SOW;R;N;N;5;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.08;V
+21PB;2017;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.08;V
+21PB;2017;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;N;N;N;7;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;E;N;N;4;1.08;V
+21PB;2017;M;60815;M Linguistiek;FdL;R;N;N;2;1.08;V

--- a/data/input_raw/telbestanden/telbestandY2018W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;28;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;8;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;3;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;37;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;6;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;26;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;15;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;5;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;8;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;9;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;6;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;4;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;14;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;10;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;5;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;9;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;5;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;3;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;28;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;8;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;3;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;37;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;6;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;26;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;15;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;5;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;8;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;9;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;6;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;4;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;14;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;10;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;5;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;9;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;5;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;3;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;36;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;8;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;4;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;42;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;7;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;3;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;26;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;26;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;21;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;6;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;10;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;11;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;8;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;6;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;31;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;16;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;11;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;5;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;10;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;6;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;3;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;36;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;8;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;4;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;42;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;7;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;3;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;26;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;26;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;21;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;6;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;10;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;11;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;8;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;6;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;31;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;16;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;11;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;5;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;10;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;6;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;3;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;36;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;10;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;4;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;52;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;7;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;3;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;37;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;23;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;21;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;21;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;7;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;12;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;3;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;11;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;4;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;10;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;6;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;18;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;12;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;6;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;11;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;7;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;4;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;36;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;10;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;4;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;52;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;7;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;3;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;37;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;23;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;21;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;21;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;7;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;12;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;3;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;11;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;4;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;10;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;6;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;18;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;12;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;6;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;11;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;7;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;4;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;45;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;12;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;5;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;60;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;4;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;38;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;17;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;38;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;25;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;26;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;26;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;8;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;15;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;3;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;15;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;5;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;11;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;10;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;7;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;38;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;20;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;14;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;7;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;12;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;7;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;4;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;45;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;12;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;5;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;60;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;4;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;38;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;17;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;38;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;25;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;26;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;26;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;8;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;15;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;3;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;15;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;5;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;11;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;10;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;7;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;38;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;20;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;14;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;7;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;12;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;7;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;4;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;52;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;14;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;5;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;68;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;10;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;4;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;43;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;18;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;42;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;16;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;29;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;31;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;9;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;3;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;15;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;4;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;17;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;5;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;12;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;9;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;41;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;29;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;24;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;16;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;8;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;14;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;8;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;5;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;52;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;14;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;5;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;68;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;10;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;4;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;43;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;18;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;42;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;16;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;29;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;31;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;9;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;3;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;15;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;4;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;17;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;5;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;12;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;9;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;41;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;29;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;24;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;16;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;8;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;14;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;8;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;5;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;63;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;15;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;6;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;78;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;12;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;6;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;51;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;21;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;51;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;35;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;34;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;37;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;10;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;3;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;19;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;4;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;20;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;7;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;14;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;10;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;47;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;26;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;17;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;8;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;9;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;5;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;63;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;15;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;6;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;78;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;12;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;6;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;51;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;21;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;51;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;35;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;34;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;37;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;10;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;3;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;19;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;4;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;20;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;7;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;14;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;10;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;1;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;47;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;26;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;17;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;8;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;9;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;5;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;70;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;19;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;8;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;92;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;14;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;6;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;60;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;56;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;42;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;37;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;42;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;12;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;4;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;23;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;5;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;23;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;8;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;19;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;16;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;4;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;12;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;35;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;24;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;28;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;19;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;9;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;10;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;6;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;70;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;19;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;8;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;92;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;14;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;6;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;60;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;56;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;42;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;37;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;42;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;12;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;4;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;23;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;5;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;23;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;8;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;19;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;16;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;4;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;12;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;35;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;24;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;28;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;19;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;9;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;10;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;6;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;86;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;20;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;96;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;16;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;7;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;68;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;67;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;42;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;44;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;13;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;4;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;26;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;6;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;26;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;9;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;4;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;22;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;18;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;4;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;14;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;4;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;56;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;39;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;26;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;31;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;20;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;10;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;18;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;11;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;6;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;86;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;20;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;96;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;16;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;7;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;68;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;67;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;42;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;44;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;13;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;4;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;26;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;6;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;26;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;9;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;4;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;22;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;18;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;4;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;14;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;4;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;56;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;39;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;26;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;31;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;20;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;10;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;18;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;11;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;6;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;95;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;23;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;10;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;110;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;18;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;8;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;81;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;31;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;76;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;54;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;50;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;53;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;15;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;5;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;31;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;7;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;30;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;10;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;4;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;25;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;20;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;5;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;15;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;4;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;60;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;42;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;34;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;22;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;11;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;20;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;13;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;7;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;95;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;23;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;10;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;110;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;18;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;8;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;81;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;31;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;76;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;54;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;50;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;53;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;15;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;5;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;31;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;7;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;30;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;10;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;4;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;25;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;20;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;5;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;15;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;4;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;60;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;42;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;34;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;22;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;11;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;20;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;13;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;7;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;103;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;26;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;11;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;126;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;20;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;9;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;85;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;36;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;83;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;29;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;61;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;55;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;59;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;16;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;5;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;35;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;7;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;32;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;11;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;28;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;21;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;6;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;17;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;5;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;65;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;46;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;30;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;36;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;24;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;12;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;21;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;13;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;7;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;103;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;26;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;11;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;126;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;20;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;9;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;85;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;36;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;83;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;29;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;61;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;55;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;59;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;16;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;5;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;35;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;7;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;32;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;11;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;28;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;21;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;6;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;17;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;5;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;65;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;46;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;30;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;36;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;24;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;12;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;21;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;13;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;7;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;117;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;28;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;12;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;140;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;22;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;10;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;99;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;39;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;89;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;33;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;67;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;62;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;18;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;6;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;41;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;8;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;37;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;13;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;25;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;6;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;19;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;5;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;49;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;38;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;27;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;13;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;23;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;15;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;8;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;117;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;28;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;12;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;140;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;22;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;10;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;99;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;39;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;89;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;33;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;67;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;62;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;18;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;6;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;41;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;8;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;37;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;13;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;25;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;6;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;19;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;5;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;2;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;49;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;38;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;27;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;13;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;23;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;15;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;8;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;134;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;32;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;13;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;147;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;25;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;11;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;108;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;42;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;100;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;35;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;73;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;67;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;67;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;20;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;7;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;45;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;8;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;40;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;14;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;6;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;33;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;7;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;4;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;21;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;6;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;3;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;74;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;41;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;28;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;14;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;29;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;25;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;8;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;134;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;32;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;13;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;147;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;25;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;11;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;108;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;42;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;100;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;35;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;73;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;67;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;67;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;20;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;7;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;45;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;8;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;40;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;14;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;6;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;33;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;7;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;4;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;21;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;6;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;3;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;74;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;41;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;28;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;14;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;29;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;25;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;8;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;150;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;34;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;15;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;165;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;28;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;12;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;116;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;47;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;25;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;113;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;39;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;80;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;70;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;77;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;22;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;8;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;51;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;9;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;4;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;45;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;15;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;7;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;36;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;30;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;8;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;4;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;23;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;6;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;3;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;80;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;44;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;30;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;15;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;39;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;27;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;9;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;150;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;34;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;15;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;165;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;28;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;12;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;116;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;47;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;25;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;113;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;39;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;80;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;70;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;77;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;22;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;8;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;51;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;9;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;4;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;45;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;15;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;7;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;36;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;30;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;8;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;4;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;23;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;6;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;3;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;80;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;44;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;30;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;15;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;39;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;27;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;9;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;168;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;38;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;16;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;185;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;30;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;13;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;133;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;53;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;28;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;123;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;41;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;91;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;79;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;85;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;24;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;8;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;56;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;10;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;4;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;48;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;17;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;8;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;41;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;33;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;9;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;4;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;26;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;7;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;3;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;85;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;59;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;47;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;32;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;16;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;34;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;28;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;17;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;9;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;168;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;38;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;16;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;185;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;30;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;13;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;133;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;53;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;28;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;123;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;41;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;91;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;79;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;85;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;24;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;8;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;56;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;10;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;4;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;48;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;17;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;8;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;41;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;33;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;9;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;4;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;26;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;7;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;3;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;85;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;59;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;47;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;32;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;16;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;34;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;28;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;17;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;9;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;186;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;42;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;18;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;199;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;32;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;15;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;147;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;58;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;31;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;129;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;46;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;96;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;89;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;93;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;26;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;9;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;60;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;11;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;4;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;54;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;18;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;8;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;45;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;35;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;9;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;5;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;29;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;8;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;4;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;91;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;63;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;51;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;34;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;17;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;44;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;30;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;19;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;10;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;186;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;42;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;18;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;199;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;32;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;15;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;147;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;58;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;31;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;129;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;46;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;96;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;89;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;93;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;26;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;9;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;60;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;11;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;4;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;54;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;18;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;8;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;45;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;35;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;9;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;5;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;29;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;8;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;4;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;91;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;63;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;51;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;34;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;17;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;44;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;30;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;19;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;10;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;196;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;44;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;19;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;215;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;37;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;16;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;155;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;62;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;148;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;109;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;95;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;98;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;28;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;10;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;67;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;12;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;5;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;59;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;20;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;9;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;49;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;40;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;10;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;6;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;32;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;8;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;4;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;96;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;65;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;52;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;36;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;18;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;46;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;31;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;20;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;10;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;196;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;44;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;19;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;215;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;37;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;16;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;155;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;62;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;148;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;109;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;95;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;98;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;28;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;10;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;67;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;12;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;5;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;59;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;20;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;9;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;49;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;40;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;10;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;6;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;32;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;8;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;4;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;96;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;65;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;52;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;36;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;18;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;46;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;31;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;20;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;10;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;208;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;47;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;21;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;231;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;39;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;17;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;171;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;66;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;36;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;158;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;116;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;109;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;30;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;10;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;73;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;13;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;5;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;63;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;22;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;10;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;53;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;43;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;11;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;6;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;34;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;9;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;4;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;102;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;70;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;55;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;37;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;19;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;49;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;32;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;21;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;11;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;208;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;47;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;21;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;231;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;39;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;17;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;171;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;66;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;36;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;158;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;116;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;109;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;30;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;10;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;73;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;13;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;5;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;63;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;22;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;10;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;53;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;43;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;11;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;6;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;34;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;9;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;4;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;102;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;70;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;55;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;37;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;19;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;49;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;32;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;21;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;11;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;223;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;53;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;22;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;249;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;41;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;18;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;181;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;73;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;169;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;57;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;126;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;107;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;112;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;32;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;11;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;80;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;14;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;6;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;69;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;24;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;11;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;58;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;46;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;12;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;7;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;37;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;10;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;5;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;58;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;39;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;19;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;42;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;51;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;34;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;22;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;12;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;223;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;53;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;22;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;249;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;41;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;18;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;181;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;73;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;169;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;57;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;126;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;107;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;112;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;32;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;11;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;80;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;14;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;6;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;69;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;24;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;11;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;58;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;46;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;12;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;7;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;37;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;10;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;5;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;58;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;39;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;19;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;42;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;51;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;34;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;22;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;12;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;247;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;58;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;24;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;269;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;45;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;20;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;197;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;78;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;41;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;185;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;62;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;133;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;123;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;35;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;12;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;85;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;15;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;6;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;71;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;25;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;11;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;61;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;49;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;13;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;7;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;40;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;10;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;5;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;112;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;62;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;42;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;20;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;36;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;23;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;12;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;247;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;58;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;24;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;269;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;45;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;20;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;197;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;78;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;41;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;185;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;62;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;133;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;123;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;35;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;12;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;85;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;15;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;6;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;71;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;25;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;11;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;61;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;49;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;13;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;7;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;40;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;10;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;5;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;112;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;62;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;42;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;20;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;36;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;23;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;12;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;262;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;60;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;26;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;286;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;49;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;21;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;216;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;84;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;195;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;66;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;145;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;127;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;131;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;38;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;13;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;90;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;16;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;6;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;76;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;27;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;12;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;52;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;14;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;8;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;42;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;11;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;5;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;117;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;80;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;65;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;43;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;21;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;46;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;37;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;24;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;12;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;262;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;60;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;26;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;286;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;49;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;21;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;216;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;84;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;195;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;66;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;145;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;127;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;131;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;38;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;13;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;90;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;16;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;6;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;76;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;27;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;12;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;52;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;14;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;8;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;42;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;11;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;5;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;117;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;80;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;65;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;43;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;21;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;46;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;37;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;24;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;12;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;281;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;63;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;27;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;305;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;52;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;23;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;228;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;89;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;208;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;71;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;156;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;135;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;142;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;40;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;14;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;97;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;17;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;7;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;82;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;28;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;13;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;72;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;57;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;15;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;8;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;45;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;12;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;6;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;122;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;82;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;68;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;44;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;22;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;38;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;25;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;13;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;281;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;63;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;27;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;305;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;52;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;23;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;228;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;89;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;208;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;71;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;156;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;135;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;142;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;40;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;14;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;97;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;17;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;7;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;82;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;28;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;13;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;72;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;57;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;15;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;8;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;45;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;12;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;6;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;122;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;82;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;68;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;44;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;22;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;38;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;25;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;13;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;299;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;68;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;29;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;325;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;55;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;24;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;242;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;95;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;223;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;164;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;144;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;151;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;42;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;14;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;105;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;18;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;7;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;88;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;31;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;14;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;78;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;60;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;15;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;9;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;50;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;13;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;6;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;125;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;70;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;47;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;23;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;40;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;26;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;13;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;299;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;68;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;29;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;325;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;55;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;24;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;242;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;95;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;223;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;164;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;144;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;151;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;42;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;14;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;105;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;18;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;7;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;88;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;31;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;14;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;78;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;60;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;15;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;9;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;50;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;13;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;6;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;125;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;70;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;47;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;23;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;40;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;26;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;13;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;320;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;73;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;31;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;342;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;60;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;25;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;260;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;100;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;239;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;78;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;177;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;151;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;159;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;44;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;15;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;110;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;19;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;8;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;93;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;32;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;28;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;63;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;17;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;9;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;52;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;13;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;6;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;132;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;89;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;73;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;49;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;24;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;42;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;27;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;14;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;320;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;73;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;31;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;342;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;60;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;25;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;260;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;100;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;239;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;78;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;177;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;151;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;159;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;44;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;15;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;110;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;19;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;8;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;93;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;32;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;28;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;63;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;17;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;9;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;52;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;13;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;6;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;132;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;89;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;73;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;49;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;24;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;42;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;27;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;14;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;342;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;77;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;33;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;365;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;62;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;27;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;274;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;105;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;252;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;84;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;187;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;159;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;164;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;46;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;16;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;121;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;20;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;8;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;97;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;34;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;86;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;67;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;18;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;10;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;54;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;14;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;7;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;135;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;92;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;75;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;50;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;24;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;63;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;43;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;28;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;15;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;342;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;77;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;33;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;365;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;62;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;27;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;274;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;105;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;252;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;84;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;187;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;159;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;164;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;46;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;16;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;121;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;20;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;8;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;97;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;34;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;86;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;67;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;18;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;10;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;54;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;14;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;7;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;135;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;92;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;75;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;50;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;24;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;63;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;43;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;28;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;15;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;358;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;80;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;35;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;390;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;65;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;28;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;290;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;110;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;59;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;263;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;88;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;196;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;166;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;176;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;49;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;17;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;127;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;21;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;8;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;104;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;36;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;16;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;90;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;70;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;19;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;11;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;58;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;15;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;7;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;139;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;77;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;52;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;26;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;44;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;29;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;15;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;358;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;80;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;35;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;390;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;65;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;28;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;290;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;110;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;59;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;263;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;88;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;196;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;166;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;176;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;49;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;17;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;127;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;21;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;8;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;104;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;36;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;16;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;90;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;70;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;19;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;11;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;58;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;15;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;7;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;139;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;77;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;52;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;26;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;44;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;29;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;15;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;376;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;85;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;36;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;397;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;69;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;29;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;307;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;117;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;276;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;91;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;208;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;176;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;184;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;52;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;18;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;132;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;22;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;9;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;110;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;38;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;17;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;97;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;73;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;20;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;11;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;62;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;16;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;7;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;144;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;79;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;53;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;26;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;45;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;30;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;15;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;376;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;85;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;36;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;397;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;69;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;29;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;307;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;117;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;276;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;91;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;208;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;176;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;184;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;52;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;18;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;132;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;22;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;9;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;110;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;38;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;17;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;97;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;73;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;20;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;11;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;62;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;16;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;7;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;144;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;79;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;53;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;26;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;45;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;30;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;15;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;392;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;89;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;38;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;421;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;73;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;31;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;318;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;122;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;289;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;96;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;214;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;182;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;189;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;54;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;19;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;139;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;23;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;9;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;114;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;40;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;18;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;101;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;78;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;21;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;12;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;63;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;17;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;8;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;148;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;100;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;81;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;54;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;27;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;46;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;31;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;16;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;392;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;89;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;38;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;421;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;73;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;31;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;318;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;122;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;289;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;96;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;214;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;182;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;189;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;54;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;19;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;139;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;23;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;9;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;114;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;40;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;18;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;101;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;78;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;21;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;12;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;63;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;17;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;8;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;148;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;100;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;81;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;54;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;27;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;46;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;31;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;16;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;409;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;92;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;39;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;436;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;76;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;32;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;334;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;128;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;67;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;298;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;100;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;228;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;189;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;197;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;56;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;19;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;148;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;24;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;10;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;119;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;42;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;19;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;105;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;35;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;81;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;22;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;12;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;68;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;17;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;8;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;152;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;83;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;56;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;27;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;48;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;32;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;16;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;409;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;92;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;39;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;436;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;76;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;32;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;334;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;128;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;67;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;298;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;100;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;228;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;189;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;197;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;56;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;19;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;148;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;24;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;10;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;119;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;42;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;19;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;105;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;35;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;81;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;22;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;12;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;68;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;17;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;8;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;152;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;83;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;56;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;27;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;48;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;32;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;16;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;429;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;97;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;41;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;458;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;80;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;34;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;351;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;132;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;68;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;314;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;104;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;239;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;198;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;208;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;58;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;20;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;152;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;25;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;10;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;123;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;44;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;20;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;110;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;84;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;23;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;13;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;70;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;18;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;8;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;155;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;85;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;58;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;28;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;48;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;32;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;16;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;429;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;97;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;41;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;458;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;80;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;34;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;351;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;132;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;68;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;314;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;104;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;239;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;198;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;208;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;58;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;20;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;152;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;25;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;10;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;123;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;44;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;20;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;110;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;84;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;23;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;13;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;70;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;18;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;8;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;155;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;85;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;58;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;28;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;48;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;32;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;16;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;448;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;102;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;42;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;473;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;83;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;35;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;366;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;138;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;323;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;249;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;208;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;214;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;60;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;21;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;159;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;26;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;10;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;127;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;45;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;21;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;114;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;88;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;23;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;13;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;73;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;19;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;106;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;88;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;58;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;29;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;50;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;33;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;448;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;102;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;42;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;473;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;83;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;35;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;366;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;138;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;323;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;249;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;208;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;214;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;60;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;21;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;159;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;26;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;10;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;127;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;45;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;21;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;114;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;88;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;23;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;13;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;73;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;19;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;106;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;88;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;58;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;29;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;50;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;33;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;469;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;104;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;44;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;491;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;86;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;36;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;380;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;144;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;74;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;336;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;111;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;256;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;212;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;219;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;62;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;21;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;165;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;27;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;11;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;132;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;47;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;21;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;119;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;91;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;24;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;14;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;76;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;20;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;108;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;89;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;60;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;29;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;50;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;34;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;469;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;104;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;44;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;491;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;86;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;36;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;380;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;144;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;74;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;336;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;111;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;256;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;212;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;219;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;62;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;21;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;165;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;27;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;11;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;132;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;47;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;21;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;119;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;91;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;24;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;14;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;76;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;20;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;108;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;89;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;60;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;29;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;50;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;34;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;479;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;107;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;45;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;507;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;88;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;37;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;389;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;76;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;345;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;113;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;263;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;219;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;227;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;64;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;22;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;172;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;28;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;11;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;137;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;48;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;22;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;123;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;94;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;25;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;14;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;79;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;20;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;164;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;90;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;61;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;30;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;51;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;34;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;479;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;107;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;45;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;507;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;88;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;37;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;389;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;76;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;345;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;113;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;263;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;219;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;227;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;64;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;22;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;172;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;28;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;11;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;137;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;48;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;22;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;123;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;94;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;25;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;14;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;79;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;20;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;164;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;90;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;61;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;30;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;51;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;34;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;496;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;110;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;46;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;518;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;91;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;38;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;404;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;356;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;117;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;271;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;223;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;233;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;65;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;23;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;177;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;28;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;11;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;139;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;49;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;23;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;127;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;95;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;26;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;81;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;21;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;166;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;92;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;62;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;30;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;52;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;34;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;496;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;110;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;46;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;518;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;91;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;38;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;404;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;356;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;117;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;271;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;223;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;233;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;65;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;23;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;177;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;28;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;11;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;139;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;49;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;23;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;127;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;95;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;26;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;81;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;21;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;9;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;166;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;92;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;62;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;30;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;52;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;34;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;17;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;504;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;113;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;48;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;533;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;93;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;38;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;410;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;154;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;363;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;119;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;278;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;226;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;237;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;67;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;23;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;183;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;29;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;141;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;50;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;24;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;131;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;97;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;83;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;21;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;81;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;93;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;62;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;30;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;52;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;35;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;504;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;113;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;48;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;533;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;93;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;38;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;410;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;154;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;363;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;119;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;278;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;226;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;237;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;67;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;23;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;183;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;29;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;141;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;50;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;24;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;131;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;97;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;83;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;21;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;81;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;93;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;62;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;30;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;52;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;35;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;514;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;114;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;48;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;533;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;95;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;39;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;425;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;364;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;121;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;286;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;233;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;239;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;68;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;187;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;145;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;51;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;24;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;99;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;15;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;85;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;22;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;93;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;63;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;35;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;514;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;114;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;48;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;533;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;95;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;39;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;425;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;364;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;121;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;286;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;233;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;239;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;68;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;187;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;145;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;51;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;24;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;99;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;15;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;85;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;22;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;93;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;63;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;35;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;523;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;117;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;49;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;552;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;97;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;40;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;426;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;375;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;122;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;289;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;233;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;246;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;69;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;190;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;147;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;52;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;25;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;101;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;27;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;16;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;87;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;22;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;94;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;63;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;36;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;523;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;117;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;49;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;552;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;97;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;40;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;426;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;375;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;122;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;289;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;233;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;246;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;69;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;190;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;147;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;52;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;25;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;101;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;27;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;16;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;87;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;22;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;94;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;63;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;36;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;531;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;118;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;49;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;554;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;99;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;40;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;437;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;379;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;295;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;235;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;246;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;69;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;194;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;147;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;53;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;25;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;103;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;28;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;16;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;88;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;23;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;95;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;64;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;36;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;531;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;118;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;49;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;554;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;99;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;40;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;437;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;379;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;295;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;235;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;246;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;69;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;194;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;147;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;53;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;25;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;103;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;28;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;16;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;88;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;23;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;95;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;64;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;36;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;542;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;120;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;49;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;558;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;99;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;40;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;437;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;380;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;299;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;236;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;246;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;69;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;194;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;147;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;53;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;25;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;140;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;103;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;28;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;16;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;90;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;23;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;95;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;64;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;36;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;542;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;120;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;49;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;558;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;99;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;40;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;437;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;380;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;299;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;236;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;246;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;69;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;24;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;194;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;30;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;12;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;147;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;53;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;25;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;140;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;103;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;28;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;16;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;90;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;23;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;10;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;95;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;64;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;31;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;53;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;36;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;18;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;1;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;3;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;3;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;1;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;7;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;7;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;1;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;0;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;0;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;5;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;5;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;7;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;5;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;3;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;1;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;2;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;7;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;5;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;3;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;1;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;2;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;7;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;3;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;5;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;7;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;5;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;3;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;3;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;2;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;7;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;3;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;9;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;5;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;2;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;7;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;5;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;3;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;3;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;2;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;7;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;3;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;18;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;4;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;10;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;5;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;4;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;2;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;7;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;3;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;18;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;0;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;4;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;10;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;5;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;4;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;2;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;1;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;10;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;4;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;18;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;2;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;1;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;8;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;3;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;8;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;5;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;2;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;3;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;2;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;10;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;4;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;18;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;2;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;1;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;8;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;0;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;3;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;2;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;8;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;5;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;2;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;3;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;2;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;13;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;4;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;2;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;21;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;3;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;9;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;15;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;9;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;3;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;4;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;4;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;16;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;9;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;6;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;3;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;5;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;3;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;2;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;13;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;4;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;2;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;21;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;3;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;9;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;15;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;9;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;3;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;4;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;4;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;0;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;16;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;9;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;6;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;3;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;5;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;3;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;2;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;20;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;5;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;2;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;22;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;3;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;11;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;10;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;10;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;4;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;4;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;6;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;5;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;10;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;7;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;3;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;6;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;2;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;20;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;5;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;2;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;22;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;3;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;11;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;10;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;10;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;4;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;4;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;0;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;6;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;5;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;2;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;10;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;7;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;3;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;6;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;2;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2018W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2018W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2018;B;56604;B Psychologie;SOW;N;N;N;24;1.28
-21PB;2018;B;56604;B Psychologie;SOW;E;N;N;5;1.28
-21PB;2018;B;56604;B Psychologie;SOW;R;N;N;3;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;27;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;4;1.28
-21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;16;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.28
-21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.28
-21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;14;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.28
-21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.28
-21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28
-21PB;2018;B;56981;B Politicologie;MAN;N;N;N;13;1.28
-21PB;2018;B;56981;B Politicologie;MAN;E;N;N;5;1.28
-21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;5;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;2;1.28
-21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;7;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;2;1.28
-21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.28
-21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;6;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28
-21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;N;N;N;3;1.28
-21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28
-21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;21;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.12
-21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.12
-21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.12
-21PB;2018;M;60300;M Informatica;SOW;N;N;N;12;1.12
-21PB;2018;M;60300;M Informatica;SOW;E;N;N;8;1.12
-21PB;2018;M;60300;M Informatica;SOW;R;N;N;4;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.12
-21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.12
-21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;8;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;4;1.12
-21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;3;1.12
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2018;B;56604;B Psychologie;SOW;N;N;N;24;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;E;N;N;5;1.28;V
+21PB;2018;B;56604;B Psychologie;SOW;R;N;N;3;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;N;N;N;27;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;E;N;N;4;1.28;V
+21PB;2018;B;56551;B Geneeskunde;MED;R;N;N;2;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;16;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.28;V
+21PB;2018;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.28;V
+21PB;2018;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;N;N;N;14;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.28;V
+21PB;2018;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.28;V
+21PB;2018;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;N;N;N;13;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;E;N;N;5;1.28;V
+21PB;2018;B;56981;B Politicologie;MAN;R;N;N;1;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;N;N;N;5;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;E;N;N;2;1.28;V
+21PB;2018;B;56034;B Geschiedenis;FdL;R;N;N;1;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;N;N;N;7;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;E;N;N;2;1.28;V
+21PB;2018;B;56980;B Wiskunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.28;V
+21PB;2018;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;N;N;N;6;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;E;N;N;1;1.28;V
+21PB;2018;B;56857;B Scheikunde;FNWI;R;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;N;N;N;3;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;E;N;N;1;1.28;V
+21PB;2018;B;56081;B Filosofie;FdL;R;N;N;0;1.28;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;21;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.12;V
+21PB;2018;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.12;V
+21PB;2018;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;N;N;N;12;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;E;N;N;8;1.12;V
+21PB;2018;M;60300;M Informatica;SOW;R;N;N;4;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.12;V
+21PB;2018;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.12;V
+21PB;2018;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;N;N;N;8;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;E;N;N;4;1.12;V
+21PB;2018;M;60815;M Linguistiek;FdL;R;N;N;3;1.12;V

--- a/data/input_raw/telbestanden/telbestandY2019W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;33;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;7;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;4;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;36;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;5;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;23;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;15;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;14;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;13;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;8;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;5;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;5;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;23;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;13;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;11;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;4;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;7;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;5;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;3;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;33;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;7;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;4;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;36;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;5;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;23;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;15;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;14;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;13;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;8;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;5;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;5;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;23;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;13;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;11;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;4;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;7;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;5;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;3;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;37;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;8;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;5;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;39;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;6;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;32;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;17;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;5;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;15;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;11;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;4;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;8;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;6;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;27;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;15;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;12;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;5;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;12;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;8;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;5;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;3;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;37;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;8;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;5;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;39;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;6;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;32;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;19;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;17;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;5;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;15;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;11;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;4;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;8;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;6;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;27;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;15;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;12;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;5;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;12;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;8;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;5;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;3;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;43;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;8;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;5;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;45;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;7;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;39;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;16;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;9;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;22;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;23;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;21;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;6;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;18;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;12;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;4;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;8;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;8;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;17;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;14;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;6;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;9;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;6;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;4;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;43;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;8;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;5;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;45;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;7;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;39;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;16;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;9;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;22;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;23;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;21;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;6;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;18;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;12;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;4;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;8;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;8;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;17;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;14;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;6;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;9;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;6;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;4;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;56;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;11;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;5;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;54;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;8;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;44;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;18;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;36;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;14;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;26;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;22;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;7;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;21;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;14;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;5;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;10;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;3;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;9;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;22;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;20;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;15;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;7;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;10;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;7;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;4;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;56;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;11;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;5;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;54;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;8;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;44;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;18;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;36;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;14;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;26;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;22;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;7;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;21;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;14;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;5;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;10;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;3;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;9;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;22;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;20;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;15;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;7;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;10;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;7;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;4;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;64;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;13;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;6;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;68;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;11;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;51;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;20;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;32;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;24;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;9;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;24;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;4;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;17;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;11;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;4;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;11;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;22;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;17;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;8;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;21;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;12;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;8;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;5;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;64;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;13;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;6;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;68;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;11;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;51;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;20;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;32;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;24;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;9;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;24;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;4;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;17;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;11;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;4;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;11;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;22;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;17;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;8;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;21;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;12;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;8;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;5;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;78;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;14;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;8;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;75;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;11;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;5;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;62;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;24;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;52;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;20;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;38;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;37;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;30;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;10;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;27;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;4;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;19;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;17;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;13;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;4;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;13;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;43;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;29;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;25;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;19;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;8;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;13;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;8;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;5;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;78;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;14;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;8;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;75;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;11;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;5;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;62;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;24;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;52;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;20;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;38;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;37;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;30;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;10;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;27;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;4;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;19;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;17;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;13;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;4;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;13;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;1;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;43;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;29;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;25;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;19;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;8;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;13;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;8;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;5;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;85;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;16;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;9;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;83;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;12;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;6;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;71;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;26;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;57;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;23;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;45;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;39;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;34;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;11;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;33;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;5;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;22;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;8;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;3;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;15;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;5;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;15;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;24;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;27;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;20;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;10;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;10;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;6;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;85;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;16;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;9;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;83;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;12;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;6;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;71;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;26;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;57;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;23;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;45;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;39;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;34;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;11;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;33;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;5;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;22;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;8;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;3;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;15;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;5;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;15;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;24;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;27;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;20;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;10;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;10;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;6;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;93;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;20;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;9;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;95;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;14;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;7;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;81;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;18;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;64;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;49;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;45;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;41;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;12;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;4;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;36;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;6;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;25;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;9;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;3;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;22;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;18;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;5;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;16;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;35;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;30;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;23;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;11;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;16;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;10;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;6;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;93;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;20;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;9;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;95;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;14;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;7;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;81;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;18;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;64;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;49;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;45;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;41;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;12;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;4;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;36;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;6;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;25;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;9;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;3;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;22;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;18;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;5;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;16;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;35;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;30;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;23;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;11;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;16;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;10;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;6;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;106;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;22;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;11;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;104;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;16;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;8;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;91;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;74;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;30;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;56;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;51;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;42;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;14;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;4;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;41;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;7;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;28;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;10;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;26;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;20;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;6;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;17;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;57;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;32;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;25;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;12;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;17;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;11;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;7;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;106;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;22;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;11;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;104;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;16;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;8;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;91;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;74;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;30;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;56;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;51;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;42;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;14;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;4;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;41;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;7;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;28;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;10;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;26;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;20;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;6;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;17;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;57;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;32;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;25;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;12;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;17;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;11;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;7;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;130;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;26;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;12;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;122;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;19;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;9;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;101;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;36;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;83;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;63;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;50;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;16;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;5;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;46;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;7;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;32;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;11;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;23;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;7;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;20;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;5;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;62;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;35;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;26;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;13;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;18;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;12;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;7;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;130;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;26;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;12;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;122;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;19;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;9;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;101;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;36;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;83;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;63;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;50;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;16;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;5;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;46;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;7;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;32;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;11;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;23;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;7;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;20;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;5;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;2;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;62;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;35;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;26;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;13;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;18;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;12;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;7;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;145;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;27;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;15;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;129;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;21;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;10;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;113;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;43;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;90;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;36;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;67;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;62;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;58;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;17;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;5;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;50;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;8;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;36;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;12;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;5;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;25;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;7;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;22;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;5;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;3;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;67;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;43;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;34;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;37;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;27;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;13;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;35;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;20;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;13;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;8;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;145;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;27;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;15;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;129;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;21;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;10;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;113;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;43;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;90;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;36;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;67;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;62;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;58;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;17;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;5;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;50;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;8;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;36;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;12;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;5;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;25;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;7;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;22;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;5;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;3;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;67;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;43;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;34;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;37;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;27;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;13;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;35;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;20;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;13;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;8;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;155;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;30;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;16;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;151;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;23;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;11;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;123;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;48;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;101;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;39;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;75;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;69;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;63;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;19;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;6;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;54;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;9;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;40;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;13;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;5;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;35;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;28;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;8;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;26;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;6;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;3;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;70;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;47;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;19;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;41;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;30;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;15;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;21;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;8;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;155;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;30;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;16;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;151;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;23;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;11;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;123;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;48;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;101;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;39;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;75;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;69;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;63;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;19;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;6;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;54;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;9;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;40;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;13;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;5;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;35;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;28;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;8;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;26;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;6;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;3;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;70;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;47;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;19;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;41;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;30;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;15;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;21;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;8;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;171;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;33;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;17;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;164;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;26;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;12;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;136;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;51;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;113;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;83;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;75;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;70;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;21;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;6;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;61;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;10;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;46;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;15;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;6;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;39;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;30;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;9;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;27;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;6;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;3;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;78;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;50;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;44;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;32;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;16;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;23;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;16;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;9;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;171;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;33;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;17;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;164;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;26;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;12;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;136;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;51;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;113;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;83;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;75;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;70;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;21;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;6;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;61;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;10;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;46;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;15;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;6;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;39;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;30;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;9;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;27;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;6;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;3;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;78;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;50;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;44;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;32;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;16;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;23;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;16;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;9;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;195;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;37;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;18;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;186;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;29;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;13;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;147;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;57;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;32;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;124;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;48;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;91;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;87;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;74;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;23;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;7;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;66;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;11;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;4;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;48;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;17;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;7;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;42;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;33;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;10;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;5;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;30;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;7;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;4;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;83;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;47;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;34;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;17;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;44;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;25;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;17;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;9;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;195;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;37;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;18;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;186;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;29;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;13;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;147;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;57;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;32;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;124;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;48;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;91;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;87;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;74;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;23;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;7;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;66;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;11;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;4;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;48;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;17;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;7;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;42;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;33;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;10;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;5;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;30;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;7;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;4;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;83;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;47;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;34;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;17;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;44;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;25;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;17;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;9;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;205;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;40;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;20;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;192;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;31;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;14;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;163;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;61;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;133;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;103;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;81;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;25;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;8;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;74;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;12;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;4;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;53;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;19;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;7;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;46;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;36;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;11;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;5;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;33;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;8;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;4;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;86;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;43;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;50;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;36;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;18;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;36;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;46;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;26;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;17;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;10;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;205;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;40;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;20;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;192;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;31;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;14;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;163;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;61;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;133;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;103;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;81;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;25;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;8;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;74;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;12;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;4;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;53;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;19;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;7;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;46;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;36;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;11;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;5;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;33;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;8;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;4;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;86;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;43;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;50;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;36;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;18;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;36;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;46;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;26;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;17;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;10;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;224;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;44;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;21;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;212;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;33;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;15;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;177;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;67;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;38;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;144;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;111;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;101;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;92;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;27;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;9;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;78;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;13;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;4;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;57;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;20;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;8;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;51;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;40;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;12;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;6;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;35;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;9;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;4;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;93;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;53;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;38;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;19;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;39;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;48;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;27;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;19;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;11;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;224;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;44;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;21;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;212;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;33;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;15;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;177;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;67;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;38;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;144;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;111;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;101;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;92;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;27;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;9;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;78;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;13;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;4;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;57;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;20;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;8;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;51;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;40;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;12;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;6;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;35;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;9;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;4;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;93;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;53;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;38;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;19;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;39;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;48;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;27;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;19;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;11;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;249;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;46;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;24;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;234;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;37;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;16;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;189;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;72;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;40;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;155;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;61;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;120;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;113;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;98;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;29;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;9;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;85;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;14;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;5;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;62;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;22;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;9;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;54;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;43;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;13;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;6;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;39;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;9;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;5;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;97;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;63;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;56;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;40;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;20;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;51;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;29;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;20;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;11;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;249;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;46;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;24;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;234;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;37;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;16;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;189;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;72;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;40;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;155;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;61;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;120;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;113;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;98;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;29;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;9;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;85;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;14;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;5;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;62;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;22;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;9;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;54;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;43;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;13;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;6;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;39;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;9;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;5;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;97;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;63;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;56;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;40;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;20;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;51;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;29;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;20;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;11;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;266;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;50;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;25;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;250;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;40;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;18;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;205;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;77;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;168;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;66;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;125;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;105;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;31;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;10;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;91;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;15;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;5;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;68;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;23;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;9;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;58;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;46;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;13;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;7;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;42;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;10;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;5;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;103;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;50;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;58;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;42;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;21;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;31;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;20;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;12;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;266;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;50;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;25;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;250;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;40;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;18;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;205;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;77;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;168;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;66;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;125;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;105;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;31;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;10;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;91;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;15;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;5;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;68;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;23;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;9;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;58;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;46;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;13;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;7;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;42;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;10;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;5;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;103;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;50;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;58;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;42;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;21;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;54;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;31;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;20;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;12;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;288;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;54;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;28;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;263;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;43;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;19;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;219;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;85;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;179;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;142;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;125;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;112;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;33;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;11;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;97;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;16;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;72;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;25;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;10;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;64;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;50;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;15;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;7;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;45;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;11;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;5;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;61;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;44;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;22;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;57;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;31;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;22;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;12;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;288;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;54;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;28;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;263;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;43;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;19;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;219;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;85;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;179;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;142;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;125;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;112;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;33;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;11;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;97;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;16;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;72;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;25;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;10;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;64;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;50;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;15;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;7;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;45;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;11;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;5;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;61;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;44;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;22;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;57;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;31;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;22;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;12;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;309;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;59;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;29;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;284;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;46;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;21;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;234;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;90;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;193;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;76;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;147;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;136;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;121;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;36;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;12;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;103;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;17;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;78;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;27;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;11;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;67;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;53;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;16;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;8;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;48;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;12;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;6;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;114;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;74;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;64;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;46;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;23;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;59;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;33;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;23;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;13;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;309;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;59;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;29;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;284;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;46;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;21;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;234;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;90;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;193;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;76;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;147;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;136;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;121;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;36;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;12;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;103;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;17;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;78;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;27;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;11;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;67;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;53;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;16;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;8;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;48;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;12;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;6;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;114;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;74;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;64;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;46;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;23;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;59;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;33;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;23;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;13;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;332;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;63;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;31;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;303;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;50;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;22;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;249;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;97;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;54;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;203;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;82;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;162;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;144;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;128;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;38;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;13;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;111;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;19;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;83;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;29;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;12;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;73;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;28;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;57;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;17;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;8;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;51;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;13;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;6;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;120;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;78;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;57;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;68;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;48;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;24;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;35;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;23;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;13;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;332;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;63;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;31;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;303;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;50;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;22;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;249;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;97;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;54;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;203;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;82;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;162;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;144;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;128;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;38;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;13;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;111;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;19;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;83;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;29;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;12;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;73;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;28;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;57;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;17;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;8;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;51;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;13;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;6;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;120;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;78;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;57;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;68;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;48;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;24;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;49;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;35;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;23;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;13;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;358;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;66;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;34;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;322;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;52;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;24;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;270;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;102;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;57;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;220;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;85;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;167;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;154;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;139;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;41;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;13;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;118;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;19;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;7;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;88;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;31;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;60;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;18;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;9;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;54;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;14;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;7;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;124;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;80;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;59;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;70;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;50;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;25;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;37;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;24;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;14;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;358;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;66;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;34;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;322;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;52;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;24;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;270;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;102;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;57;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;220;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;85;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;167;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;154;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;139;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;41;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;13;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;118;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;19;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;7;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;88;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;31;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;60;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;18;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;9;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;54;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;14;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;7;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;124;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;80;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;59;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;70;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;50;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;25;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;37;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;24;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;14;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;376;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;70;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;36;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;339;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;56;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;25;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;285;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;107;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;229;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;90;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;178;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;164;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;149;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;43;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;14;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;125;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;21;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;7;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;93;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;33;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;64;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;19;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;9;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;57;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;15;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;7;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;126;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;72;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;52;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;26;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;38;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;26;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;14;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;376;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;70;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;36;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;339;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;56;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;25;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;285;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;107;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;229;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;90;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;178;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;164;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;149;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;43;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;14;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;125;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;21;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;7;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;93;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;33;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;64;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;19;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;9;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;57;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;15;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;7;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;126;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;72;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;52;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;26;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;38;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;26;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;14;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;400;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;74;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;38;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;359;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;59;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;26;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;300;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;115;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;63;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;243;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;95;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;186;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;173;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;155;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;46;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;15;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;131;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;22;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;8;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;100;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;34;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;88;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;68;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;20;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;9;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;60;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;15;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;7;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;87;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;75;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;53;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;27;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;68;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;39;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;26;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;15;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;400;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;74;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;38;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;359;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;59;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;26;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;300;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;115;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;63;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;243;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;95;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;186;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;173;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;155;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;46;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;15;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;131;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;22;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;8;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;100;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;34;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;88;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;68;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;20;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;9;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;60;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;15;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;7;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;87;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;75;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;53;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;27;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;68;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;39;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;26;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;15;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;413;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;78;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;39;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;374;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;63;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;27;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;319;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;120;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;257;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;101;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;200;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;182;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;162;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;48;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;16;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;137;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;23;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;8;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;106;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;37;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;15;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;93;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;72;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;21;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;10;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;64;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;16;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;8;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;137;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;88;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;78;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;55;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;28;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;56;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;41;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;27;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;15;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;413;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;78;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;39;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;374;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;63;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;27;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;319;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;120;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;257;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;101;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;200;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;182;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;162;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;48;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;16;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;137;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;23;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;8;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;106;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;37;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;15;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;93;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;72;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;21;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;10;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;64;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;16;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;8;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;137;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;88;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;78;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;55;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;28;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;56;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;41;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;27;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;15;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;442;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;83;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;42;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;397;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;66;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;30;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;330;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;126;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;273;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;106;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;40;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;208;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;195;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;168;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;50;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;17;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;144;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;25;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;9;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;111;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;39;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;16;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;97;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;76;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;22;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;11;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;67;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;17;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;8;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;141;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;81;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;57;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;29;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;41;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;28;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;15;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;442;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;83;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;42;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;397;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;66;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;30;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;330;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;126;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;273;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;106;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;40;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;208;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;195;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;168;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;50;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;17;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;144;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;25;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;9;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;111;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;39;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;16;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;97;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;76;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;22;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;11;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;67;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;17;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;8;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;141;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;81;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;57;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;29;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;41;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;28;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;15;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;461;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;85;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;43;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;417;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;69;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;30;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;132;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;281;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;110;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;218;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;203;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;177;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;52;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;18;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;149;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;26;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;9;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;118;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;40;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;17;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;101;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;78;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;23;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;11;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;71;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;18;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;8;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;146;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;95;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;83;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;59;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;30;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;43;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;29;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;16;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;461;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;85;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;43;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;417;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;69;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;30;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;132;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;281;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;110;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;218;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;203;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;177;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;52;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;18;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;149;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;26;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;9;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;118;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;40;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;17;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;101;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;78;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;23;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;11;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;71;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;18;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;8;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;146;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;95;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;83;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;59;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;30;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;43;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;29;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;16;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;481;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;90;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;46;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;433;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;73;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;32;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;360;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;136;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;76;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;293;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;44;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;227;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;211;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;189;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;54;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;18;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;159;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;26;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;9;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;122;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;42;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;17;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;107;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;82;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;23;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;12;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;74;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;19;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;9;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;85;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;59;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;30;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;45;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;30;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;16;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;481;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;90;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;46;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;433;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;73;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;32;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;360;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;136;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;76;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;293;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;44;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;227;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;211;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;189;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;54;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;18;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;159;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;26;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;9;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;122;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;42;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;17;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;107;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;82;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;23;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;12;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;74;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;19;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;9;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;98;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;85;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;59;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;30;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;45;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;30;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;16;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;503;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;94;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;48;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;446;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;77;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;33;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;375;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;142;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;305;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;240;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;222;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;194;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;56;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;19;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;163;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;27;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;10;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;127;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;44;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;18;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;112;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;84;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;24;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;12;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;77;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;20;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;9;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;153;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;87;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;61;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;31;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;45;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;30;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;503;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;94;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;48;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;446;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;77;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;33;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;375;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;142;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;305;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;240;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;222;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;194;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;56;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;19;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;163;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;27;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;10;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;127;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;44;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;18;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;112;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;84;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;24;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;12;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;77;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;20;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;9;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;153;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;87;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;61;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;31;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;45;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;30;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;525;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;96;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;49;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;469;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;77;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;35;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;388;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;320;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;124;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;249;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;230;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;202;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;59;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;20;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;170;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;28;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;10;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;133;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;46;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;19;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;89;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;25;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;12;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;79;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;20;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;9;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;89;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;62;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;32;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;46;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;31;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;525;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;96;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;49;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;469;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;77;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;35;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;388;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;320;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;124;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;249;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;230;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;202;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;59;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;20;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;170;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;28;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;10;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;133;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;46;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;19;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;89;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;25;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;12;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;79;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;20;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;9;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;89;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;62;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;32;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;46;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;31;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;548;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;101;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;51;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;483;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;81;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;36;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;402;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;322;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;127;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;259;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;238;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;211;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;60;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;21;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;175;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;30;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;10;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;136;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;47;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;20;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;121;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;91;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;26;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;83;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;21;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;10;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;91;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;64;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;32;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;47;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;31;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;548;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;101;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;51;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;483;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;81;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;36;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;402;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;322;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;127;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;259;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;238;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;211;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;60;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;21;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;175;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;30;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;10;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;136;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;47;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;20;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;121;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;91;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;26;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;83;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;21;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;10;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;91;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;64;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;32;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;47;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;31;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;559;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;104;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;53;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;494;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;83;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;37;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;416;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;156;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;86;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;336;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;263;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;247;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;218;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;62;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;21;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;180;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;30;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;11;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;141;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;49;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;20;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;125;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;94;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;27;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;85;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;22;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;10;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;93;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;65;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;33;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;48;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;32;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;559;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;104;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;53;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;494;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;83;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;37;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;416;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;156;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;86;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;336;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;263;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;247;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;218;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;62;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;21;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;180;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;30;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;11;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;141;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;49;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;20;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;125;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;94;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;27;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;85;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;22;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;10;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;93;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;65;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;33;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;48;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;32;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;17;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;579;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;107;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;54;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;508;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;86;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;38;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;424;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;162;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;88;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;351;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;135;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;272;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;253;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;222;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;63;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;22;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;184;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;31;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;11;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;145;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;50;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;21;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;128;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;97;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;28;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;13;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;86;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;23;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;10;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;94;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;65;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;34;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;48;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;33;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;579;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;107;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;54;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;508;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;86;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;38;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;424;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;162;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;88;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;351;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;135;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;272;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;253;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;222;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;63;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;22;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;184;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;31;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;11;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;145;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;50;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;21;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;128;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;97;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;28;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;13;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;86;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;23;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;10;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;94;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;65;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;34;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;48;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;33;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;593;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;111;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;56;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;516;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;88;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;39;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;438;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;355;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;137;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;276;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;260;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;228;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;65;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;23;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;187;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;32;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;11;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;150;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;52;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;21;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;99;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;28;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;89;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;23;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;109;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;96;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;66;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;34;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;68;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;49;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;33;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;593;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;111;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;56;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;516;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;88;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;39;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;438;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;355;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;137;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;276;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;260;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;228;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;65;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;23;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;187;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;32;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;11;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;150;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;52;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;21;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;99;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;28;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;89;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;23;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;109;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;96;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;66;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;34;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;68;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;49;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;33;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;606;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;112;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;57;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;527;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;90;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;40;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;92;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;358;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;282;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;266;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;233;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;66;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;23;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;190;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;32;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;152;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;53;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;22;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;133;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;101;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;91;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;24;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;169;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;96;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;67;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;34;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;50;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;606;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;112;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;57;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;527;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;90;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;40;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;92;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;358;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;282;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;266;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;233;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;66;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;23;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;190;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;32;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;152;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;53;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;22;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;133;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;101;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;91;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;24;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;169;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;96;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;67;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;34;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;50;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;621;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;114;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;58;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;535;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;91;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;40;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;449;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;167;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;92;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;365;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;141;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;286;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;270;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;236;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;67;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;24;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;195;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;33;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;154;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;54;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;22;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;136;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;102;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;92;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;24;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;97;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;67;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;35;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;50;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;621;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;114;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;58;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;535;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;91;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;40;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;449;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;167;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;92;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;365;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;141;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;286;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;270;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;236;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;67;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;24;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;195;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;33;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;154;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;54;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;22;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;136;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;102;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;92;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;24;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;97;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;67;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;35;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;50;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;627;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;116;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;58;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;544;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;93;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;41;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;450;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;171;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;93;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;368;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;290;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;239;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;67;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;24;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;195;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;33;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;157;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;55;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;23;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;137;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;104;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;93;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;24;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;173;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;97;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;68;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;35;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;50;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;627;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;116;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;58;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;544;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;93;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;41;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;450;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;171;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;93;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;368;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;290;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;239;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;67;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;24;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;195;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;33;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;157;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;55;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;23;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;137;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;104;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;93;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;24;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;173;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;97;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;68;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;35;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;50;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;634;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;117;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;59;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;544;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;94;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;41;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;454;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;171;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;93;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;370;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;143;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;292;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;241;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;67;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;24;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;196;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;33;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;157;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;55;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;23;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;104;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;94;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;25;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;173;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;98;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;68;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;35;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;51;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;634;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;117;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;59;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;544;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;94;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;41;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;454;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;171;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;93;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;370;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;143;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;292;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;241;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;67;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;24;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;196;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;33;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;12;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;157;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;55;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;23;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;104;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;29;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;14;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;94;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;25;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;11;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;173;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;98;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;68;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;35;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;51;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;34;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;18;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;3;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;3;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;3;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;3;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;0;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;0;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;3;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;3;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;0;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;3;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;3;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;4;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;3;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;3;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;9;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;3;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;3;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;9;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;3;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;3;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;3;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;1;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;6;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;9;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;7;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;5;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;5;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;5;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;2;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;6;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;9;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;7;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;5;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;2;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;5;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;5;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;2;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;14;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;3;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;15;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;15;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;7;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;5;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;6;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;12;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;6;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;6;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;2;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;3;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;14;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;3;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;15;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;15;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;7;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;5;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;6;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;12;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;6;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;6;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;2;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;3;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;1;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;14;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;4;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;15;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;13;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;8;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;6;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;3;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;3;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;15;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;9;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;6;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;3;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;4;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;3;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;2;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;14;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;4;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;15;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;2;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;13;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;8;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;2;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;6;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;3;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;0;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;3;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;15;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;9;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;6;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;3;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;4;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;3;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;2;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;17;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;4;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;3;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;22;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;3;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;20;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;9;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;10;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;3;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;10;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;4;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;11;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;8;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;3;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;5;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;3;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;2;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;17;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;4;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;3;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;22;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;3;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;1;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;20;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;9;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;10;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;3;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;10;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;4;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;11;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;8;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;3;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;5;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;3;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;2;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2019W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2019W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2019;B;56604;B Psychologie;SOW;N;N;N;24;1.33
-21PB;2019;B;56604;B Psychologie;SOW;E;N;N;5;1.33
-21PB;2019;B;56604;B Psychologie;SOW;R;N;N;3;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;27;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;4;1.33
-21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;2;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.33
-21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.33
-21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.33
-21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.33
-21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33
-21PB;2019;B;56981;B Politicologie;MAN;N;N;N;10;1.33
-21PB;2019;B;56981;B Politicologie;MAN;E;N;N;4;1.33
-21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;12;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;2;1.33
-21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;6;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.33
-21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;5;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33
-21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;N;N;N;4;1.33
-21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33
-21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.09
-21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.09
-21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.09
-21PB;2019;M;60300;M Informatica;SOW;N;N;N;11;1.09
-21PB;2019;M;60300;M Informatica;SOW;E;N;N;8;1.09
-21PB;2019;M;60300;M Informatica;SOW;R;N;N;4;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.09
-21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.09
-21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;6;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;4;1.09
-21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;3;1.09
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2019;B;56604;B Psychologie;SOW;N;N;N;24;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;E;N;N;5;1.33;V
+21PB;2019;B;56604;B Psychologie;SOW;R;N;N;3;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;N;N;N;27;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;E;N;N;4;1.33;V
+21PB;2019;B;56551;B Geneeskunde;MED;R;N;N;2;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.33;V
+21PB;2019;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;N;N;N;19;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.33;V
+21PB;2019;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.33;V
+21PB;2019;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.33;V
+21PB;2019;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;N;N;N;10;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;E;N;N;4;1.33;V
+21PB;2019;B;56981;B Politicologie;MAN;R;N;N;1;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;N;N;N;12;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;E;N;N;2;1.33;V
+21PB;2019;B;56034;B Geschiedenis;FdL;R;N;N;0;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;N;N;N;6;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56980;B Wiskunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.33;V
+21PB;2019;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;N;N;N;5;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;E;N;N;2;1.33;V
+21PB;2019;B;56857;B Scheikunde;FNWI;R;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;N;N;N;4;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;E;N;N;1;1.33;V
+21PB;2019;B;56081;B Filosofie;FdL;R;N;N;0;1.33;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.09;V
+21PB;2019;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.09;V
+21PB;2019;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;N;N;N;11;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;E;N;N;8;1.09;V
+21PB;2019;M;60300;M Informatica;SOW;R;N;N;4;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.09;V
+21PB;2019;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.09;V
+21PB;2019;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;N;N;N;6;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;E;N;N;4;1.09;V
+21PB;2019;M;60815;M Linguistiek;FdL;R;N;N;3;1.09;V

--- a/data/input_raw/telbestanden/telbestandY2020W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;38;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;5;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;3;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;36;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;5;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;12;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;14;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;2;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;11;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;4;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;7;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;18;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;15;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;9;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;6;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;8;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;5;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;3;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;38;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;5;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;3;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;36;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;5;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;12;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;14;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;2;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;11;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;4;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;7;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;18;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;15;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;9;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;6;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;8;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;5;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;3;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;46;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;6;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;45;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;6;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;3;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;33;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;24;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;24;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;18;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;15;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;2;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;16;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;3;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;13;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;4;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;7;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;18;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;10;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;6;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;9;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;6;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;4;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;46;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;6;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;45;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;6;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;3;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;33;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;24;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;24;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;18;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;15;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;16;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;3;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;13;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;4;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;7;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;18;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;10;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;6;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;9;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;6;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;4;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;50;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;8;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;46;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;6;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;3;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;38;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;27;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;30;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;22;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;20;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;5;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;2;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;20;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;3;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;15;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;7;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;3;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;8;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;37;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;24;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;21;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;12;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;7;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;10;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;7;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;4;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;50;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;8;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;46;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;6;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;3;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;38;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;27;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;30;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;22;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;20;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;5;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;20;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;3;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;15;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;7;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;3;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;8;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;37;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;24;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;21;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;12;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;7;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;10;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;7;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;4;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;66;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;11;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;5;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;63;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;8;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;3;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;45;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;16;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;13;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;37;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;25;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;6;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;2;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;23;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;18;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;6;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;9;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;3;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;10;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;3;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;41;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;27;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;23;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;13;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;8;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;12;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;8;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;4;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;66;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;11;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;5;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;63;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;8;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;3;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;45;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;16;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;13;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;37;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;25;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;6;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;23;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;18;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;6;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;9;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;3;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;10;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;3;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;41;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;27;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;23;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;13;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;8;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;12;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;8;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;4;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;74;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;12;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;6;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;78;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;10;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;4;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;50;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;37;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;16;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;38;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;30;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;26;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;7;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;3;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;26;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;21;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;7;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;11;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;4;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;11;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;3;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;46;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;30;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;26;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;15;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;9;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;13;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;8;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;5;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;74;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;12;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;6;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;78;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;10;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;4;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;50;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;37;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;16;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;38;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;30;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;26;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;7;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;3;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;26;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;21;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;7;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;11;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;4;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;11;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;3;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;46;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;30;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;26;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;15;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;9;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;13;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;8;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;5;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;87;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;14;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;7;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;82;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;11;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;5;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;60;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;21;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;9;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;45;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;19;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;45;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;36;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;31;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;8;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;3;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;28;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;5;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;24;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;8;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;12;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;4;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;12;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;4;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;52;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;33;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;27;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;17;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;10;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;14;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;9;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;5;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;87;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;14;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;7;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;82;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;11;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;5;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;60;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;21;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;9;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;45;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;19;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;45;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;36;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;31;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;8;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;3;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;28;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;5;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;24;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;8;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;12;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;4;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;12;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;4;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;1;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;52;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;33;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;27;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;17;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;10;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;14;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;9;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;5;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;98;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;15;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;8;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;96;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;13;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;6;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;62;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;51;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;53;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;41;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;37;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;10;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;34;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;6;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;28;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;10;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;15;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;5;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;16;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;4;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;57;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;36;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;30;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;18;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;11;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;19;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;16;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;10;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;6;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;98;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;15;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;8;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;96;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;13;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;6;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;62;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;51;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;53;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;41;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;37;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;10;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;34;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;6;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;28;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;10;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;15;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;5;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;16;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;4;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;57;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;36;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;30;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;18;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;11;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;19;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;16;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;10;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;6;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;113;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;18;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;9;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;111;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;15;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;7;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;77;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;60;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;24;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;60;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;46;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;42;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;12;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;38;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;6;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;30;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;10;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;16;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;5;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;16;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;4;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;63;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;40;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;24;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;33;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;20;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;12;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;18;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;11;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;6;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;113;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;18;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;9;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;111;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;15;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;7;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;77;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;60;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;24;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;60;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;46;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;42;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;12;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;38;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;6;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;30;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;10;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;16;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;5;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;16;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;4;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;63;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;40;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;24;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;33;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;20;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;12;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;18;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;11;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;6;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;122;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;21;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;11;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;121;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;17;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;7;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;85;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;31;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;67;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;28;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;72;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;49;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;49;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;13;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;5;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;42;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;7;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;33;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;12;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;30;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;18;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;6;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;19;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;5;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;67;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;36;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;21;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;13;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;30;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;19;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;12;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;7;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;122;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;21;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;11;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;121;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;17;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;7;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;85;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;31;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;67;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;28;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;72;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;49;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;49;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;13;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;5;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;42;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;7;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;33;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;12;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;30;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;18;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;6;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;19;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;5;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;67;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;36;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;21;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;13;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;30;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;19;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;12;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;7;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;138;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;23;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;12;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;135;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;20;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;96;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;37;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;75;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;31;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;78;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;59;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;15;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;5;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;46;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;8;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;38;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;13;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;21;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;7;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;3;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;21;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;6;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;47;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;40;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;23;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;15;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;20;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;13;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;7;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;138;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;23;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;12;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;135;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;20;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;96;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;37;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;75;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;31;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;78;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;59;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;59;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;15;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;5;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;46;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;8;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;38;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;13;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;21;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;7;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;3;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;21;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;6;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;47;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;40;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;23;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;15;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;20;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;13;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;7;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;165;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;26;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;14;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;145;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;22;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;9;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;106;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;42;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;88;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;87;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;63;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;62;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;17;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;6;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;51;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;9;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;43;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;14;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;5;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;39;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;25;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;7;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;23;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;6;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;79;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;50;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;30;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;19;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;42;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;26;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;15;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;22;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;14;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;8;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;165;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;26;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;14;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;145;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;22;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;9;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;106;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;42;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;88;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;87;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;63;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;62;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;17;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;6;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;51;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;9;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;43;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;14;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;5;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;39;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;25;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;7;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;23;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;6;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;79;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;50;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;30;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;19;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;42;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;26;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;15;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;22;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;14;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;8;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;171;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;29;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;15;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;169;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;25;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;10;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;115;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;47;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;96;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;38;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;94;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;72;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;67;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;18;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;6;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;59;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;10;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;45;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;16;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;6;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;42;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;26;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;8;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;4;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;26;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;7;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;84;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;32;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;47;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;28;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;16;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;37;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;24;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;8;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;171;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;29;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;15;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;169;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;25;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;10;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;115;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;47;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;96;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;38;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;94;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;72;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;67;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;18;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;6;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;59;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;10;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;45;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;16;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;6;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;42;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;26;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;8;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;4;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;26;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;7;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;2;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;84;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;32;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;47;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;28;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;16;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;37;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;24;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;8;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;188;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;32;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;17;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;184;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;27;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;11;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;126;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;51;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;105;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;43;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;103;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;77;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;74;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;20;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;7;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;65;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;10;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;49;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;18;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;6;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;46;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;29;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;9;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;5;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;28;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;8;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;3;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;89;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;48;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;30;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;17;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;25;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;16;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;9;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;188;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;32;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;17;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;184;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;27;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;11;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;126;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;51;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;105;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;43;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;103;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;77;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;74;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;20;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;7;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;65;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;10;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;49;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;18;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;6;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;46;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;29;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;9;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;5;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;28;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;8;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;3;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;89;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;48;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;30;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;17;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;25;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;16;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;9;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;215;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;35;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;18;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;199;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;30;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;13;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;140;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;54;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;117;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;111;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;85;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;83;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;22;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;8;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;69;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;11;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;56;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;19;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;7;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;50;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;33;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;10;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;5;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;31;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;8;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;3;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;93;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;51;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;32;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;18;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;34;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;43;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;27;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;17;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;10;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;215;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;35;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;18;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;199;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;30;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;13;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;140;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;54;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;117;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;111;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;85;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;83;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;22;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;8;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;69;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;11;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;56;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;19;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;7;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;50;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;33;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;10;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;5;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;31;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;8;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;3;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;93;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;23;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;51;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;32;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;18;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;34;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;43;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;27;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;17;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;10;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;237;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;39;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;20;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;220;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;33;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;14;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;156;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;60;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;128;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;50;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;125;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;97;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;90;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;24;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;9;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;78;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;12;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;4;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;62;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;21;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;7;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;55;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;36;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;10;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;5;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;34;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;9;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;3;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;99;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;65;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;55;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;33;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;19;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;46;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;29;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;19;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;10;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;237;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;39;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;20;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;220;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;33;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;14;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;156;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;60;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;128;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;50;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;125;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;97;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;90;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;24;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;9;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;78;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;12;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;4;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;62;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;21;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;7;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;55;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;36;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;10;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;5;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;34;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;9;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;3;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;99;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;65;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;55;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;33;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;19;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;46;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;29;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;19;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;10;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;244;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;42;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;22;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;237;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;36;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;15;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;169;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;69;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;29;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;138;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;135;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;102;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;100;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;26;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;10;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;84;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;13;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;4;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;65;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;23;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;8;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;60;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;38;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;12;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;6;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;37;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;10;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;4;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;105;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;58;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;35;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;21;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;37;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;48;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;31;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;20;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;11;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;244;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;42;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;22;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;237;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;36;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;15;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;169;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;69;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;29;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;138;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;56;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;135;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;102;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;100;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;26;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;10;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;84;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;13;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;4;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;65;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;23;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;8;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;60;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;38;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;12;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;6;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;37;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;10;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;4;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;105;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;58;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;35;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;21;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;37;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;48;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;31;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;20;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;11;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;266;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;44;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;23;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;256;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;39;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;16;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;179;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;72;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;31;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;152;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;147;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;114;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;109;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;29;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;11;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;92;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;15;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;4;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;71;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;25;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;9;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;43;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;13;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;6;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;39;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;10;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;4;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;111;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;61;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;38;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;22;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;32;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;21;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;11;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;266;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;44;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;23;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;256;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;39;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;16;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;179;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;72;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;31;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;152;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;147;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;114;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;109;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;29;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;11;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;92;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;15;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;4;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;71;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;25;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;9;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;43;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;13;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;6;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;39;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;10;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;4;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;111;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;61;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;38;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;22;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;32;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;21;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;11;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;289;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;48;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;26;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;280;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;43;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;17;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;194;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;79;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;34;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;163;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;64;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;27;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;156;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;121;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;117;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;32;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;11;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;98;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;16;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;76;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;26;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;9;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;69;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;46;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;14;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;7;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;42;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;12;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;4;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;116;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;64;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;39;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;23;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;42;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;33;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;22;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;12;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;289;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;48;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;26;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;280;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;43;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;17;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;194;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;79;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;34;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;163;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;64;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;27;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;156;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;121;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;117;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;32;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;11;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;98;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;16;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;76;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;26;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;9;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;69;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;46;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;14;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;7;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;42;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;12;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;4;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;116;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;64;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;39;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;23;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;42;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;33;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;22;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;12;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;314;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;53;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;27;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;294;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;46;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;18;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;209;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;84;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;37;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;175;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;67;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;167;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;130;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;129;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;34;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;12;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;104;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;17;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;82;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;28;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;10;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;76;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;49;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;14;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;8;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;46;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;12;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;124;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;79;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;67;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;41;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;24;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;35;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;23;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;12;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;314;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;53;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;27;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;294;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;46;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;18;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;209;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;84;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;37;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;175;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;67;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;167;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;130;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;129;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;34;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;12;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;104;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;17;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;82;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;28;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;10;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;76;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;49;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;14;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;8;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;46;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;12;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;124;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;79;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;67;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;41;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;24;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;35;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;23;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;12;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;326;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;57;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;29;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;322;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;50;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;20;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;225;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;91;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;40;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;187;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;179;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;140;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;135;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;36;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;13;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;113;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;18;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;88;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;30;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;11;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;80;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;53;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;16;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;8;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;49;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;13;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;126;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;70;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;43;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;25;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;46;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;57;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;37;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;23;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;13;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;326;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;57;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;29;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;322;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;50;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;20;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;225;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;91;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;40;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;187;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;179;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;140;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;135;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;36;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;13;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;113;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;18;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;88;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;30;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;11;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;80;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;53;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;16;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;8;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;49;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;13;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;126;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;51;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;70;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;43;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;25;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;46;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;57;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;37;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;23;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;13;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;350;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;60;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;31;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;335;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;53;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;21;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;238;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;96;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;203;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;78;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;33;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;192;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;29;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;148;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;145;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;39;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;14;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;120;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;19;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;6;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;92;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;32;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;12;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;84;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;56;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;17;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;9;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;52;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;14;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;132;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;87;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;73;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;45;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;26;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;59;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;38;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;25;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;13;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;350;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;60;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;31;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;335;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;53;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;21;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;238;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;96;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;203;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;78;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;33;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;192;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;29;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;148;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;145;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;39;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;14;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;120;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;19;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;6;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;92;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;32;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;12;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;84;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;56;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;17;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;9;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;52;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;14;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;132;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;87;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;73;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;45;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;26;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;59;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;38;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;25;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;13;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;375;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;63;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;33;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;358;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;56;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;23;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;254;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;103;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;46;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;218;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;83;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;200;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;159;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;156;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;41;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;15;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;127;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;21;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;6;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;98;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;34;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;13;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;91;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;61;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;18;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;9;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;56;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;15;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;89;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;76;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;47;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;27;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;39;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;26;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;14;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;375;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;63;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;33;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;358;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;56;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;23;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;254;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;103;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;46;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;218;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;83;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;200;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;159;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;156;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;41;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;15;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;127;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;21;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;6;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;98;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;34;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;13;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;91;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;61;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;18;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;9;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;56;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;15;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;5;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;89;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;76;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;47;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;27;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;39;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;26;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;14;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;395;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;69;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;36;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;387;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;60;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;24;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;271;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;109;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;49;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;229;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;89;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;216;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;168;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;166;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;44;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;16;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;133;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;22;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;7;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;105;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;36;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;14;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;96;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;64;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;19;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;10;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;59;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;16;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;6;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;143;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;57;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;78;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;49;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;28;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;41;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;26;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;14;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;395;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;69;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;36;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;387;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;60;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;24;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;271;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;109;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;49;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;229;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;89;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;216;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;168;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;166;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;44;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;16;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;133;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;22;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;7;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;105;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;36;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;14;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;96;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;64;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;19;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;10;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;59;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;16;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;6;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;143;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;57;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;78;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;49;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;28;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;41;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;26;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;14;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;414;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;73;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;38;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;406;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;63;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;25;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;288;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;115;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;249;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;94;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;226;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;179;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;177;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;47;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;17;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;142;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;23;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;7;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;110;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;38;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;14;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;69;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;20;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;10;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;62;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;17;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;6;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;145;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;96;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;82;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;51;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;29;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;42;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;28;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;15;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;414;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;73;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;38;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;406;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;63;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;25;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;288;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;115;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;249;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;94;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;226;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;179;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;177;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;47;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;17;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;142;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;23;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;7;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;110;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;38;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;14;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;69;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;20;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;10;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;62;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;17;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;6;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;145;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;96;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;82;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;51;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;29;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;42;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;28;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;15;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;436;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;78;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;39;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;424;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;67;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;27;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;301;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;121;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;55;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;260;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;236;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;190;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;185;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;50;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;18;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;149;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;24;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;7;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;115;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;40;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;15;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;108;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;73;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;21;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;11;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;65;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;17;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;6;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;84;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;53;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;30;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;44;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;28;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;15;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;436;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;78;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;39;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;424;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;67;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;27;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;301;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;121;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;55;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;260;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;236;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;190;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;185;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;50;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;18;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;149;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;24;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;7;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;115;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;40;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;15;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;108;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;73;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;21;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;11;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;65;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;17;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;6;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;84;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;53;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;30;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;44;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;28;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;15;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;453;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;81;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;42;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;441;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;70;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;28;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;319;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;128;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;58;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;274;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;103;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;246;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;199;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;196;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;52;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;18;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;158;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;26;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;8;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;123;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;42;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;16;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;112;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;76;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;22;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;11;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;69;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;19;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;7;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;157;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;103;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;86;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;55;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;31;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;45;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;29;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;15;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;453;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;81;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;42;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;441;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;70;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;28;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;319;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;128;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;58;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;274;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;103;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;246;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;199;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;196;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;52;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;18;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;158;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;26;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;8;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;123;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;42;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;16;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;112;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;76;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;22;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;11;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;69;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;19;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;7;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;157;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;103;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;86;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;55;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;31;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;45;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;29;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;15;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;477;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;84;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;44;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;463;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;73;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;29;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;337;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;133;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;287;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;108;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;260;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;207;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;203;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;55;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;19;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;164;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;27;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;8;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;127;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;44;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;17;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;120;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;80;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;23;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;12;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;72;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;19;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;7;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;88;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;55;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;32;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;45;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;30;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;16;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;477;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;84;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;44;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;463;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;73;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;29;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;337;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;133;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;61;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;287;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;108;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;260;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;207;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;203;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;55;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;19;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;164;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;27;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;8;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;127;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;44;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;17;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;120;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;80;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;23;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;12;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;72;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;19;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;7;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;88;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;55;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;32;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;45;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;30;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;16;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;497;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;88;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;46;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;484;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;78;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;31;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;346;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;140;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;302;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;112;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;274;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;219;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;215;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;58;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;20;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;173;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;28;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;9;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;132;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;45;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;17;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;125;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;84;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;24;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;12;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;74;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;20;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;7;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;109;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;92;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;57;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;32;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;47;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;31;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;16;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;497;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;88;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;46;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;484;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;78;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;31;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;346;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;140;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;302;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;112;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;274;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;219;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;215;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;58;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;20;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;173;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;28;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;9;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;132;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;45;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;17;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;125;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;84;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;24;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;12;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;74;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;20;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;7;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;109;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;92;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;57;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;32;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;47;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;31;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;16;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;518;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;92;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;48;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;503;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;81;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;32;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;363;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;148;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;310;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;116;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;285;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;227;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;224;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;60;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;21;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;176;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;29;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;9;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;138;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;47;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;18;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;88;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;25;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;13;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;78;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;21;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;93;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;59;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;33;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;48;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;31;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;518;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;92;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;48;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;503;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;81;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;32;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;363;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;148;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;310;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;116;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;285;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;227;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;224;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;60;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;21;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;176;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;29;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;9;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;138;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;47;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;18;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;88;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;25;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;13;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;78;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;21;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;93;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;59;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;33;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;48;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;31;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;534;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;96;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;50;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;521;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;84;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;33;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;380;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;153;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;69;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;319;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;122;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;292;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;236;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;234;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;62;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;22;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;185;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;30;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;9;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;143;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;49;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;19;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;92;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;26;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;14;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;81;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;22;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;96;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;60;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;34;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;49;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;32;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;534;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;96;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;50;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;521;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;84;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;33;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;380;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;153;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;69;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;319;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;122;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;292;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;236;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;234;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;62;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;22;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;185;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;30;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;9;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;143;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;49;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;19;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;92;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;26;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;14;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;81;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;22;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;96;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;60;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;34;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;49;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;32;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;554;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;99;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;51;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;538;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;87;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;35;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;389;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;157;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;334;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;125;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;304;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;246;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;238;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;65;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;22;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;193;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;31;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;148;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;50;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;20;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;93;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;27;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;14;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;83;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;22;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;174;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;97;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;61;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;34;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;49;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;33;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;554;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;99;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;51;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;538;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;87;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;35;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;389;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;157;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;334;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;125;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;304;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;246;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;238;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;65;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;22;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;193;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;31;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;148;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;50;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;20;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;138;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;93;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;27;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;14;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;83;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;22;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;174;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;97;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;61;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;34;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;49;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;33;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;571;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;104;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;54;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;553;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;90;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;36;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;401;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;75;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;347;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;309;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;253;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;247;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;66;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;23;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;196;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;32;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;151;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;52;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;20;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;143;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;97;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;28;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;14;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;86;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;23;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;178;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;117;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;70;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;98;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;62;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;34;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;51;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;33;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;571;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;104;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;54;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;553;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;90;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;36;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;401;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;75;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;347;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;309;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;253;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;247;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;66;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;23;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;196;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;32;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;151;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;52;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;20;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;143;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;97;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;28;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;14;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;86;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;23;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;8;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;178;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;117;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;70;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;98;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;62;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;34;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;51;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;33;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;583;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;107;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;55;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;563;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;93;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;37;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;416;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;357;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;134;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;319;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;259;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;256;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;69;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;24;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;202;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;33;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;154;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;53;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;21;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;146;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;101;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;28;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;15;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;89;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;24;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;182;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;100;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;63;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;35;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;51;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;34;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;583;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;107;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;55;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;563;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;93;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;37;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;416;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;357;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;134;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;319;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;259;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;256;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;69;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;24;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;202;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;33;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;154;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;53;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;21;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;146;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;101;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;28;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;15;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;89;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;24;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;182;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;100;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;63;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;35;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;51;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;34;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;595;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;109;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;57;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;577;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;96;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;38;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;423;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;366;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;136;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;323;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;270;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;258;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;71;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;24;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;206;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;34;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;158;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;55;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;21;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;150;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;103;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;29;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;15;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;91;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;24;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;183;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;121;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;101;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;64;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;35;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;52;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;34;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;595;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;109;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;57;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;577;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;96;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;38;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;423;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;366;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;136;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;323;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;270;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;258;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;71;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;24;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;206;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;34;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;10;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;158;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;55;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;21;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;150;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;103;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;29;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;15;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;91;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;24;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;183;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;121;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;101;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;64;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;35;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;52;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;34;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;604;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;110;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;58;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;592;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;99;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;38;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;435;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;328;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;50;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;268;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;73;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;25;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;210;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;34;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;161;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;55;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;22;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;153;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;107;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;15;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;93;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;184;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;102;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;65;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;68;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;52;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;34;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;604;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;110;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;58;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;592;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;99;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;38;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;435;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;81;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;328;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;50;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;268;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;73;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;25;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;210;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;34;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;161;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;55;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;22;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;153;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;107;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;15;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;93;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;184;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;102;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;65;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;68;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;52;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;34;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;611;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;113;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;59;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;592;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;101;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;39;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;440;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;175;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;83;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;381;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;140;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;331;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;274;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;74;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;25;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;213;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;35;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;162;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;56;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;22;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;154;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;108;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;16;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;93;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;184;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;102;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;65;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;53;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;35;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;611;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;113;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;59;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;592;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;101;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;39;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;440;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;175;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;83;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;381;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;140;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;331;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;274;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;74;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;25;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;213;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;35;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;162;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;56;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;22;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;154;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;108;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;16;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;93;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;184;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;102;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;65;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;53;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;35;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;612;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;114;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;59;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;599;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;102;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;40;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;177;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;387;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;331;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;281;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;275;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;75;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;26;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;213;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;35;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;163;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;56;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;23;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;109;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;16;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;94;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;186;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;103;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;65;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;53;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;35;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;612;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;114;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;59;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;599;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;102;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;40;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;177;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;387;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;331;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;281;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;275;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;75;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;26;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;213;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;35;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;163;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;56;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;23;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;109;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;16;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;94;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;186;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;103;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;65;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;53;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;35;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;615;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;115;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;60;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;599;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;103;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;40;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;447;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;178;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;387;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;144;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;336;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;285;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;277;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;76;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;26;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;215;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;35;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;164;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;56;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;23;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;110;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;16;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;94;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;187;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;103;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;66;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;53;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;35;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;615;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;115;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;60;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;599;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;103;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;40;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;447;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;178;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;387;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;144;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;336;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;285;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;277;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;76;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;26;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;215;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;35;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;11;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;164;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;56;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;23;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;110;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;30;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;16;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;94;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;25;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;9;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;187;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;103;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;66;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;36;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;53;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;35;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;3;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;4;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;1;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;1;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;4;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;1;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;7;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;4;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;3;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;1;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;1;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;7;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;4;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;3;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;1;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;4;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;1;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;4;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;0;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;4;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;1;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;9;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;10;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;5;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;3;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;9;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;10;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;5;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;3;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;10;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;9;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;4;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;4;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;7;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;4;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;3;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;3;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;10;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;9;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;4;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;0;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;4;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;0;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;7;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;4;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;3;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;3;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;22;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;5;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;5;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;8;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;4;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;3;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;4;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;3;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;2;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;13;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;22;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;5;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;5;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;2;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;8;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;4;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;3;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;4;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;3;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;2;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;20;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;22;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;3;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;8;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;6;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;3;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;18;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;10;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;5;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;4;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;4;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;3;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;2;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;20;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;22;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;3;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;8;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;6;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;3;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;18;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;10;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;5;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;4;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;4;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;3;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;2;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;28;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;4;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;2;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;25;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;3;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;16;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;13;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;11;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;8;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;8;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;2;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;7;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;4;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;23;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;12;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;6;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;4;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;6;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;4;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;2;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;28;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;4;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;25;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;3;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;1;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;16;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;13;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;11;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;8;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;2;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;8;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;2;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;7;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;0;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;4;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;23;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;12;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;6;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;4;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;6;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;4;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;2;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2020W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2020W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2020;B;56604;B Psychologie;SOW;N;N;N;37;1.35
-21PB;2020;B;56604;B Psychologie;SOW;E;N;N;5;1.35
-21PB;2020;B;56604;B Psychologie;SOW;R;N;N;3;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;27;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;3;1.35
-21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;2;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.35
-21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.35
-21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35
-21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.35
-21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35
-21PB;2020;B;56981;B Politicologie;MAN;N;N;N;12;1.35
-21PB;2020;B;56981;B Politicologie;MAN;E;N;N;3;1.35
-21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;11;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;2;1.35
-21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;9;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;3;1.35
-21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;5;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;2;1.35
-21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;N;N;N;5;1.35
-21PB;2020;B;56081;B Filosofie;FdL;E;N;N;1;1.35
-21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.11
-21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.11
-21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.11
-21PB;2020;M;60300;M Informatica;SOW;N;N;N;13;1.11
-21PB;2020;M;60300;M Informatica;SOW;E;N;N;7;1.11
-21PB;2020;M;60300;M Informatica;SOW;R;N;N;5;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.11
-21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.11
-21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;7;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;5;1.11
-21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;3;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2020;B;56604;B Psychologie;SOW;N;N;N;37;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;E;N;N;5;1.35;V
+21PB;2020;B;56604;B Psychologie;SOW;R;N;N;3;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;N;N;N;27;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;E;N;N;3;1.35;V
+21PB;2020;B;56551;B Geneeskunde;MED;R;N;N;2;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.35;V
+21PB;2020;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.35;V
+21PB;2020;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.35;V
+21PB;2020;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.35;V
+21PB;2020;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;N;N;N;12;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;E;N;N;3;1.35;V
+21PB;2020;B;56981;B Politicologie;MAN;R;N;N;1;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;N;N;N;11;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;E;N;N;2;1.35;V
+21PB;2020;B;56034;B Geschiedenis;FdL;R;N;N;0;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;N;N;N;9;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;E;N;N;3;1.35;V
+21PB;2020;B;56980;B Wiskunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;N;N;N;5;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;E;N;N;2;1.35;V
+21PB;2020;B;56857;B Scheikunde;FNWI;R;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;N;N;N;5;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;E;N;N;1;1.35;V
+21PB;2020;B;56081;B Filosofie;FdL;R;N;N;0;1.35;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.11;V
+21PB;2020;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.11;V
+21PB;2020;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;N;N;N;13;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;E;N;N;7;1.11;V
+21PB;2020;M;60300;M Informatica;SOW;R;N;N;5;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.11;V
+21PB;2020;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.11;V
+21PB;2020;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;N;N;N;7;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;E;N;N;5;1.11;V
+21PB;2020;M;60815;M Linguistiek;FdL;R;N;N;3;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2021W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;29;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;6;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;32;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;4;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;2;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;23;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;15;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;10;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;10;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;5;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;5;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;13;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;11;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;5;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;10;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;5;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;2;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;29;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;6;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;32;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;4;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;2;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;23;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;15;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;10;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;10;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;5;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;5;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;13;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;11;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;5;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;16;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;10;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;5;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;2;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;38;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;8;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;3;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;40;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;5;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;2;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;27;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;20;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;15;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;4;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;14;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;7;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;6;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;6;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;27;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;15;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;12;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;6;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;11;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;6;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;3;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;38;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;8;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;3;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;40;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;5;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;2;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;27;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;20;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;15;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;4;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;14;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;7;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;6;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;6;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;27;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;15;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;12;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;6;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;11;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;6;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;3;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;46;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;10;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;4;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;40;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;7;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;3;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;32;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;17;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;13;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;20;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;18;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;5;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;18;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;3;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;14;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;4;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;10;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;7;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;7;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;27;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;18;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;13;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;7;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;13;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;7;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;3;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;46;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;10;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;4;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;40;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;7;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;3;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;32;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;17;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;13;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;20;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;18;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;5;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;18;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;3;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;14;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;4;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;10;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;7;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;7;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;27;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;18;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;13;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;7;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;13;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;13;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;7;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;3;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;57;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;11;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;5;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;49;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;7;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;4;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;41;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;40;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;28;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;25;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;21;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;6;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;3;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;19;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;3;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;16;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;5;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;11;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;10;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;9;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;28;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;20;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;14;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;8;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;14;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;7;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;4;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;57;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;11;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;5;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;49;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;7;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;4;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;41;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;40;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;28;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;25;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;21;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;6;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;3;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;19;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;3;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;16;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;5;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;11;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;10;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;9;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;28;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;20;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;14;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;8;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;14;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;7;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;4;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;73;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;13;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;5;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;54;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;9;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;5;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;50;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;22;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;26;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;6;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;3;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;25;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;18;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;6;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;11;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;10;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;22;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;16;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;9;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;15;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;8;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;4;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;73;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;13;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;5;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;54;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;9;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;5;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;50;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;22;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;29;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;26;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;6;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;3;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;25;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;18;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;6;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;11;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;10;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;32;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;22;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;16;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;9;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;15;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;8;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;4;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;73;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;16;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;7;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;65;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;11;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;5;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;53;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;52;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;40;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;36;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;32;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;8;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;25;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;23;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;7;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;13;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;12;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;43;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;25;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;18;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;10;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;17;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;9;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;4;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;73;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;16;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;7;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;65;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;11;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;5;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;53;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;52;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;21;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;40;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;36;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;32;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;8;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;25;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;23;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;7;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;13;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;12;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;43;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;25;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;18;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;10;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;17;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;9;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;4;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;92;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;19;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;7;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;76;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;12;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;6;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;64;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;57;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;23;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;41;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;40;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;34;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;9;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;31;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;5;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;23;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;8;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;4;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;14;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;4;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;14;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;48;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;29;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;20;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;11;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;18;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;10;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;5;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;92;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;19;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;7;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;76;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;12;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;6;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;64;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;57;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;23;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;41;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;40;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;34;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;9;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;31;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;5;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;23;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;8;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;4;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;14;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;4;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;14;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;48;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;29;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;20;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;11;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;15;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;18;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;10;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;5;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;107;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;21;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;8;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;86;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;15;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;6;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;78;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;62;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;49;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;48;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;39;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;10;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;5;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;36;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;6;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;26;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;9;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;4;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;17;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;5;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;16;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;4;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;53;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;31;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;21;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;12;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;20;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;11;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;5;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;107;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;21;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;8;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;86;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;15;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;6;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;78;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;62;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;49;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;48;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;39;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;10;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;5;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;36;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;6;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;26;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;9;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;4;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;17;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;5;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;16;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;4;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;1;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;53;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;31;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;21;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;12;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;20;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;11;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;5;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;123;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;24;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;9;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;98;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;16;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;7;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;82;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;37;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;74;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;31;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;55;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;52;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;46;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;11;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;5;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;42;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;7;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;31;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;9;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;5;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;19;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;6;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;18;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;5;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;56;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;32;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;34;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;23;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;13;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;22;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;13;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;6;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;123;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;24;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;9;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;98;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;16;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;7;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;82;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;37;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;19;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;74;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;31;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;55;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;52;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;46;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;11;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;5;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;42;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;7;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;31;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;9;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;5;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;19;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;6;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;18;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;5;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;56;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;32;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;34;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;23;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;13;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;22;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;13;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;6;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;136;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;27;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;10;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;114;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;19;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;8;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;97;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;41;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;84;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;66;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;57;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;51;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;13;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;6;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;44;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;7;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;34;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;5;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;21;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;6;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;20;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;5;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;61;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;34;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;35;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;25;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;14;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;24;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;14;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;6;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;136;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;27;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;10;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;114;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;19;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;8;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;97;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;41;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;84;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;66;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;57;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;51;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;13;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;6;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;44;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;7;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;34;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;5;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;21;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;6;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;3;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;20;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;5;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;61;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;34;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;35;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;25;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;14;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;25;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;24;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;14;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;6;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;149;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;30;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;12;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;124;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;21;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;9;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;105;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;45;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;25;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;92;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;37;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;72;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;64;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;55;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;14;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;7;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;52;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;9;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;38;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;6;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;24;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;7;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;4;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;23;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;6;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;68;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;51;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;39;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;27;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;15;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;40;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;25;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;14;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;7;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;149;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;30;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;12;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;124;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;21;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;9;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;105;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;45;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;25;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;92;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;37;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;72;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;64;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;55;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;14;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;7;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;52;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;9;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;38;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;6;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;24;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;7;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;4;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;23;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;6;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;68;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;51;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;39;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;27;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;15;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;40;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;25;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;14;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;7;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;174;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;33;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;13;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;145;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;24;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;10;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;120;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;51;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;102;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;40;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;78;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;70;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;62;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;16;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;8;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;58;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;9;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;42;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;14;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;7;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;8;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;4;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;26;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;7;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;70;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;42;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;29;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;15;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;29;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;27;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;7;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;174;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;33;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;13;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;145;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;24;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;10;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;120;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;51;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;102;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;40;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;78;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;70;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;62;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;16;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;8;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;58;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;9;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;42;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;14;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;7;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;8;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;4;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;26;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;7;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;2;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;70;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;55;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;42;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;29;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;15;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;29;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;27;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;7;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;198;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;36;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;15;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;155;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;27;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;11;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;134;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;55;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;111;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;88;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;16;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;80;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;67;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;18;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;8;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;62;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;10;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;44;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;15;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;7;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;38;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;30;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;9;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;5;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;28;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;7;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;3;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;76;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;46;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;30;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;17;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;44;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;29;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;17;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;8;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;198;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;36;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;15;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;155;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;27;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;11;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;134;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;55;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;111;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;88;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;16;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;80;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;67;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;18;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;8;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;62;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;10;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;44;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;15;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;7;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;38;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;30;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;9;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;5;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;28;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;7;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;3;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;76;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;46;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;30;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;17;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;31;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;44;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;29;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;17;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;8;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;206;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;40;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;16;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;182;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;28;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;12;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;146;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;60;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;120;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;92;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;84;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;76;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;20;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;9;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;68;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;11;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;4;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;51;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;17;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;8;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;42;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;33;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;9;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;5;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;31;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;8;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;3;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;82;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;63;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;49;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;32;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;18;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;31;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;18;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;8;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;206;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;40;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;16;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;182;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;28;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;12;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;146;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;60;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;120;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;92;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;84;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;76;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;20;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;9;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;68;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;11;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;4;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;51;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;17;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;8;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;42;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;33;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;9;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;5;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;31;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;8;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;3;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;82;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;63;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;49;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;32;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;18;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;31;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;18;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;8;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;236;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;43;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;17;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;189;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;32;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;14;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;160;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;65;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;134;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;104;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;83;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;21;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;9;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;75;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;13;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;4;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;54;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;18;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;9;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;46;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;36;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;10;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;6;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;34;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;9;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;3;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;87;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;66;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;52;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;35;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;19;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;32;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;19;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;9;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;236;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;43;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;17;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;189;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;32;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;14;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;160;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;65;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;134;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;104;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;19;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;83;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;21;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;9;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;75;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;13;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;4;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;54;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;18;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;9;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;46;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;36;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;10;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;6;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;34;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;9;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;3;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;87;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;66;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;46;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;52;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;35;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;19;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;32;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;19;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;9;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;253;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;47;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;19;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;208;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;35;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;15;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;170;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;71;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;145;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;115;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;88;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;23;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;11;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;80;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;14;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;5;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;60;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;20;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;10;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;50;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;39;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;11;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;6;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;37;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;10;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;4;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;92;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;69;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;54;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;36;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;20;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;34;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;21;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;10;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;253;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;47;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;19;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;208;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;35;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;15;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;170;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;71;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;39;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;145;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;115;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;88;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;23;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;11;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;80;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;14;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;5;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;60;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;20;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;10;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;50;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;39;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;11;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;6;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;37;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;10;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;4;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;92;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;69;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;54;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;36;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;20;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;34;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;21;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;10;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;277;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;52;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;20;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;222;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;38;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;16;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;190;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;75;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;42;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;155;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;62;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;126;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;113;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;97;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;25;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;11;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;89;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;15;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;5;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;63;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;22;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;11;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;54;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;43;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;12;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;7;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;41;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;10;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;4;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;97;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;57;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;39;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;21;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;39;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;36;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;21;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;10;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;277;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;52;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;20;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;222;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;38;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;16;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;190;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;75;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;42;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;155;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;62;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;126;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;113;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;97;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;25;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;11;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;89;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;15;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;5;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;63;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;22;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;11;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;54;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;43;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;12;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;7;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;41;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;10;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;4;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;97;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;57;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;39;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;21;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;39;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;36;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;21;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;10;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;296;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;56;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;22;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;250;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;41;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;17;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;201;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;82;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;170;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;67;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;132;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;117;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;104;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;28;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;12;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;98;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;16;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;5;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;69;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;24;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;11;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;60;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;47;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;13;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;7;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;45;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;11;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;4;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;100;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;61;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;40;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;22;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;37;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;23;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;11;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;296;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;56;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;22;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;250;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;41;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;17;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;201;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;82;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;170;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;67;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;132;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;117;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;104;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;28;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;12;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;98;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;16;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;5;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;69;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;24;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;11;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;60;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;47;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;13;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;7;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;45;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;11;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;4;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;100;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;61;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;40;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;22;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;37;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;23;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;11;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;323;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;59;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;24;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;267;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;45;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;19;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;220;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;90;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;48;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;178;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;71;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;145;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;131;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;113;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;30;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;13;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;104;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;17;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;6;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;74;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;25;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;12;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;63;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;50;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;14;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;8;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;47;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;12;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;5;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;81;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;64;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;42;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;23;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;60;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;39;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;24;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;11;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;323;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;59;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;24;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;267;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;45;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;19;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;220;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;90;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;48;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;178;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;71;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;30;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;145;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;131;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;113;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;30;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;13;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;104;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;17;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;6;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;74;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;25;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;12;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;63;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;50;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;14;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;8;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;47;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;12;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;5;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;81;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;64;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;42;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;23;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;60;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;39;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;24;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;11;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;353;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;65;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;26;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;284;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;48;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;20;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;236;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;93;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;191;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;77;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;158;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;138;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;122;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;32;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;14;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;111;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;18;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;6;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;80;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;27;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;13;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;68;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;28;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;54;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;15;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;8;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;52;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;13;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;5;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;110;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;84;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;67;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;45;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;24;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;65;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;41;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;25;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;12;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;353;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;65;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;26;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;284;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;48;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;20;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;236;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;93;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;52;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;191;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;77;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;32;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;158;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;138;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;122;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;32;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;14;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;111;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;18;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;6;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;80;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;27;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;13;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;68;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;28;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;54;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;15;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;8;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;52;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;13;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;5;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;110;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;84;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;67;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;45;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;24;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;65;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;41;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;25;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;12;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;375;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;70;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;28;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;299;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;51;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;21;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;253;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;100;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;208;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;81;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;165;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;145;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;129;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;34;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;15;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;119;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;20;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;7;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;85;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;29;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;14;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;73;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;57;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;16;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;9;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;54;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;14;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;5;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;115;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;88;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;70;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;46;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;25;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;42;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;26;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;12;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;375;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;70;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;28;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;299;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;51;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;21;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;253;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;100;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;208;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;81;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;165;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;145;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;129;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;34;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;15;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;119;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;20;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;7;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;85;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;29;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;14;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;73;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;57;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;16;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;9;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;54;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;14;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;5;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;115;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;88;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;70;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;46;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;25;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;42;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;26;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;12;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;404;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;75;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;29;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;324;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;53;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;23;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;269;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;105;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;59;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;219;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;87;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;179;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;153;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;137;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;37;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;16;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;128;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;22;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;7;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;90;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;31;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;15;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;79;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;62;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;17;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;9;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;58;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;15;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;6;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;121;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;90;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;73;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;48;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;26;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;68;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;43;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;27;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;13;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;404;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;75;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;29;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;324;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;53;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;23;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;269;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;105;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;59;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;219;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;87;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;36;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;179;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;153;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;137;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;37;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;16;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;128;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;22;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;7;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;90;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;31;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;15;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;79;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;62;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;17;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;9;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;58;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;15;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;6;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;121;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;90;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;73;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;48;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;26;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;68;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;43;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;27;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;13;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;427;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;79;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;31;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;341;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;57;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;24;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;284;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;111;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;230;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;190;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;165;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;147;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;39;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;17;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;136;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;23;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;8;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;94;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;33;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;83;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;66;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;18;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;10;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;61;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;16;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;6;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;125;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;76;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;50;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;27;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;45;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;29;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;13;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;427;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;79;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;31;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;341;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;57;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;24;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;284;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;111;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;230;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;38;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;190;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;165;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;147;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;39;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;17;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;136;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;23;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;8;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;94;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;33;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;83;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;66;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;18;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;10;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;61;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;16;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;6;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;125;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;93;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;76;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;50;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;27;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;45;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;29;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;13;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;450;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;83;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;34;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;369;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;61;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;26;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;299;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;119;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;244;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;97;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;40;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;204;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;177;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;153;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;42;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;18;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;143;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;24;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;8;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;100;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;35;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;17;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;88;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;35;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;69;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;20;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;11;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;66;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;17;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;6;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;130;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;96;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;79;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;52;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;28;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;47;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;30;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;14;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;450;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;83;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;34;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;369;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;61;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;26;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;299;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;119;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;244;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;97;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;40;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;204;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;177;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;153;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;42;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;18;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;143;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;24;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;8;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;100;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;35;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;17;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;88;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;35;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;69;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;20;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;11;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;66;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;17;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;6;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;130;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;96;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;79;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;52;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;28;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;73;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;47;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;30;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;14;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;480;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;87;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;35;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;387;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;64;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;27;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;322;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;123;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;256;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;103;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;212;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;187;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;161;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;44;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;18;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;153;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;25;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;9;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;106;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;36;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;18;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;93;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;73;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;20;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;11;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;69;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;18;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;7;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;134;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;81;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;53;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;29;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;48;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;31;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;14;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;480;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;87;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;35;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;387;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;64;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;27;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;322;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;123;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;256;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;103;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;212;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;187;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;161;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;44;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;18;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;153;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;25;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;9;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;106;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;36;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;18;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;93;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;73;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;20;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;11;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;69;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;18;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;7;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;134;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;69;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;81;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;53;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;29;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;48;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;31;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;14;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;501;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;92;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;37;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;405;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;68;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;28;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;337;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;129;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;74;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;263;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;109;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;223;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;197;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;167;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;47;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;19;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;161;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;26;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;9;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;111;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;38;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;18;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;99;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;78;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;21;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;12;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;72;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;19;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;7;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;139;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;84;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;55;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;29;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;50;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;31;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;15;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;501;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;92;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;37;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;405;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;68;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;28;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;337;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;129;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;74;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;263;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;109;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;223;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;197;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;167;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;47;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;19;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;161;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;26;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;9;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;111;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;38;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;18;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;99;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;78;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;21;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;12;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;72;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;19;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;7;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;139;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;72;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;84;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;55;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;29;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;50;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;31;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;15;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;527;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;97;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;38;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;418;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;72;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;29;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;356;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;134;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;279;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;113;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;236;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;205;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;179;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;48;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;20;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;168;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;28;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;9;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;117;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;40;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;19;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;81;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;22;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;12;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;76;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;19;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;7;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;142;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;86;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;57;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;31;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;52;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;32;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;15;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;527;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;97;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;38;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;418;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;72;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;29;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;356;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;134;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;279;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;113;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;236;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;205;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;179;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;48;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;20;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;168;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;28;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;9;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;117;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;40;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;19;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;103;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;81;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;22;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;12;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;76;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;19;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;7;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;142;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;105;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;86;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;57;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;31;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;52;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;32;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;15;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;548;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;101;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;40;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;442;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;75;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;31;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;370;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;141;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;292;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;243;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;214;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;186;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;50;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;21;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;174;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;29;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;10;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;121;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;42;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;20;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;107;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;85;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;24;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;13;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;79;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;20;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;8;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;145;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;88;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;58;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;31;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;52;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;33;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;16;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;548;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;101;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;40;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;442;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;75;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;31;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;370;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;141;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;292;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;243;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;214;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;186;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;50;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;21;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;174;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;29;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;10;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;121;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;42;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;20;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;107;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;85;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;24;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;13;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;79;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;20;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;8;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;145;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;88;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;58;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;31;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;52;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;33;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;16;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;573;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;106;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;41;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;466;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;76;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;32;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;383;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;145;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;303;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;256;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;224;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;196;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;53;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;22;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;181;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;30;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;10;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;125;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;44;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;21;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;114;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;88;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;25;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;13;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;83;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;21;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;8;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;149;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;90;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;59;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;32;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;53;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;34;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;16;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;573;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;106;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;41;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;466;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;76;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;32;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;383;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;145;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;303;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;123;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;256;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;224;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;196;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;53;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;22;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;181;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;30;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;10;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;125;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;44;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;21;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;114;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;43;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;88;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;25;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;13;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;83;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;21;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;8;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;149;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;90;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;59;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;32;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;53;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;34;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;16;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;593;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;110;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;44;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;486;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;80;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;33;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;404;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;152;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;87;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;315;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;126;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;266;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;233;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;200;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;55;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;22;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;190;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;32;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;11;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;131;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;46;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;22;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;93;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;26;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;14;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;86;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;22;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;8;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;92;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;60;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;32;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;54;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;35;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;16;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;593;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;110;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;44;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;486;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;80;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;33;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;404;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;152;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;87;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;315;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;126;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;266;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;233;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;200;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;55;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;22;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;190;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;32;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;11;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;131;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;46;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;22;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;93;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;26;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;14;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;86;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;22;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;8;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;92;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;60;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;32;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;54;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;35;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;16;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;621;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;113;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;45;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;504;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;85;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;34;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;415;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;327;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;276;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;242;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;209;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;58;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;23;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;197;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;32;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;11;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;137;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;47;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;23;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;123;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;96;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;27;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;14;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;89;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;23;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;113;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;95;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;62;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;33;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;86;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;55;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;36;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;621;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;113;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;45;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;504;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;85;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;34;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;415;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;159;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;327;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;131;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;276;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;242;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;209;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;58;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;23;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;197;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;32;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;11;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;137;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;47;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;23;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;123;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;96;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;27;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;14;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;89;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;23;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;113;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;95;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;62;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;33;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;86;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;55;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;36;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;634;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;116;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;46;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;513;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;86;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;35;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;431;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;92;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;334;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;136;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;287;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;248;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;217;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;60;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;24;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;202;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;33;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;140;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;48;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;23;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;128;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;99;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;15;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;91;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;23;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;81;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;96;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;63;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;33;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;56;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;36;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;634;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;116;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;46;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;513;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;86;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;35;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;431;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;92;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;334;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;136;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;287;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;248;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;217;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;60;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;24;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;202;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;33;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;140;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;48;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;23;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;128;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;99;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;15;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;91;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;23;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;114;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;81;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;96;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;63;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;33;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;56;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;36;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;660;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;120;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;48;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;533;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;88;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;37;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;442;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;95;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;341;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;295;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;258;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;221;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;62;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;24;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;210;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;35;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;140;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;51;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;24;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;102;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;15;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;94;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;24;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;98;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;64;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;34;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;88;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;57;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;37;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;660;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;120;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;48;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;533;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;88;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;37;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;442;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;164;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;95;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;341;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;295;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;258;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;221;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;62;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;24;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;210;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;35;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;140;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;51;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;24;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;102;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;15;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;94;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;24;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;98;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;64;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;34;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;88;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;57;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;37;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;674;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;124;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;49;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;549;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;92;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;37;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;459;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;97;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;351;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;301;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;262;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;229;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;63;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;25;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;217;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;35;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;146;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;52;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;25;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;135;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;104;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;29;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;15;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;96;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;25;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;117;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;99;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;64;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;34;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;90;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;57;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;37;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;674;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;124;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;49;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;549;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;92;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;37;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;459;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;97;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;351;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;301;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;262;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;229;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;63;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;25;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;217;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;35;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;146;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;52;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;25;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;135;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;104;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;29;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;15;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;96;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;25;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;9;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;117;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;99;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;64;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;34;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;90;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;57;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;37;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;17;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;694;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;126;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;50;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;554;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;93;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;38;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;463;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;170;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;99;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;355;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;145;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;309;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;267;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;232;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;64;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;25;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;221;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;36;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;149;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;53;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;25;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;137;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;106;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;30;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;99;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;25;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;100;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;34;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;57;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;694;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;126;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;50;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;554;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;93;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;38;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;463;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;170;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;99;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;355;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;145;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;309;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;267;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;232;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;64;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;25;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;221;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;36;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;12;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;149;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;53;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;25;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;137;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;106;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;30;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;99;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;25;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;162;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;100;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;34;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;57;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;705;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;128;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;51;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;569;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;95;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;39;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;473;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;100;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;360;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;145;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;317;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;272;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;237;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;65;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;26;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;224;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;36;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;13;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;151;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;54;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;26;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;141;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;109;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;30;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;101;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;25;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;163;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;84;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;101;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;35;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;58;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;705;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;128;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;51;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;569;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;95;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;39;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;473;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;100;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;360;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;145;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;317;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;272;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;237;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;65;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;26;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;224;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;36;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;13;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;151;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;54;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;26;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;141;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;109;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;30;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;101;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;25;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;163;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;84;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;101;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;35;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;58;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;718;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;130;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;51;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;577;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;96;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;39;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;481;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;101;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;362;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;61;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;318;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;240;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;67;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;26;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;227;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;37;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;13;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;152;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;55;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;26;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;141;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;111;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;31;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;102;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;26;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;85;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;102;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;35;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;92;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;58;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;718;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;130;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;51;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;577;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;96;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;39;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;481;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;101;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;362;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;61;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;318;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;240;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;67;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;26;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;227;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;37;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;13;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;152;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;55;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;26;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;141;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;111;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;31;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;102;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;26;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;119;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;85;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;102;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;35;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;92;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;58;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;720;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;130;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;52;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;580;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;97;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;39;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;482;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;101;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;367;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;322;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;242;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;67;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;26;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;230;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;37;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;13;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;152;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;55;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;26;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;141;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;111;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;31;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;102;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;26;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;85;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;102;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;35;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;92;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;58;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;720;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;130;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;52;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;580;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;97;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;39;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;482;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;101;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;367;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;322;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;278;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;242;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;67;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;26;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;230;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;37;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;13;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;152;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;55;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;26;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;141;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;111;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;31;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;16;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;102;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;26;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;10;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;85;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;102;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;65;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;35;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;92;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;58;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;38;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;18;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;4;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;4;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;0;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;3;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;3;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;2;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;1;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;3;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;3;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;1;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;0;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;5;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;3;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;3;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;2;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;3;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;5;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;3;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;3;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;2;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;3;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;0;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;4;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;5;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;3;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;3;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;4;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;4;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;5;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;3;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;3;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;6;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;4;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;6;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;5;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;4;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;4;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;2;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;5;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;6;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;5;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;1;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;4;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;4;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;2;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;5;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;6;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;7;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;4;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;4;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;11;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;6;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;5;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;3;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;5;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;6;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;7;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;0;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;1;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;4;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;4;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;11;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;6;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;5;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;3;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;5;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;10;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;4;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;11;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;12;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;9;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;5;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;7;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;4;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;12;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;8;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;6;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;3;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;7;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;3;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;10;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;4;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;11;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;12;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;9;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;5;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;7;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;0;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;4;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;2;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;2;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;12;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;8;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;6;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;3;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;7;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;3;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;1;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;18;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;4;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;20;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;1;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;7;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;2;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;7;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;7;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;3;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;4;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;10;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;7;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;4;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;7;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;3;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;2;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;18;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;4;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;20;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;1;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;12;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;7;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;2;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;7;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;0;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;7;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;3;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;4;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;10;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;7;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;4;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;11;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;7;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;3;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;2;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2021W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2021W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2021;B;56604;B Psychologie;SOW;N;N;N;23;1.3
-21PB;2021;B;56604;B Psychologie;SOW;E;N;N;5;1.3
-21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;24;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;3;1.3
-21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;2;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.3
-21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;18;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.3
-21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3
-21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.3
-21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3
-21PB;2021;B;56981;B Politicologie;MAN;N;N;N;11;1.3
-21PB;2021;B;56981;B Politicologie;MAN;E;N;N;3;1.3
-21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;10;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;1;1.3
-21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;8;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.3
-21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;4;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3
-21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3
-21PB;2021;B;56081;B Filosofie;FdL;N;N;N;4;1.3
-21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3
-21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.07
-21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.07
-21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.07
-21PB;2021;M;60300;M Informatica;SOW;N;N;N;11;1.07
-21PB;2021;M;60300;M Informatica;SOW;E;N;N;9;1.07
-21PB;2021;M;60300;M Informatica;SOW;R;N;N;4;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.07
-21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.07
-21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;9;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;4;1.07
-21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;2;1.07
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2021;B;56604;B Psychologie;SOW;N;N;N;23;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;E;N;N;5;1.3;V
+21PB;2021;B;56604;B Psychologie;SOW;R;N;N;2;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;N;N;N;24;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;E;N;N;3;1.3;V
+21PB;2021;B;56551;B Geneeskunde;MED;R;N;N;2;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.3;V
+21PB;2021;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;N;N;N;18;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.3;V
+21PB;2021;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;N;N;N;16;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.3;V
+21PB;2021;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;N;N;N;12;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.3;V
+21PB;2021;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;N;N;N;11;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;E;N;N;3;1.3;V
+21PB;2021;B;56981;B Politicologie;MAN;R;N;N;2;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;N;N;N;10;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;E;N;N;1;1.3;V
+21PB;2021;B;56034;B Geschiedenis;FdL;R;N;N;1;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;N;N;N;8;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56980;B Wiskunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.3;V
+21PB;2021;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;N;N;N;4;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;E;N;N;1;1.3;V
+21PB;2021;B;56857;B Scheikunde;FNWI;R;N;N;0;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;N;N;N;4;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;E;N;N;1;1.3;V
+21PB;2021;B;56081;B Filosofie;FdL;R;N;N;0;1.3;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;20;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.07;V
+21PB;2021;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.07;V
+21PB;2021;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;N;N;N;11;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;E;N;N;9;1.07;V
+21PB;2021;M;60300;M Informatica;SOW;R;N;N;4;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.07;V
+21PB;2021;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.07;V
+21PB;2021;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;N;N;N;9;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;E;N;N;4;1.07;V
+21PB;2021;M;60815;M Linguistiek;FdL;R;N;N;2;1.07;V

--- a/data/input_raw/telbestanden/telbestandY2022W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;32;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;4;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;23;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;4;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;21;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;11;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;3;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;12;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;9;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;7;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;5;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;16;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;9;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;6;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;10;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;6;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;2;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;32;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;4;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;23;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;4;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;24;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;21;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;14;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;11;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;3;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;12;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;9;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;7;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;5;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;16;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;9;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;6;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;10;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;6;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;2;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;39;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;5;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;26;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;6;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;14;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;24;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;24;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;16;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;15;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;4;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;15;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;10;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;4;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;10;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;8;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;7;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;18;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;11;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;7;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;12;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;7;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;3;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;39;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;5;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;26;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;6;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;14;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;24;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;11;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;24;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;16;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;15;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;4;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;15;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;10;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;4;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;10;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;8;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;7;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;18;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;11;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;7;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;12;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;7;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;3;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;50;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;9;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;6;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;39;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;8;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;41;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;15;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;25;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;22;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;19;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;6;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;15;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;11;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;5;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;10;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;8;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;20;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;13;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;7;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;14;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;8;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;3;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;50;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;9;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;6;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;39;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;8;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;41;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;15;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;25;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;22;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;19;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;6;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;15;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;11;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;5;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;10;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;8;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;20;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;13;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;7;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;16;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;20;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;14;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;8;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;3;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;50;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;11;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;6;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;45;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;9;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;3;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;45;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;20;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;9;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;31;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;30;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;22;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;6;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;19;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;15;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;5;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;11;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;9;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;44;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;19;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;22;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;14;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;8;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;16;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;8;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;3;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;50;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;11;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;6;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;45;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;9;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;3;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;45;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;20;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;9;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;31;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;30;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;22;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;6;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;19;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;15;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;5;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;14;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;11;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;9;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;44;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;19;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;22;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;14;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;8;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;16;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;8;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;3;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;60;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;13;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;8;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;54;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;12;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;4;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;49;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;23;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;43;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;20;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;31;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;26;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;7;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;26;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;4;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;16;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;7;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;13;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;9;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;33;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;25;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;15;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;9;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;19;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;17;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;9;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;4;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;60;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;13;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;8;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;54;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;12;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;4;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;49;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;23;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;43;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;20;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;31;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;26;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;7;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;26;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;4;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;16;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;7;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;13;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;9;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;33;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;25;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;15;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;9;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;19;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;17;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;9;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;4;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;73;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;15;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;9;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;61;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;13;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;5;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;61;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;27;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;40;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;34;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;29;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;9;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;28;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;5;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;19;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;8;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;15;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;4;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;11;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;4;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;53;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;35;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;29;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;18;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;10;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;19;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;10;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;4;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;73;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;15;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;9;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;61;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;13;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;5;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;61;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;27;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;12;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;44;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;40;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;34;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;29;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;9;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;28;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;5;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;19;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;8;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;15;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;4;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;11;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;4;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;53;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;35;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;29;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;18;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;10;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;19;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;10;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;4;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;77;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;19;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;10;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;73;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;15;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;5;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;65;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;45;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;41;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;35;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;10;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;4;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;31;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;5;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;22;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;9;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;4;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;18;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;5;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;14;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;4;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;58;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;39;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;32;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;19;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;11;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;20;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;11;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;5;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;77;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;19;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;10;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;73;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;15;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;5;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;65;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;45;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;41;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;35;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;10;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;4;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;31;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;5;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;22;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;9;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;4;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;18;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;5;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;14;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;4;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;1;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;58;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;39;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;32;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;19;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;11;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;20;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;11;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;5;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;97;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;22;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;10;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;85;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;17;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;6;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;79;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;61;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;29;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;52;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;46;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;40;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;12;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;5;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;37;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;6;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;25;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;9;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;4;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;21;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;5;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;16;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;5;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;64;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;42;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;28;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;35;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;22;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;12;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;22;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;13;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;5;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;97;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;22;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;10;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;85;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;17;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;6;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;79;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;33;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;61;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;29;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;52;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;46;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;40;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;12;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;5;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;37;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;6;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;25;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;9;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;4;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;21;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;5;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;16;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;5;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;64;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;42;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;28;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;35;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;22;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;12;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;22;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;13;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;5;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;106;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;23;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;12;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;94;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;19;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;7;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;83;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;39;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;18;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;66;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;60;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;51;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;45;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;13;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;5;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;43;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;7;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;29;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;11;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;21;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;6;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;18;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;5;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;69;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;46;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;30;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;38;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;23;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;13;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;24;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;13;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;6;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;106;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;23;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;12;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;94;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;19;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;7;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;83;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;39;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;18;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;66;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;60;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;51;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;45;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;13;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;5;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;43;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;7;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;29;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;11;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;29;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;21;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;6;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;18;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;5;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;69;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;46;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;30;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;38;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;23;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;13;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;27;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;24;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;13;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;6;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;121;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;27;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;14;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;104;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;21;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;8;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;99;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;43;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;75;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;35;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;65;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;61;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;51;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;14;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;5;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;48;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;8;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;33;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;12;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;32;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;26;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;7;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;4;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;20;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;6;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;75;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;51;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;40;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;25;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;14;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;29;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;26;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;6;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;121;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;27;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;14;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;104;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;21;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;8;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;99;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;43;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;75;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;35;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;65;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;61;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;51;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;14;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;5;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;48;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;8;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;33;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;12;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;32;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;26;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;7;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;4;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;20;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;6;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;75;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;51;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;40;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;25;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;14;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;29;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;38;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;26;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;6;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;130;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;29;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;15;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;112;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;25;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;9;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;107;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;46;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;85;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;39;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;74;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;68;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;59;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;17;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;6;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;51;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;8;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;3;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;38;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;14;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;6;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;28;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;7;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;4;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;22;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;6;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;83;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;54;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;43;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;27;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;15;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;28;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;7;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;130;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;29;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;15;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;112;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;25;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;9;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;107;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;46;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;85;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;39;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;14;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;74;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;11;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;68;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;59;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;17;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;6;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;51;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;8;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;3;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;38;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;14;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;6;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;34;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;28;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;7;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;4;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;22;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;6;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;2;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;83;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;54;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;43;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;27;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;15;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;41;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;28;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;7;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;149;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;33;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;16;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;133;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;27;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;10;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;118;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;53;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;100;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;82;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;76;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;62;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;18;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;7;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;61;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;9;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;3;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;41;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;15;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;7;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;32;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;8;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;25;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;7;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;3;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;86;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;47;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;30;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;16;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;34;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;43;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;29;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;17;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;7;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;149;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;33;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;16;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;133;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;27;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;10;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;118;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;53;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;100;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;82;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;76;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;62;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;18;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;7;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;61;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;9;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;3;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;41;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;15;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;7;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;32;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;8;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;25;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;7;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;3;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;86;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;58;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;37;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;47;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;30;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;16;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;34;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;23;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;43;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;29;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;17;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;7;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;165;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;36;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;18;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;149;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;30;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;11;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;132;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;56;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;105;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;92;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;82;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;71;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;21;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;8;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;66;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;10;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;4;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;45;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;17;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;8;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;43;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;34;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;9;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;27;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;8;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;3;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;95;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;50;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;32;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;17;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;36;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;32;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;18;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;8;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;165;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;36;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;18;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;149;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;30;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;11;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;132;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;56;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;27;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;105;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;92;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;82;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;71;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;21;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;8;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;66;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;10;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;4;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;45;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;17;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;8;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;43;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;34;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;9;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;27;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;8;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;3;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;95;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;61;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;50;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;32;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;17;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;36;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;32;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;18;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;8;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;179;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;39;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;20;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;162;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;33;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;12;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;146;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;62;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;118;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;99;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;76;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;23;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;8;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;71;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;11;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;4;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;49;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;18;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;8;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;47;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;38;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;10;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;5;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;29;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;8;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;3;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;99;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;65;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;53;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;33;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;18;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;34;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;19;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;8;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;179;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;39;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;20;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;162;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;33;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;12;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;146;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;62;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;118;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;53;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;99;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;76;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;23;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;8;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;71;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;11;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;4;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;49;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;18;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;8;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;47;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;38;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;10;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;5;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;29;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;8;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;3;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;99;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;65;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;53;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;33;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;18;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;34;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;19;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;8;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;196;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;43;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;22;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;174;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;35;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;13;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;158;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;70;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;129;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;57;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;112;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;16;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;99;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;85;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;25;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;9;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;77;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;12;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;4;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;56;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;20;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;9;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;52;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;41;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;11;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;6;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;32;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;10;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;4;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;106;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;56;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;36;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;20;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;36;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;20;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;9;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;196;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;43;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;22;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;174;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;35;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;13;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;158;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;70;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;129;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;57;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;112;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;16;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;99;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;85;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;25;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;9;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;77;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;12;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;4;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;56;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;20;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;9;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;52;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;41;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;11;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;6;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;32;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;10;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;4;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;106;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;68;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;56;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;36;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;20;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;36;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;20;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;9;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;214;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;49;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;24;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;194;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;39;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;14;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;175;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;77;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;139;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;60;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;118;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;110;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;93;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;27;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;10;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;87;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;14;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;5;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;61;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;22;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;10;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;55;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;44;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;11;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;6;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;35;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;10;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;4;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;111;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;60;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;37;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;20;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;56;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;38;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;21;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;9;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;214;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;49;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;24;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;194;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;39;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;14;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;175;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;77;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;139;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;60;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;22;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;118;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;110;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;93;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;27;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;10;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;87;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;14;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;5;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;61;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;22;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;10;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;55;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;18;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;44;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;11;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;6;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;35;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;10;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;4;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;111;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;60;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;37;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;20;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;56;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;38;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;21;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;9;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;229;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;51;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;25;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;212;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;43;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;16;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;187;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;80;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;38;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;148;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;67;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;128;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;99;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;29;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;11;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;93;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;14;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;5;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;66;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;24;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;11;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;61;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;20;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;48;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;12;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;7;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;38;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;11;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;4;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;117;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;50;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;62;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;40;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;22;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;46;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;40;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;22;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;10;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;229;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;51;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;25;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;212;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;43;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;16;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;187;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;80;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;38;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;148;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;67;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;128;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;99;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;29;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;11;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;93;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;14;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;5;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;66;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;24;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;11;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;61;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;20;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;48;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;12;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;7;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;38;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;11;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;4;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;117;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;50;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;62;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;40;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;22;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;46;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;40;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;22;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;10;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;250;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;54;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;27;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;231;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;45;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;17;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;205;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;87;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;41;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;164;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;139;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;128;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;110;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;32;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;12;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;99;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;16;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;6;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;71;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;25;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;12;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;52;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;13;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;7;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;40;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;12;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;5;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;124;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;81;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;66;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;42;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;23;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;42;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;23;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;10;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;250;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;54;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;27;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;231;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;45;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;17;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;205;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;87;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;41;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;164;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;139;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;128;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;110;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;32;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;12;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;99;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;16;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;6;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;71;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;25;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;12;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;52;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;13;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;7;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;40;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;12;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;5;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;124;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;81;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;29;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;66;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;42;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;23;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;62;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;42;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;23;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;10;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;269;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;60;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;30;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;242;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;49;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;18;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;220;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;94;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;172;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;75;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;148;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;134;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;116;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;33;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;13;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;108;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;17;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;6;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;78;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;27;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;12;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;72;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;55;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;15;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;8;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;44;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;13;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;5;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;127;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;84;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;70;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;43;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;23;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;43;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;25;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;11;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;269;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;60;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;30;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;242;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;49;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;18;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;220;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;94;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;44;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;172;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;75;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;28;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;148;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;134;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;22;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;116;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;33;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;13;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;108;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;17;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;6;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;78;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;27;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;12;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;72;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;55;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;15;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;8;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;44;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;13;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;5;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;127;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;84;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;70;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;43;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;23;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;64;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;43;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;25;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;11;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;291;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;63;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;31;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;262;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;53;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;20;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;235;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;102;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;191;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;82;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;31;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;159;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;148;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;123;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;36;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;13;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;120;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;18;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;6;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;84;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;29;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;13;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;60;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;15;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;8;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;48;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;14;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;5;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;72;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;45;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;25;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;46;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;26;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;11;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;291;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;63;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;31;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;262;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;53;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;20;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;235;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;102;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;191;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;82;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;31;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;159;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;24;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;148;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;123;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;36;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;13;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;120;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;18;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;6;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;84;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;29;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;13;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;60;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;15;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;8;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;48;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;14;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;5;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;72;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;45;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;25;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;34;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;46;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;26;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;11;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;313;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;68;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;33;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;284;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;57;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;21;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;250;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;107;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;201;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;88;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;33;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;171;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;159;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;132;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;39;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;14;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;124;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;20;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;7;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;88;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;31;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;14;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;63;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;17;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;9;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;51;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;15;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;6;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;91;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;75;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;48;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;25;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;48;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;27;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;12;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;313;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;68;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;33;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;284;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;57;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;21;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;250;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;107;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;201;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;88;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;33;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;171;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;159;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;132;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;39;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;14;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;124;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;20;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;7;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;88;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;31;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;14;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;63;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;17;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;9;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;51;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;15;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;6;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;91;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;75;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;48;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;25;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;70;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;48;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;27;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;12;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;327;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;73;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;35;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;301;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;60;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;22;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;268;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;114;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;54;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;209;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;93;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;186;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;169;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;143;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;41;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;15;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;131;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;21;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;7;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;95;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;33;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;15;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;87;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;67;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;17;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;9;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;55;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;16;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;6;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;143;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;77;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;50;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;27;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;49;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;28;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;12;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;327;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;73;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;35;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;301;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;60;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;22;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;268;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;114;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;54;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;209;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;93;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;186;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;169;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;143;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;41;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;15;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;131;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;21;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;7;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;95;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;33;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;15;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;87;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;67;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;17;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;9;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;55;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;16;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;6;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;143;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;77;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;50;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;27;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;49;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;28;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;12;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;351;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;77;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;37;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;317;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;63;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;24;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;285;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;123;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;55;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;227;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;195;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;183;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;151;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;45;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;17;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;139;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;22;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;8;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;102;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;35;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;16;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;94;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;71;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;18;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;10;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;57;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;17;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;6;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;149;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;97;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;81;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;51;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;27;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;51;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;29;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;13;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;351;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;77;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;37;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;317;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;63;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;24;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;285;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;123;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;55;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;227;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;195;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;183;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;151;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;45;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;17;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;139;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;22;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;8;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;102;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;35;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;16;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;94;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;71;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;18;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;10;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;57;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;17;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;6;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;149;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;97;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;81;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;51;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;27;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;51;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;29;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;13;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;376;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;81;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;39;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;341;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;68;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;25;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;305;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;128;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;243;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;104;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;206;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;189;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;158;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;47;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;17;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;151;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;24;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;8;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;106;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;37;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;17;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;99;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;75;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;20;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;11;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;62;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;18;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;7;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;84;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;53;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;29;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;61;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;52;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;30;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;13;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;376;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;81;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;39;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;341;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;68;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;25;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;305;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;128;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;243;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;104;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;206;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;189;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;158;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;47;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;17;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;151;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;24;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;8;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;106;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;37;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;17;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;99;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;75;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;20;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;11;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;62;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;18;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;7;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;156;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;84;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;53;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;29;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;61;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;77;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;52;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;30;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;13;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;391;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;86;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;41;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;361;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;70;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;27;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;319;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;135;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;63;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;254;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;108;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;220;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;200;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;168;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;49;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;18;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;158;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;25;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;9;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;113;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;38;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;18;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;104;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;35;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;80;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;21;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;11;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;65;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;19;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;7;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;159;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;104;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;86;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;55;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;29;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;54;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;30;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;14;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;391;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;86;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;41;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;361;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;70;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;27;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;319;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;135;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;63;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;254;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;108;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;220;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;200;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;168;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;49;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;18;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;158;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;25;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;9;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;113;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;38;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;18;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;104;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;35;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;80;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;21;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;11;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;65;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;19;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;7;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;159;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;104;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;86;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;55;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;29;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;62;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;80;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;54;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;30;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;14;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;411;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;90;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;43;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;379;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;76;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;28;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;336;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;140;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;270;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;114;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;232;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;211;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;177;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;52;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;19;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;167;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;26;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;9;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;119;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;41;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;19;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;110;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;82;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;22;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;12;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;68;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;19;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;7;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;166;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;106;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;89;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;56;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;30;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;55;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;32;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;14;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;411;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;90;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;43;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;379;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;76;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;28;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;336;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;140;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;270;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;114;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;232;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;34;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;211;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;177;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;52;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;19;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;167;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;26;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;9;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;119;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;41;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;19;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;110;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;37;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;82;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;22;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;12;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;68;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;19;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;7;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;166;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;106;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;89;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;56;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;30;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;55;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;32;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;14;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;435;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;95;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;45;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;398;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;79;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;30;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;357;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;148;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;280;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;243;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;222;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;184;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;54;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;20;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;173;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;28;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;10;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;124;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;43;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;20;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;87;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;23;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;12;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;71;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;21;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;8;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;171;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;109;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;91;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;58;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;31;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;57;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;32;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;435;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;95;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;45;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;398;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;79;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;30;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;357;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;148;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;280;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;45;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;243;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;36;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;222;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;34;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;184;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;54;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;20;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;173;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;28;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;10;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;124;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;43;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;20;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;116;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;87;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;23;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;12;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;71;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;21;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;8;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;171;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;109;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;91;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;58;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;31;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;57;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;32;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;457;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;98;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;46;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;416;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;83;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;31;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;367;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;153;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;293;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;122;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;251;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;234;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;196;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;57;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;21;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;182;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;29;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;10;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;131;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;44;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;20;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;120;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;90;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;24;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;13;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;74;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;21;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;8;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;176;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;93;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;60;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;32;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;68;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;86;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;59;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;33;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;457;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;98;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;46;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;416;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;83;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;31;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;367;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;153;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;72;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;293;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;122;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;251;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;234;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;196;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;57;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;21;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;182;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;29;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;10;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;131;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;44;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;20;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;120;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;90;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;24;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;13;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;74;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;21;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;8;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;176;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;93;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;60;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;32;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;68;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;86;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;59;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;33;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;474;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;103;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;49;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;439;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;85;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;33;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;382;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;160;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;75;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;308;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;129;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;263;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;245;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;202;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;59;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;22;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;188;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;30;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;10;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;137;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;46;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;21;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;125;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;95;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;25;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;13;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;78;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;22;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;8;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;178;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;96;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;61;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;32;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;88;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;60;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;34;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;474;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;103;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;49;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;439;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;85;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;33;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;382;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;160;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;75;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;308;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;129;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;263;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;245;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;37;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;202;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;59;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;22;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;188;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;30;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;10;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;137;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;46;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;21;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;125;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;95;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;25;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;13;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;78;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;22;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;8;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;178;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;96;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;61;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;32;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;88;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;60;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;34;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;497;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;106;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;50;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;450;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;88;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;34;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;398;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;167;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;320;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;133;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;277;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;251;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;209;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;61;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;23;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;196;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;31;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;11;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;143;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;47;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;22;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;129;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;99;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;26;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;14;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;81;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;23;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;182;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;97;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;63;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;33;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;89;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;61;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;35;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;497;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;106;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;50;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;450;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;88;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;34;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;398;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;167;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;320;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;133;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;52;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;277;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;251;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;209;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;61;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;23;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;196;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;31;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;11;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;143;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;47;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;22;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;129;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;99;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;26;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;14;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;81;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;23;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;182;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;97;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;63;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;33;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;70;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;89;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;61;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;35;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;15;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;514;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;110;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;52;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;468;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;93;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;35;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;408;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;172;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;332;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;138;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;285;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;261;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;219;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;64;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;24;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;203;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;33;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;11;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;146;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;49;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;23;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;101;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;27;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;14;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;84;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;24;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;184;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;99;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;65;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;62;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;35;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;514;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;110;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;52;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;468;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;93;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;35;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;408;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;172;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;332;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;138;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;285;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;261;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;219;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;64;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;24;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;203;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;33;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;11;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;146;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;49;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;23;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;101;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;27;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;14;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;84;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;24;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;184;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;99;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;65;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;62;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;35;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;531;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;114;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;53;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;486;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;95;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;36;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;422;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;177;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;346;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;293;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;269;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;224;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;66;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;24;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;211;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;34;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;12;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;152;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;50;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;23;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;140;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;105;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;28;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;15;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;87;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;24;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;186;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;101;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;65;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;92;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;63;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;36;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;531;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;114;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;53;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;486;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;95;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;36;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;422;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;177;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;346;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;293;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;269;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;41;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;224;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;66;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;24;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;211;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;34;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;12;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;152;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;50;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;23;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;140;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;105;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;28;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;15;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;87;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;24;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;186;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;101;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;65;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;92;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;63;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;36;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;546;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;118;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;54;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;504;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;98;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;37;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;435;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;182;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;352;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;144;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;304;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;280;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;232;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;68;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;25;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;216;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;35;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;12;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;158;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;52;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;24;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;144;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;109;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;29;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;15;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;88;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;25;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;189;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;102;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;66;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;93;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;64;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;36;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;546;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;118;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;54;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;504;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;98;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;37;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;435;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;182;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;84;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;352;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;144;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;304;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;280;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;232;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;68;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;25;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;216;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;35;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;12;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;158;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;52;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;24;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;144;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;109;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;29;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;15;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;88;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;25;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;9;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;189;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;102;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;66;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;93;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;64;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;36;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;566;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;120;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;55;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;511;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;101;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;38;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;448;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;186;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;86;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;364;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;312;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;287;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;234;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;69;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;26;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;220;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;36;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;12;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;163;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;54;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;25;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;147;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;111;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;30;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;15;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;91;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;26;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;191;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;103;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;67;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;74;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;64;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;36;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;566;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;120;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;55;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;511;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;101;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;38;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;448;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;186;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;86;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;364;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;312;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;287;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;234;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;69;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;26;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;220;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;36;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;12;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;163;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;54;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;25;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;147;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;111;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;30;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;15;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;91;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;26;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;191;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;122;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;82;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;103;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;67;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;34;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;74;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;64;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;36;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;16;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;571;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;124;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;524;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;104;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;39;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;456;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;190;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;89;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;372;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;150;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;317;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;292;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;241;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;70;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;26;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;225;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;37;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;166;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;54;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;25;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;152;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;112;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;30;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;94;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;26;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;192;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;104;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;68;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;64;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;571;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;124;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;524;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;104;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;39;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;456;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;190;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;89;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;372;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;150;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;317;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;292;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;241;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;70;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;26;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;225;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;37;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;166;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;54;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;25;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;152;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;50;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;112;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;30;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;94;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;26;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;192;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;104;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;68;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;64;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;577;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;124;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;533;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;105;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;40;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;464;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;194;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;89;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;151;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;61;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;324;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;295;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;246;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;72;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;26;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;227;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;37;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;167;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;54;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;26;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;154;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;114;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;30;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;96;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;26;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;194;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;104;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;68;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;76;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;96;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;65;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;577;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;124;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;533;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;105;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;40;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;464;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;194;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;89;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;151;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;61;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;324;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;295;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;246;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;72;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;26;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;227;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;37;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;167;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;54;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;26;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;154;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;114;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;30;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;96;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;26;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;194;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;83;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;104;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;68;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;76;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;96;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;65;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;596;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;126;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;547;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;106;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;40;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;472;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;194;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;382;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;153;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;330;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;299;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;250;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;74;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;27;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;229;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;38;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;170;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;55;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;26;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;155;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;53;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;114;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;31;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;96;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;27;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;194;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;84;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;47;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;105;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;69;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;76;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;96;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;65;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;596;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;126;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;547;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;106;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;40;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;472;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;194;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;382;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;153;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;330;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;299;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;250;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;74;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;27;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;229;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;38;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;170;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;55;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;26;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;155;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;53;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;114;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;31;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;96;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;27;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;194;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;84;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;47;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;105;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;69;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;76;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;96;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;65;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;596;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;127;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;549;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;107;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;41;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;475;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;194;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;388;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;153;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;330;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;250;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;74;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;27;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;234;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;39;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;171;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;55;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;26;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;158;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;53;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;114;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;31;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;98;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;27;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;194;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;84;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;47;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;106;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;69;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;76;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;96;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;65;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;596;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;127;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;57;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;549;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;107;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;41;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;475;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;194;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;90;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;388;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;153;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;330;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;250;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;74;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;27;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;234;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;39;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;13;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;171;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;55;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;26;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;158;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;53;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;114;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;31;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;16;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;98;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;27;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;10;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;194;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;84;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;47;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;106;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;69;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;35;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;76;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;96;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;65;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;37;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;17;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;3;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;3;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;3;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;3;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;0;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;3;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;3;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;3;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;3;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;3;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;4;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;3;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;3;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;1;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;0;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;5;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;4;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;3;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;0;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;3;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;4;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;3;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;1;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;3;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;4;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;3;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;1;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;4;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;5;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;3;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;11;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;7;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;6;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;3;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;2;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;3;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;5;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;6;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;3;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;11;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;7;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;6;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;3;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;2;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;3;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;12;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;2;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;5;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;4;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;3;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;9;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;7;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;4;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;2;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;4;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;12;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;2;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;5;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;4;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;3;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;14;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;9;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;6;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;7;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;4;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;2;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;4;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;17;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;2;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;11;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;5;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;5;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;3;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;16;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;8;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;5;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;3;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;6;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;4;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;17;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;2;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;11;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;7;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;5;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;5;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;3;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;0;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;16;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;8;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;5;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;3;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;6;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;4;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;19;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;4;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;13;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;11;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;8;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;7;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;3;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;4;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;4;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;19;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;10;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;6;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;4;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;7;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;4;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;19;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;4;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;13;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;0;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;11;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;10;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;10;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;1;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;8;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;7;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;3;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;4;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;4;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;2;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;19;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;14;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;10;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;6;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;4;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;7;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;4;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;1;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;19;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;4;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;17;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;3;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;8;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;2;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;8;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;5;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;5;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;22;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;12;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;7;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;5;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;12;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;7;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;5;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;2;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;19;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;4;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;2;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;17;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;3;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;8;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;6;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;8;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;2;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;8;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;5;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;5;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;22;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;12;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;7;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;5;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;12;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;7;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;5;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;2;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2022W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2022W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2022;B;56604;B Psychologie;SOW;N;N;N;27;1.27
-21PB;2022;B;56604;B Psychologie;SOW;E;N;N;6;1.27
-21PB;2022;B;56604;B Psychologie;SOW;R;N;N;4;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;23;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;4;1.27
-21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;1;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.27
-21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;13;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.27
-21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.27
-21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.27
-21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27
-21PB;2022;B;56981;B Politicologie;MAN;N;N;N;9;1.27
-21PB;2022;B;56981;B Politicologie;MAN;E;N;N;3;1.27
-21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;8;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27
-21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;8;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;3;1.27
-21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;6;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;2;1.27
-21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;N;N;N;3;1.27
-21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27
-21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.13
-21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.13
-21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.13
-21PB;2022;M;60300;M Informatica;SOW;N;N;N;14;1.13
-21PB;2022;M;60300;M Informatica;SOW;E;N;N;9;1.13
-21PB;2022;M;60300;M Informatica;SOW;R;N;N;5;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.13
-21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.13
-21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;9;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;5;1.13
-21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;2;1.13
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2022;B;56604;B Psychologie;SOW;N;N;N;27;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;E;N;N;6;1.27;V
+21PB;2022;B;56604;B Psychologie;SOW;R;N;N;4;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;N;N;N;23;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;E;N;N;4;1.27;V
+21PB;2022;B;56551;B Geneeskunde;MED;R;N;N;1;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;11;1.27;V
+21PB;2022;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;N;N;N;13;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.27;V
+21PB;2022;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.27;V
+21PB;2022;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;N;N;N;9;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.27;V
+21PB;2022;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;N;N;N;9;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;E;N;N;3;1.27;V
+21PB;2022;B;56981;B Politicologie;MAN;R;N;N;1;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;N;N;N;8;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;E;N;N;2;1.27;V
+21PB;2022;B;56034;B Geschiedenis;FdL;R;N;N;0;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;N;N;N;8;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;E;N;N;3;1.27;V
+21PB;2022;B;56980;B Wiskunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;N;N;N;6;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;E;N;N;2;1.27;V
+21PB;2022;B;56857;B Scheikunde;FNWI;R;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;N;N;N;3;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;E;N;N;1;1.27;V
+21PB;2022;B;56081;B Filosofie;FdL;R;N;N;0;1.27;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.13;V
+21PB;2022;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.13;V
+21PB;2022;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;N;N;N;14;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;E;N;N;9;1.13;V
+21PB;2022;M;60300;M Informatica;SOW;R;N;N;5;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.13;V
+21PB;2022;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.13;V
+21PB;2022;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;N;N;N;9;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;E;N;N;5;1.13;V
+21PB;2022;M;60815;M Linguistiek;FdL;R;N;N;2;1.13;V

--- a/data/input_raw/telbestanden/telbestandY2023W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;48;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;7;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;3;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;30;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;8;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;27;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;19;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;20;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;14;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;5;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;12;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;10;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;4;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;6;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;5;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;15;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;9;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;5;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;12;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;10;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;5;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;3;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;48;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;7;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;3;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;30;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;8;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;27;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;29;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;19;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;20;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;14;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;5;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;12;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;10;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;4;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;9;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;6;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;5;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;29;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;6;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;20;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;11;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;15;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;9;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;5;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;12;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;10;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;5;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;3;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;58;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;8;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;4;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;36;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;9;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;34;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;25;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;18;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;6;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;13;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;12;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;7;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;6;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;17;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;11;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;6;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;12;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;6;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;3;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;58;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;8;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;4;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;36;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;9;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;34;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;10;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;32;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;21;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;25;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;18;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;6;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;13;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;12;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;12;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;7;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;6;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;35;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;17;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;11;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;6;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;12;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;6;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;3;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;63;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;9;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;46;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;12;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;3;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;40;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;45;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;26;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;24;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;6;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;14;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;3;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;14;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;8;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;3;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;7;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;2;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;38;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;28;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;19;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;13;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;7;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;13;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;7;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;4;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;63;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;9;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;46;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;12;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;3;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;40;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;13;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;7;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;45;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;26;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;24;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;6;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;14;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;3;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;14;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;8;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;3;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;7;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;2;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;38;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;28;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;14;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;8;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;19;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;13;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;7;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;15;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;13;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;7;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;4;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;76;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;9;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;52;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;13;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;4;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;47;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;17;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;46;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;32;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;33;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;25;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;7;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;17;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;4;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;17;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;7;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;11;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;3;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;8;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;2;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;42;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;22;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;14;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;8;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;13;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;8;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;4;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;76;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;9;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;52;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;13;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;4;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;47;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;17;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;46;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;32;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;33;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;25;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;7;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;17;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;4;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;17;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;7;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;15;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;11;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;3;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;8;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;2;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;42;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;16;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;22;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;14;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;8;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;17;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;12;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;18;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;13;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;8;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;4;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;88;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;12;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;6;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;63;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;15;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;5;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;57;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;35;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;30;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;8;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;3;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;19;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;4;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;19;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;7;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;19;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;13;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;4;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;10;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;3;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;46;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;24;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;16;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;9;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;19;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;15;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;9;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;5;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;88;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;12;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;6;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;63;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;15;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;5;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;57;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;17;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;35;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;30;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;8;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;3;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;19;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;4;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;19;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;7;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;19;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;13;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;4;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;10;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;3;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;46;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;18;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;11;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;24;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;16;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;9;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;19;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;15;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;9;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;5;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;103;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;14;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;7;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;75;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;16;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;6;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;62;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;22;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;62;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;19;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;44;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;33;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;10;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;3;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;25;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;5;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;22;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;9;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;15;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;5;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;11;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;3;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;38;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;27;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;17;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;10;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;17;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;9;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;5;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;103;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;14;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;7;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;75;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;16;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;6;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;62;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;22;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;62;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;19;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;36;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;44;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;33;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;10;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;3;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;25;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;5;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;22;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;9;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;21;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;15;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;5;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;11;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;3;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;51;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;11;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;38;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;20;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;12;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;27;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;17;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;10;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;21;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;22;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;17;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;9;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;5;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;113;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;17;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;8;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;82;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;18;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;7;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;70;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;24;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;71;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;46;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;46;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;41;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;11;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;3;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;28;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;6;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;26;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;10;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;4;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;25;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;17;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;5;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;14;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;56;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;40;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;30;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;19;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;11;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;18;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;10;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;6;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;113;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;17;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;8;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;82;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;18;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;7;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;70;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;24;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;13;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;71;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;9;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;46;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;46;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;41;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;11;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;3;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;28;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;6;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;26;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;10;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;4;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;25;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;17;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;5;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;14;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;1;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;56;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;40;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;22;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;30;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;19;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;11;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;23;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;24;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;18;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;10;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;6;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;130;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;19;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;8;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;94;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;21;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;7;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;83;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;79;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;56;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;55;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;41;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;13;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;4;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;31;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;6;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;29;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;11;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;5;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;18;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;6;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;14;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;63;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;45;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;31;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;21;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;12;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;20;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;11;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;6;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;130;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;19;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;8;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;94;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;21;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;7;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;83;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;28;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;79;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;56;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;8;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;55;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;41;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;13;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;4;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;31;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;6;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;29;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;11;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;5;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;18;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;6;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;14;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;63;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;45;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;31;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;21;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;12;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;27;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;20;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;11;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;6;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;143;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;22;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;10;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;105;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;25;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;9;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;96;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;35;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;89;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;30;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;59;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;64;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;49;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;14;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;4;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;38;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;8;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;31;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;12;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;6;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;21;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;7;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;3;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;17;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;68;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;35;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;23;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;13;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;21;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;13;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;7;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;143;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;22;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;10;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;105;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;25;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;9;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;96;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;35;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;17;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;89;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;30;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;59;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;64;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;49;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;14;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;4;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;38;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;8;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;31;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;12;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;6;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;21;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;7;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;3;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;17;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;68;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;35;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;23;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;13;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;19;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;10;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;29;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;21;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;13;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;7;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;160;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;24;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;12;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;119;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;27;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;10;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;109;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;37;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;20;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;99;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;64;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;71;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;56;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;16;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;5;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;43;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;8;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;37;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;14;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;6;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;35;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;25;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;8;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;19;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;5;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;28;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;37;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;25;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;14;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;23;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;14;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;8;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;160;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;24;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;12;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;119;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;27;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;10;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;109;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;37;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;20;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;99;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;34;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;64;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;71;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;56;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;16;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;5;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;43;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;8;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;37;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;14;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;6;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;35;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;25;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;8;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;19;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;5;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;72;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;28;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;37;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;25;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;14;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;23;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;14;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;8;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;181;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;28;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;13;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;132;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;29;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;11;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;119;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;41;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;111;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;38;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;73;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;76;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;61;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;18;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;5;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;49;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;9;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;3;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;40;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;16;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;7;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;39;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;26;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;8;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;21;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;6;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;79;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;54;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;42;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;27;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;15;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;24;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;15;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;8;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;181;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;28;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;13;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;132;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;29;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;11;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;119;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;41;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;22;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;111;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;38;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;73;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;76;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;12;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;61;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;18;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;5;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;49;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;9;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;3;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;40;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;16;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;7;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;39;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;12;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;26;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;8;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;21;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;6;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;2;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;79;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;54;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;42;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;27;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;15;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;32;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;34;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;24;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;15;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;8;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;189;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;30;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;14;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;156;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;32;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;12;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;126;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;48;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;117;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;41;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;79;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;84;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;70;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;19;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;6;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;53;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;10;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;3;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;44;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;16;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;7;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;44;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;29;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;9;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;24;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;6;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;84;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;59;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;43;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;29;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;16;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;37;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;27;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;16;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;9;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;189;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;30;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;14;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;156;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;32;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;12;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;126;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;48;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;24;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;117;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;41;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;18;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;79;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;14;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;84;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;70;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;19;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;6;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;53;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;10;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;3;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;44;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;16;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;7;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;44;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;29;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;9;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;24;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;6;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;84;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;17;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;59;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;33;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;43;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;29;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;16;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;37;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;27;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;16;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;9;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;211;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;33;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;16;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;176;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;34;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;13;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;142;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;52;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;28;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;138;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;91;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;77;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;21;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;7;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;59;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;11;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;3;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;50;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;19;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;8;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;47;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;33;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;10;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;5;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;27;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;7;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;88;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;64;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;46;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;31;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;17;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;36;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;40;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;28;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;17;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;9;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;211;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;33;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;16;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;176;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;34;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;13;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;142;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;52;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;28;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;138;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;45;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;91;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;93;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;77;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;21;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;7;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;59;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;11;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;3;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;50;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;19;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;8;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;47;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;14;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;33;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;10;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;5;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;27;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;7;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;88;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;64;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;21;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;46;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;31;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;17;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;36;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;40;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;28;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;17;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;9;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;230;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;38;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;17;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;192;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;38;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;14;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;157;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;57;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;146;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;51;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;97;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;81;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;23;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;7;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;68;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;12;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;4;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;53;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;20;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;9;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;51;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;36;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;11;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;5;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;30;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;8;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;95;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;67;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;38;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;50;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;34;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;19;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;39;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;30;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;18;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;10;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;230;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;38;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;17;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;192;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;38;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;14;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;157;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;57;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;146;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;51;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;20;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;97;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;103;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;16;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;81;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;23;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;7;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;68;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;12;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;4;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;53;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;20;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;9;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;51;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;16;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;36;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;11;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;5;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;30;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;8;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;95;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;67;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;38;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;50;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;34;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;19;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;39;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;26;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;30;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;18;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;10;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;248;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;40;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;19;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;200;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;41;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;16;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;171;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;62;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;160;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;55;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;108;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;109;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;93;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;26;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;8;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;72;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;13;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;4;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;59;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;22;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;10;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;54;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;40;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;12;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;6;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;31;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;9;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;101;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;53;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;35;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;19;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;32;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;19;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;11;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;248;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;40;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;19;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;200;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;41;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;16;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;171;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;62;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;33;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;160;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;55;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;108;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;109;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;93;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;26;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;8;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;72;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;13;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;4;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;59;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;22;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;10;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;54;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;40;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;12;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;6;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;31;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;9;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;3;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;101;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;21;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;72;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;40;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;53;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;35;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;19;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;41;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;28;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;15;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;32;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;19;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;11;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;275;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;45;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;21;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;227;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;45;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;17;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;186;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;68;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;170;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;116;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;122;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;96;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;28;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;9;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;80;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;15;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;4;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;64;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;23;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;11;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;60;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;43;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;13;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;6;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;34;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;10;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;4;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;106;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;57;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;37;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;20;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;33;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;20;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;11;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;275;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;45;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;21;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;227;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;45;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;17;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;186;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;68;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;170;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;24;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;116;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;122;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;19;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;96;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;28;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;9;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;80;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;15;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;4;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;64;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;23;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;11;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;60;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;43;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;13;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;6;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;34;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;10;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;4;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;106;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;76;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;42;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;57;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;37;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;20;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;44;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;47;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;33;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;20;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;11;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;302;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;49;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;22;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;248;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;48;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;18;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;198;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;74;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;40;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;186;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;63;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;126;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;132;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;108;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;30;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;9;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;85;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;16;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;67;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;25;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;12;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;20;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;46;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;14;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;7;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;37;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;10;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;4;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;110;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;78;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;60;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;40;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;22;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;35;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;21;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;12;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;302;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;49;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;22;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;248;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;48;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;18;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;198;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;74;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;40;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;186;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;63;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;26;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;126;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;21;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;132;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;108;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;30;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;9;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;85;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;16;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;67;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;25;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;12;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;66;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;20;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;46;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;14;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;7;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;37;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;10;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;4;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;110;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;78;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;26;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;60;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;40;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;22;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;47;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;31;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;17;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;50;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;35;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;21;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;12;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;322;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;52;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;25;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;263;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;53;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;20;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;215;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;79;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;42;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;199;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;140;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;141;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;115;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;32;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;10;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;94;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;17;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;74;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;27;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;13;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;70;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;51;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;15;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;7;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;40;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;11;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;4;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;117;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;47;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;63;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;42;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;23;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;37;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;22;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;12;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;322;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;52;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;25;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;263;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;53;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;20;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;215;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;79;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;42;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;199;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;140;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;141;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;115;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;32;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;10;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;94;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;17;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;74;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;27;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;13;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;70;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;22;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;51;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;15;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;7;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;40;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;11;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;4;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;117;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;83;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;47;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;63;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;42;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;23;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;37;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;22;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;12;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;346;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;58;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;26;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;285;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;56;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;22;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;232;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;86;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;219;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;31;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;148;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;153;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;122;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;34;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;11;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;99;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;18;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;6;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;79;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;29;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;14;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;53;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;16;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;8;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;43;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;12;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;5;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;123;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;67;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;44;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;24;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;51;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;38;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;24;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;13;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;346;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;58;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;26;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;285;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;56;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;22;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;232;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;86;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;219;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;74;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;31;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;148;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;153;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;24;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;122;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;34;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;11;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;99;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;18;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;6;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;79;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;29;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;14;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;24;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;16;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;53;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;16;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;8;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;43;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;12;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;5;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;123;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;25;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;86;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;49;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;67;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;44;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;24;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;51;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;55;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;38;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;24;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;13;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;373;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;60;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;28;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;300;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;58;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;23;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;249;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;93;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;229;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;80;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;33;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;158;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;162;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;131;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;38;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;12;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;108;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;19;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;6;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;85;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;31;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;15;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;81;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;58;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;17;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;8;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;47;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;13;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;5;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;129;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;90;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;70;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;46;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;25;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;40;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;25;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;13;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;373;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;60;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;28;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;300;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;58;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;23;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;249;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;93;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;229;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;80;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;33;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;158;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;26;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;162;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;26;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;131;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;38;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;12;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;108;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;19;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;6;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;85;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;31;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;15;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;81;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;18;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;58;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;17;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;8;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;47;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;13;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;5;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;129;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;90;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;52;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;70;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;46;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;25;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;53;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;36;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;40;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;25;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;13;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;398;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;66;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;30;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;328;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;64;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;26;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;261;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;101;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;53;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;247;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;87;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;168;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;172;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;140;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;39;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;12;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;115;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;21;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;6;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;90;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;33;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;15;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;87;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;62;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;18;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;9;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;51;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;14;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;5;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;72;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;48;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;26;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;60;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;42;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;26;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;14;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;398;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;66;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;30;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;328;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;64;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;26;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;261;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;101;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;53;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;247;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;87;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;168;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;28;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;172;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;140;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;39;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;12;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;115;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;21;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;6;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;90;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;33;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;15;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;87;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;27;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;62;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;18;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;9;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;51;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;14;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;5;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;94;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;54;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;32;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;72;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;48;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;26;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;55;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;38;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;60;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;42;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;26;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;14;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;417;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;69;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;33;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;346;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;67;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;26;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;278;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;106;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;259;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;177;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;180;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;149;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;42;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;13;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;124;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;22;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;7;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;96;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;36;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;17;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;93;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;65;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;19;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;10;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;54;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;15;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;6;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;97;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;76;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;50;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;27;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;63;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;43;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;26;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;14;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;417;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;69;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;33;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;346;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;67;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;26;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;278;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;106;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;56;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;259;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;177;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;30;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;180;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;29;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;149;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;42;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;13;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;124;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;22;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;7;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;96;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;36;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;17;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;93;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;65;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;19;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;10;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;54;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;15;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;6;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;138;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;97;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;56;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;76;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;50;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;27;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;58;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;63;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;43;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;26;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;14;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;447;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;73;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;34;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;372;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;71;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;28;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;289;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;111;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;275;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;190;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;194;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;157;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;45;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;14;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;134;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;24;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;7;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;102;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;37;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;18;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;100;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;71;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;20;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;10;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;57;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;16;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;6;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;143;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;79;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;52;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;28;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;44;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;28;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;15;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;447;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;73;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;34;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;372;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;71;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;28;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;289;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;111;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;275;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;98;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;190;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;32;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;194;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;31;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;157;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;45;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;14;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;134;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;24;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;7;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;102;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;37;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;18;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;100;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;31;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;71;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;20;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;10;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;57;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;16;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;6;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;143;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;101;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;79;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;52;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;28;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;60;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;66;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;44;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;28;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;15;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;466;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;78;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;36;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;389;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;75;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;30;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;310;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;120;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;63;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;291;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;101;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;203;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;203;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;167;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;48;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;15;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;140;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;25;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;8;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;106;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;39;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;19;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;104;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;74;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;22;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;11;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;60;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;17;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;6;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;148;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;104;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;61;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;82;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;53;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;29;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;61;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;46;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;29;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;16;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;466;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;78;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;36;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;389;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;75;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;30;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;310;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;120;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;63;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;291;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;101;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;42;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;203;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;203;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;167;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;48;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;15;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;140;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;25;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;8;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;106;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;39;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;19;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;104;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;33;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;74;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;22;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;11;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;60;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;17;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;6;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;148;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;31;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;104;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;61;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;35;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;82;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;53;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;29;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;61;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;46;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;29;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;16;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;487;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;82;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;38;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;418;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;79;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;32;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;327;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;129;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;67;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;309;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;109;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;44;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;216;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;214;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;175;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;50;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;16;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;150;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;26;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;8;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;115;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;41;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;20;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;110;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;79;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;23;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;11;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;64;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;18;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;7;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;153;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;84;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;55;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;30;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;47;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;30;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;16;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;487;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;82;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;38;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;418;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;79;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;32;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;327;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;129;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;67;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;309;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;109;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;44;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;216;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;214;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;175;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;50;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;16;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;150;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;26;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;8;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;115;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;41;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;20;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;110;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;24;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;79;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;23;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;11;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;64;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;18;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;7;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;153;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;62;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;37;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;84;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;55;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;30;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;64;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;43;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;47;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;30;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;16;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;512;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;87;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;40;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;442;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;83;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;33;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;341;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;134;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;71;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;318;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;224;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;226;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;183;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;53;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;17;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;159;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;27;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;8;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;119;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;44;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;20;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;115;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;83;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;24;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;12;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;68;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;19;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;7;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;88;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;57;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;31;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;49;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;31;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;512;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;87;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;40;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;442;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;83;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;33;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;341;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;134;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;71;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;318;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;115;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;47;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;224;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;226;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;183;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;53;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;17;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;159;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;27;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;8;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;119;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;44;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;20;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;115;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;83;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;24;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;12;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;68;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;19;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;7;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;158;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;111;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;64;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;88;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;57;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;31;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;65;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;24;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;72;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;49;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;31;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;532;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;92;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;42;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;458;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;86;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;35;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;360;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;139;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;334;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;238;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;238;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;192;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;56;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;17;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;165;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;29;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;9;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;124;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;46;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;22;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;121;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;87;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;25;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;12;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;70;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;20;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;7;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;91;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;59;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;32;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;50;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;32;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;17;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;532;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;92;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;42;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;458;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;86;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;35;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;360;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;139;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;334;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;118;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;49;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;238;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;39;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;238;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;38;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;192;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;56;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;17;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;165;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;29;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;9;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;124;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;46;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;22;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;121;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;26;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;87;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;25;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;12;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;70;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;20;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;7;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;66;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;39;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;91;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;59;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;32;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;74;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;50;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;32;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;17;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;557;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;96;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;44;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;478;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;90;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;36;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;374;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;347;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;125;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;246;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;246;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;200;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;58;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;18;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;174;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;30;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;9;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;129;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;47;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;22;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;126;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;91;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;26;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;13;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;75;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;21;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;8;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;92;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;60;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;33;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;51;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;32;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;557;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;96;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;44;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;478;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;90;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;36;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;374;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;147;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;79;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;347;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;125;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;246;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;41;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;246;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;200;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;58;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;18;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;174;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;30;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;9;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;129;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;47;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;22;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;126;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;39;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;91;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;26;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;13;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;75;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;21;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;8;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;165;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;115;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;67;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;92;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;60;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;33;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;51;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;32;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;580;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;100;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;46;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;496;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;94;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;38;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;384;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;152;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;363;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;130;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;257;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;256;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;209;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;61;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;19;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;181;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;31;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;10;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;136;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;49;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;23;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;131;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;95;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;27;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;13;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;77;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;22;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;8;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;70;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;94;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;62;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;33;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;52;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;33;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;580;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;100;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;46;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;496;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;94;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;38;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;384;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;152;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;82;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;363;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;130;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;53;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;257;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;256;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;209;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;61;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;19;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;181;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;31;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;10;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;136;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;49;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;23;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;131;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;41;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;95;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;27;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;13;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;77;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;22;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;8;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;168;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;70;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;94;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;62;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;33;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;26;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;52;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;33;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;605;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;105;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;47;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;522;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;97;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;39;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;403;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;158;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;135;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;265;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;262;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;218;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;63;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;20;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;188;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;32;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;10;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;139;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;51;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;24;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;99;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;28;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;14;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;80;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;23;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;8;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;97;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;63;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;34;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;72;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;53;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;34;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;605;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;105;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;47;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;522;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;97;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;39;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;403;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;158;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;135;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;55;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;265;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;44;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;262;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;218;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;63;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;20;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;188;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;32;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;10;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;139;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;51;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;24;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;99;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;28;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;14;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;80;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;23;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;8;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;120;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;97;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;63;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;34;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;72;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;79;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;53;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;34;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;628;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;109;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;49;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;541;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;100;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;40;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;413;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;88;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;387;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;278;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;225;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;64;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;21;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;196;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;34;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;10;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;145;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;53;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;25;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;140;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;103;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;29;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;14;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;83;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;24;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;176;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;121;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;99;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;64;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;35;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;54;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;34;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;628;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;109;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;49;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;541;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;100;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;40;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;413;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;165;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;88;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;387;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;142;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;278;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;46;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;45;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;225;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;64;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;21;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;196;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;34;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;10;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;145;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;53;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;25;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;140;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;103;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;29;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;14;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;83;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;24;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;176;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;121;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;99;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;64;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;35;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;82;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;54;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;34;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;18;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;635;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;113;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;51;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;556;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;104;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;42;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;428;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;171;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;91;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;401;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;147;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;289;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;281;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;234;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;68;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;21;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;204;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;35;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;11;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;149;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;54;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;26;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;144;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;31;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;106;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;30;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;15;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;86;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;24;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;176;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;100;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;65;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;35;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;55;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;35;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;19;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;635;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;113;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;51;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;556;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;104;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;42;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;428;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;171;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;91;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;401;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;147;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;289;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;281;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;234;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;68;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;21;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;204;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;35;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;11;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;149;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;54;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;26;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;144;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;31;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;106;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;30;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;15;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;86;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;24;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;176;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;100;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;65;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;35;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;51;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;55;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;35;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;19;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;657;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;116;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;52;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;579;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;107;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;42;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;435;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;94;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;409;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;291;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;290;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;47;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;235;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;69;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;22;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;208;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;36;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;11;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;153;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;56;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;26;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;149;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;32;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;109;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;30;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;15;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;89;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;25;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;179;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;102;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;66;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;36;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;55;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;35;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;19;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;657;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;116;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;52;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;579;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;107;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;42;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;435;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;94;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;409;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;148;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;60;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;291;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;290;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;47;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;235;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;69;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;22;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;208;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;36;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;11;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;153;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;56;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;26;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;149;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;46;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;32;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;109;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;30;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;15;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;89;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;25;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;179;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;102;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;66;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;36;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;83;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;55;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;35;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;19;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;666;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;119;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;54;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;592;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;108;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;44;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;447;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;180;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;95;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;420;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;153;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;61;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;301;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;50;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;293;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;49;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;244;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;70;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;23;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;213;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;36;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;11;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;156;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;57;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;27;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;151;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;111;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;31;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;15;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;90;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;26;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;180;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;105;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;67;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;36;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;77;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;56;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;36;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;19;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;666;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;119;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;54;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;592;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;108;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;44;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;447;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;180;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;95;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;420;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;153;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;61;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;301;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;50;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;293;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;49;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;16;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;244;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;70;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;23;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;213;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;36;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;11;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;156;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;57;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;27;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;151;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;111;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;31;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;15;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;90;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;26;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;9;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;180;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;105;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;67;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;36;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;77;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;52;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;85;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;56;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;36;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;19;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;683;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;120;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;54;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;603;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;109;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;45;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;453;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;185;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;99;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;433;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;157;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;310;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;50;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;298;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;50;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;247;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;72;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;23;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;218;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;37;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;159;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;58;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;27;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;155;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;34;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;115;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;92;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;27;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;183;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;105;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;67;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;36;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;77;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;53;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;56;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;683;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;120;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;54;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;603;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;109;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;45;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;453;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;185;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;99;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;433;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;157;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;62;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;310;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;50;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;298;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;50;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;247;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;72;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;23;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;218;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;37;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;159;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;58;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;27;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;155;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;34;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;115;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;92;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;27;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;183;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;125;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;45;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;105;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;67;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;36;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;77;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;53;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;56;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;689;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;124;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;56;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;616;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;112;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;45;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;460;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;188;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;101;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;437;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;159;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;63;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;311;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;50;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;252;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;74;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;24;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;225;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;37;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;162;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;59;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;28;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;34;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;116;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;93;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;27;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;105;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;69;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;37;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;77;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;53;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;56;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;689;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;124;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;56;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;616;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;112;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;45;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;460;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;188;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;101;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;437;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;159;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;63;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;311;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;50;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;252;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;74;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;24;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;225;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;37;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;162;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;59;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;28;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;34;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;116;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;93;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;27;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;105;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;69;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;37;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;77;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;53;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;56;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;689;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;125;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;56;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;630;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;112;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;46;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;462;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;192;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;102;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;440;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;161;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;63;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;318;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;51;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;254;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;74;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;24;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;229;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;38;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;163;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;59;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;28;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;35;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;118;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;95;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;28;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;107;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;69;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;37;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;54;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;57;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;689;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;125;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;56;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;630;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;112;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;46;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;462;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;192;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;102;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;440;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;161;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;63;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;318;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;51;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;254;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;74;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;24;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;229;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;38;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;163;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;59;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;28;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;157;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;35;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;118;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;95;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;28;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;107;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;69;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;37;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;54;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;87;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;57;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;698;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;127;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;57;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;634;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;113;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;46;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;462;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;192;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;103;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;440;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;162;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;64;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;321;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;52;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;51;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;254;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;76;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;24;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;229;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;38;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;163;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;59;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;28;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;158;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;35;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;119;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;95;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;28;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;107;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;69;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;37;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;54;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;88;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;57;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;698;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;127;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;57;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;634;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;113;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;46;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;462;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;192;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;103;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;440;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;162;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;64;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;321;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;52;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;304;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;51;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;17;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;254;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;76;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;24;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;229;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;38;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;12;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;163;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;59;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;28;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;158;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;49;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;35;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;119;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;32;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;16;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;95;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;28;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;10;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;77;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;107;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;69;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;37;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;54;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;88;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;57;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;37;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;20;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;1;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;2;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;1;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;1;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;1;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;2;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;2;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;7;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;7;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;6;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;2;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;0;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;1;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;4;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;0;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;3;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;3;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;3;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;6;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;3;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;3;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;3;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;8;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;3;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;4;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;3;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;3;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;14;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;2;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;3;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;4;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;4;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;3;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;3;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;14;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;3;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;5;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;9;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;4;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;9;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;4;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;3;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;1;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;3;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;16;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;2;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;9;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;4;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;5;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;4;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;5;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;4;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;2;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;5;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;16;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;2;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;9;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;4;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;5;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;4;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;0;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;5;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;4;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;2;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;5;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;1;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;23;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;3;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;9;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;4;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;11;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;9;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;3;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;16;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;7;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;5;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;3;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;5;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;2;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;23;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;3;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;9;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;4;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;0;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;10;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;14;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;3;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;11;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;9;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;2;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;3;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;16;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;11;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;7;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;5;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;3;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;6;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;5;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;2;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;29;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;3;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;19;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;18;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;11;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;11;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;3;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;4;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;5;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;4;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;19;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;8;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;6;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;4;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;6;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;3;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;2;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;29;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;3;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;19;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;14;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;5;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;18;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;8;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;11;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;11;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;3;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;4;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;5;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;5;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;4;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;0;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;19;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;8;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;6;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;4;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;6;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;3;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;2;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;33;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;3;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;22;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;1;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;18;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;21;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;12;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;11;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;3;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;5;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;7;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;3;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;4;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;3;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;21;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;11;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;7;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;4;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;7;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;4;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;2;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;33;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;3;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;22;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;1;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;18;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;3;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;21;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;12;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;11;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;3;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;5;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;0;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;7;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;3;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;4;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;1;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;3;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;21;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;16;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;11;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;7;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;4;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;6;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;7;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;4;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;2;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2023W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2023W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2023;B;56604;B Psychologie;SOW;N;N;N;42;1.32
-21PB;2023;B;56604;B Psychologie;SOW;E;N;N;5;1.32
-21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;25;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;5;1.32
-21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;2;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.32
-21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;27;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.32
-21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;19;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32
-21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;16;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.32
-21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32
-21PB;2023;B;56981;B Politicologie;MAN;N;N;N;13;1.32
-21PB;2023;B;56981;B Politicologie;MAN;E;N;N;4;1.32
-21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;7;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32
-21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;8;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;4;1.32
-21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;7;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;5;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;2;1.32
-21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;N;N;N;4;1.32
-21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32
-21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;24;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1
-21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.1
-21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.1
-21PB;2023;M;60300;M Informatica;SOW;N;N;N;12;1.1
-21PB;2023;M;60300;M Informatica;SOW;E;N;N;8;1.1
-21PB;2023;M;60300;M Informatica;SOW;R;N;N;5;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.1
-21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1
-21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;9;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;4;1.1
-21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;3;1.1
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2023;B;56604;B Psychologie;SOW;N;N;N;42;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;E;N;N;5;1.32;V
+21PB;2023;B;56604;B Psychologie;SOW;R;N;N;2;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;N;N;N;25;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;E;N;N;5;1.32;V
+21PB;2023;B;56551;B Geneeskunde;MED;R;N;N;2;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;19;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;7;1.32;V
+21PB;2023;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;N;N;N;27;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;E;N;N;7;1.32;V
+21PB;2023;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;N;N;N;19;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.32;V
+21PB;2023;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;N;N;N;16;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.32;V
+21PB;2023;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;N;N;N;13;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;E;N;N;4;1.32;V
+21PB;2023;B;56981;B Politicologie;MAN;R;N;N;1;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;N;N;N;7;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;E;N;N;2;1.32;V
+21PB;2023;B;56034;B Geschiedenis;FdL;R;N;N;1;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;N;N;N;8;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;E;N;N;4;1.32;V
+21PB;2023;B;56980;B Wiskunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;N;N;N;7;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;N;N;N;5;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;E;N;N;2;1.32;V
+21PB;2023;B;56857;B Scheikunde;FNWI;R;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;N;N;N;4;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;E;N;N;1;1.32;V
+21PB;2023;B;56081;B Filosofie;FdL;R;N;N;0;1.32;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;24;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.1;V
+21PB;2023;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;N;N;N;19;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;E;N;N;9;1.1;V
+21PB;2023;M;60720;M Cognitive Neuroscience;SOW;R;N;N;6;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;N;N;N;12;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;E;N;N;8;1.1;V
+21PB;2023;M;60300;M Informatica;SOW;R;N;N;5;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;10;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.1;V
+21PB;2023;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.1;V
+21PB;2023;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;N;N;N;9;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;E;N;N;4;1.1;V
+21PB;2023;M;60815;M Linguistiek;FdL;R;N;N;3;1.1;V

--- a/data/input_raw/telbestanden/telbestandY2024W01.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W01.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;36;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;7;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;4;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;39;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;6;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;26;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;15;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;15;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;4;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;12;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;12;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;3;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;10;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;6;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;7;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;21;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;16;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;12;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;5;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;12;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;6;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;3;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;36;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;7;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;4;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;39;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;6;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;26;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;6;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;15;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;10;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;17;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;3;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;15;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;15;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;4;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;12;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;12;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;3;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;10;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;6;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;7;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;34;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;7;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;21;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;13;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;16;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;12;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;5;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;14;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;7;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;5;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;14;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;12;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;6;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;3;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W02.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W02.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;48;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;9;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;4;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;48;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;6;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;20;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;21;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;19;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;4;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;15;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;14;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;4;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;7;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;8;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;20;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;13;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;6;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;14;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;7;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;4;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;48;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;9;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;4;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;48;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;6;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;30;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;12;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;17;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;12;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;3;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;20;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;21;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;3;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;19;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;4;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;15;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;14;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;4;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;3;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;7;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;8;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;39;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;8;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;15;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;9;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;20;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;13;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;6;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;15;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;8;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;6;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;17;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;6;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;14;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;7;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;4;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W03.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W03.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;56;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;11;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;5;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;63;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;6;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;4;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;38;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;14;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;25;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;27;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;22;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;19;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;6;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;18;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;3;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;16;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;4;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;9;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;3;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;9;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;44;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;22;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;15;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;7;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;19;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;15;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;8;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;4;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;56;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;11;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;5;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;63;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;6;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;4;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;38;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;14;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;8;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;25;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;15;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;4;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;27;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;4;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;22;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;19;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;6;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;18;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;3;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;16;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;4;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;13;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;4;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;9;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;3;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;9;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;44;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;9;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;5;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;26;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;17;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;22;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;15;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;7;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;18;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;9;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;7;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;19;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;7;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;15;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;8;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;4;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W04.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W04.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;59;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;13;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;6;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;64;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;9;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;4;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;43;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;18;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;31;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;29;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;24;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;7;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;22;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;4;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;19;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;11;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;3;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;13;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;19;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;24;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;16;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;8;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;21;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;17;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;9;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;5;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;59;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;13;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;6;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;64;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;9;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;4;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;43;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;18;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;10;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;31;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;18;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;5;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;29;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;5;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;27;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;24;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;7;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;22;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;4;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;19;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;16;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;11;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;3;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;13;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;49;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;31;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;19;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;10;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;24;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;16;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;8;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;20;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;10;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;8;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;21;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;17;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;9;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;5;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W05.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W05.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;69;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;14;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;6;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;84;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;10;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;5;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;49;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;36;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;19;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;34;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;31;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;29;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;8;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;3;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;25;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;4;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;21;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;7;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;12;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;3;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;13;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;55;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;28;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;18;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;9;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;18;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;10;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;5;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;69;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;14;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;6;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;84;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;10;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;5;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;49;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;19;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;11;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;36;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;19;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;6;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;34;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;6;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;31;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;5;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;29;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;8;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;3;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;25;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;4;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;21;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;7;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;18;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;5;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;12;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;3;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;13;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;55;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;10;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;6;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;34;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;21;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;13;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;28;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;18;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;9;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;22;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;11;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;23;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;8;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;18;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;10;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;5;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W06.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W06.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;82;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;16;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;8;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;92;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;11;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;6;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;59;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;23;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;40;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;37;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;39;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;33;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;9;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;3;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;28;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;4;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;26;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;8;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;4;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;13;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;4;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;16;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;62;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;31;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;20;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;10;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;20;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;11;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;5;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;82;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;16;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;8;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;92;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;11;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;6;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;59;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;23;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;14;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;40;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;22;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;7;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;37;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;7;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;2;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;39;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;6;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;33;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;9;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;3;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;28;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;4;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;26;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;8;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;4;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;20;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;6;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;4;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;13;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;4;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;16;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;62;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;12;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;37;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;14;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;31;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;20;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;10;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;24;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;13;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;9;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;26;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;9;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;4;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;20;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;11;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;5;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W07.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W07.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;88;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;19;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;9;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;100;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;13;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;7;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;67;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;48;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;41;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;39;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;10;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;4;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;32;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;5;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;29;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;9;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;4;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;16;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;4;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;17;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;4;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;65;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;34;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;22;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;11;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;22;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;12;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;6;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;88;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;19;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;9;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;100;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;13;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;7;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;67;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;25;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;15;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;48;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;26;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;8;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;44;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;41;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;7;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;39;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;10;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;4;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;32;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;5;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;29;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;9;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;4;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;24;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;7;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;16;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;4;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;17;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;4;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;65;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;13;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;7;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;41;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;25;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;15;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;34;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;22;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;11;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;26;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;14;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;11;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;28;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;10;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;22;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;12;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;6;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W08.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W08.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;104;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;20;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;10;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;115;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;15;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;8;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;80;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;51;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;49;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;40;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;12;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;4;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;36;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;6;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;31;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;10;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;5;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;17;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;5;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;21;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;4;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;71;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;37;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;24;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;13;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;23;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;13;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;7;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;104;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;20;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;10;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;115;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;15;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;8;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;80;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;29;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;16;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;53;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;27;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;10;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;51;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;9;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;3;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;49;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;8;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;40;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;12;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;4;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;36;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;6;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;31;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;10;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;5;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;27;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;8;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;5;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;17;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;5;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;21;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;4;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;71;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;14;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;8;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;44;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;27;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;16;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;37;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;24;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;13;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;28;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;16;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;31;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;11;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;23;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;13;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;7;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W09.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W09.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;116;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;24;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;11;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;128;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;16;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;9;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;90;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;31;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;18;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;62;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;62;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;56;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;51;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;13;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;5;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;40;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;7;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;36;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;11;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;5;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;21;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;6;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;22;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;5;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;77;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;40;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;25;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;13;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;26;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;14;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;7;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;116;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;24;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;11;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;128;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;16;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;9;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;90;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;31;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;18;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;62;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;32;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;11;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;62;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;10;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;56;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;9;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;51;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;13;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;5;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;40;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;7;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;36;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;11;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;5;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;31;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;9;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;6;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;21;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;6;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;22;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;5;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;77;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;15;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;48;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;29;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;17;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;40;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;25;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;13;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;30;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;17;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;12;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;12;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;5;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;26;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;14;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;7;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W10.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W10.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;132;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;25;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;13;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;149;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;18;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;10;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;97;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;36;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;76;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;36;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;67;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;61;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;51;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;15;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;5;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;49;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;7;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;3;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;42;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;13;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;6;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;36;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;24;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;7;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;25;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;5;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;85;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;43;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;29;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;15;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;27;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;16;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;8;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;132;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;25;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;13;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;149;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;18;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;10;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;97;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;36;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;21;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;76;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;36;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;12;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;67;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;61;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;10;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;51;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;15;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;5;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;49;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;7;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;3;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;42;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;13;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;6;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;36;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;10;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;7;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;24;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;7;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;25;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;5;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;2;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;85;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;16;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;9;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;52;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;31;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;18;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;43;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;29;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;15;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;33;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;18;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;13;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;36;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;13;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;27;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;16;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;8;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W11.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W11.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;143;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;29;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;15;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;164;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;22;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;11;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;109;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;40;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;81;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;40;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;80;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;66;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;57;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;16;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;6;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;57;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;8;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;3;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;44;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;14;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;6;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;25;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;8;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;4;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;28;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;6;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;3;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;90;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;57;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;47;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;30;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;16;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;39;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;29;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;17;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;8;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;143;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;29;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;15;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;164;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;22;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;11;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;109;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;40;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;23;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;81;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;40;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;13;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;80;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;12;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;66;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;11;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;57;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;16;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;6;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;57;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;8;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;3;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;44;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;14;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;6;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;40;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;11;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;25;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;8;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;4;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;28;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;6;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;3;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;90;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;18;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;10;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;57;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;35;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;20;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;47;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;30;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;16;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;35;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;20;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;14;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;39;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;14;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;6;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;29;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;17;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;8;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W12.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W12.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;157;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;34;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;16;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;173;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;25;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;12;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;117;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;44;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;25;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;88;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;87;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;74;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;66;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;19;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;7;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;62;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;9;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;3;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;49;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;16;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;7;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;43;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;28;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;8;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;4;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;31;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;7;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;3;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;94;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;60;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;36;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;51;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;32;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;17;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;32;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;18;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;9;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;157;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;34;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;16;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;173;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;25;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;12;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;117;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;44;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;25;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;88;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;44;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;15;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;87;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;13;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;5;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;74;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;13;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;66;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;19;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;7;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;62;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;9;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;3;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;49;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;16;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;7;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;43;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;13;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;8;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;28;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;8;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;4;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;31;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;7;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;3;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;94;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;19;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;60;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;36;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;22;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;51;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;32;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;17;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;38;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;21;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;42;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;15;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;32;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;18;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;9;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W13.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W13.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;172;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;37;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;18;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;194;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;27;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;14;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;132;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;49;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;100;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;96;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;85;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;71;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;21;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;7;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;65;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;11;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;4;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;53;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;17;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;8;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;48;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;31;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;10;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;5;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;35;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;7;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;3;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;100;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;64;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;54;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;34;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;18;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;33;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;19;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;9;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;172;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;37;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;18;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;194;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;27;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;14;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;132;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;49;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;30;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;100;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;49;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;16;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;96;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;15;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;6;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;85;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;14;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;4;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;71;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;21;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;7;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;65;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;11;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;4;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;53;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;17;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;8;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;48;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;9;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;31;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;10;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;5;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;35;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;7;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;3;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;100;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;20;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;11;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;64;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;39;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;24;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;54;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;34;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;18;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;40;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;22;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;16;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;45;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;16;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;7;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;33;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;19;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;9;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W14.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W14.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;193;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;40;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;19;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;211;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;30;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;15;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;147;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;54;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;32;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;108;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;55;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;104;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;90;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;80;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;22;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;8;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;73;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;11;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;4;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;58;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;19;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;8;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;52;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;35;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;10;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;5;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;38;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;8;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;4;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;67;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;58;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;36;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;19;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;48;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;35;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;20;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;10;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;193;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;40;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;19;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;211;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;30;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;15;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;147;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;54;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;32;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;108;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;55;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;17;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;104;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;17;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;90;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;15;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;80;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;22;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;8;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;73;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;11;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;4;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;58;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;19;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;8;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;52;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;15;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;10;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;35;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;10;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;5;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;38;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;8;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;4;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;107;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;22;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;12;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;67;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;41;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;25;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;58;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;36;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;19;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;43;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;24;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;18;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;48;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;17;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;35;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;20;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;10;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W15.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W15.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;214;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;44;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;22;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;236;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;33;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;17;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;161;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;58;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;119;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;117;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;101;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;87;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;24;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;9;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;78;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;12;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;62;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;20;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;9;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;56;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;39;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;11;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;6;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;41;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;9;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;4;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;115;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;60;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;39;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;20;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;51;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;37;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;21;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;11;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;214;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;44;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;22;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;236;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;33;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;17;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;161;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;58;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;35;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;119;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;58;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;19;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;117;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;18;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;7;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;101;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;17;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;87;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;24;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;9;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;78;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;12;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;62;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;20;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;9;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;56;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;17;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;11;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;39;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;11;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;6;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;41;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;9;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;4;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;115;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;23;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;73;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;44;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;27;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;60;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;39;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;20;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;45;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;25;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;19;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;51;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;18;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;8;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;37;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;21;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;11;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W16.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W16.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;234;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;49;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;23;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;248;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;37;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;18;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;171;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;64;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;37;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;131;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;64;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;125;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;109;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;95;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;25;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;9;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;85;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;14;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;68;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;23;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;10;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;59;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;42;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;12;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;6;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;45;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;10;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;4;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;121;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;64;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;41;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;22;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;39;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;22;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;11;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;234;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;49;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;23;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;248;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;37;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;18;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;171;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;64;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;37;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;131;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;64;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;21;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;125;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;20;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;8;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;109;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;18;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;5;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;95;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;25;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;9;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;85;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;14;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;68;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;23;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;10;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;59;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;19;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;12;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;42;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;12;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;6;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;45;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;10;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;4;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;121;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;24;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;13;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;77;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;45;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;28;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;64;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;41;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;22;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;48;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;27;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;20;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;53;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;19;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;39;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;22;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;11;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W17.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W17.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;261;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;52;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;25;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;277;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;38;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;18;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;190;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;72;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;41;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;144;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;136;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;102;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;28;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;10;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;92;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;15;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;74;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;24;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;11;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;67;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;46;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;13;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;7;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;48;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;11;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;5;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;127;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;81;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;68;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;43;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;24;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;56;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;41;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;24;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;11;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;261;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;52;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;25;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;277;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;38;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;18;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;190;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;72;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;41;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;144;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;70;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;23;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;136;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;22;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;118;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;20;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;102;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;28;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;10;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;92;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;15;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;74;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;24;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;11;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;67;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;21;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;13;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;46;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;13;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;7;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;48;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;11;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;5;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;127;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;26;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;14;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;81;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;48;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;30;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;68;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;43;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;24;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;50;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;29;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;21;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;56;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;20;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;9;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;41;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;24;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;11;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W18.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W18.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;279;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;58;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;28;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;292;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;42;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;21;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;198;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;75;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;43;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;159;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;73;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;151;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;128;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;112;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;31;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;11;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;101;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;17;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;6;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;81;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;26;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;12;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;70;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;50;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;14;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;7;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;53;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;11;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;5;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;84;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;50;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;70;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;45;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;25;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;43;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;25;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;12;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;279;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;58;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;28;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;292;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;42;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;21;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;198;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;75;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;43;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;159;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;73;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;25;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;151;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;23;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;9;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;128;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;21;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;6;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;112;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;31;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;11;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;101;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;17;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;6;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;81;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;26;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;12;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;70;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;23;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;14;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;50;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;14;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;7;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;53;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;11;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;5;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;133;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;27;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;84;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;50;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;31;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;70;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;45;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;25;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;52;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;30;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;22;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;58;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;21;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;43;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;25;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;12;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W19.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W19.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;294;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;61;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;30;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;309;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;46;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;22;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;214;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;82;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;171;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;81;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;27;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;161;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;135;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;120;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;33;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;12;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;109;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;18;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;6;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;84;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;28;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;13;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;54;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;15;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;8;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;57;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;12;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;5;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;140;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;89;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;53;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;74;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;47;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;26;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;45;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;26;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;13;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;294;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;61;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;30;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;309;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;46;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;22;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;214;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;82;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;47;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;171;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;81;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;27;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;161;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;25;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;10;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;135;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;23;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;120;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;33;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;12;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;109;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;18;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;6;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;84;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;28;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;13;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;77;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;25;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;15;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;54;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;15;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;8;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;57;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;12;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;5;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;140;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;28;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;15;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;89;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;53;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;33;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;74;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;47;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;26;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;54;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;32;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;61;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;22;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;10;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;45;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;26;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;13;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W20.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W20.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;320;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;65;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;31;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;332;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;48;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;24;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;233;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;90;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;184;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;85;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;172;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;145;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;130;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;35;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;13;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;117;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;19;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;7;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;91;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;30;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;14;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;56;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;17;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;8;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;60;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;13;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;6;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;146;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;91;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;78;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;50;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;27;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;65;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;47;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;27;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;13;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;320;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;65;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;31;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;332;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;48;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;24;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;233;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;90;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;50;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;184;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;85;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;29;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;172;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;27;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;11;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;145;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;25;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;7;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;130;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;35;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;13;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;117;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;19;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;7;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;91;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;30;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;14;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;82;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;26;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;56;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;17;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;8;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;60;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;13;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;6;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;146;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;29;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;16;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;91;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;55;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;34;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;78;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;50;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;27;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;57;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;33;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;23;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;65;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;23;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;47;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;27;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;13;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W21.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W21.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;340;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;71;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;34;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;353;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;52;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;25;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;251;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;94;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;53;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;194;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;31;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;186;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;29;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;157;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;137;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;38;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;14;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;125;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;20;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;7;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;98;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;32;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;14;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;86;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;62;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;17;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;9;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;65;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;14;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;6;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;96;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;81;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;52;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;28;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;49;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;28;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;14;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;340;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;71;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;34;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;353;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;52;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;25;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;251;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;94;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;53;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;194;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;92;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;31;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;186;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;29;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;12;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;157;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;27;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;8;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;137;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;38;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;14;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;125;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;20;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;7;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;98;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;32;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;14;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;86;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;29;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;17;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;62;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;17;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;9;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;65;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;14;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;6;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;151;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;30;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;96;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;58;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;81;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;52;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;28;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;59;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;67;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;24;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;11;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;49;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;28;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;14;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W22.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W22.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;363;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;74;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;36;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;373;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;55;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;26;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;264;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;102;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;58;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;209;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;97;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;197;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;165;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;146;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;40;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;15;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;132;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;22;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;8;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;103;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;34;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;16;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;92;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;66;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;19;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;9;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;70;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;15;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;7;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;157;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;83;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;53;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;29;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;61;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;51;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;29;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;14;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;363;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;74;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;36;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;373;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;55;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;26;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;264;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;102;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;58;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;209;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;97;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;34;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;197;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;31;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;13;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;165;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;28;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;146;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;40;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;15;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;132;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;22;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;8;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;103;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;34;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;16;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;92;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;30;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;19;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;66;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;19;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;9;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;70;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;15;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;7;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;157;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;32;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;17;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;99;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;60;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;36;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;83;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;53;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;29;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;61;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;35;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;25;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;69;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;51;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;29;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;14;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W23.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W23.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;387;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;78;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;38;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;399;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;59;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;28;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;278;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;108;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;224;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;102;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;210;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;172;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;154;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;43;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;16;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;141;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;23;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;8;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;109;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;36;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;16;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;99;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;70;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;20;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;10;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;73;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;16;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;7;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;61;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;88;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;55;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;31;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;53;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;30;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;15;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;387;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;78;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;38;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;399;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;59;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;28;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;278;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;108;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;60;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;224;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;102;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;35;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;210;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;33;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;172;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;30;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;154;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;43;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;16;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;141;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;23;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;8;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;109;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;36;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;16;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;99;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;32;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;20;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;70;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;20;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;10;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;73;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;16;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;7;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;160;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;33;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;18;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;102;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;61;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;38;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;88;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;55;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;31;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;63;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;37;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;71;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;25;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;53;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;30;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;15;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W24.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W24.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;411;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;83;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;40;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;417;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;62;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;30;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;289;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;115;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;236;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;220;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;187;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;165;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;45;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;16;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;147;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;24;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;9;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;114;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;38;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;17;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;104;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;73;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;21;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;11;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;76;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;17;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;7;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;90;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;57;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;31;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;54;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;31;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;15;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;411;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;83;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;40;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;417;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;62;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;30;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;289;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;115;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;64;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;236;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;107;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;37;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;220;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;35;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;14;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;187;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;32;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;9;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;165;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;45;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;16;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;147;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;24;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;9;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;114;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;38;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;17;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;104;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;34;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;21;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;73;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;21;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;11;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;76;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;17;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;7;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;167;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;34;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;107;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;63;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;40;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;90;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;57;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;31;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;66;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;39;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;27;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;75;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;26;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;12;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;54;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;31;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;15;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W25.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W25.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;431;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;88;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;42;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;435;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;66;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;31;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;305;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;119;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;250;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;112;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;237;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;194;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;173;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;49;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;18;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;155;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;26;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;9;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;120;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;41;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;18;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;108;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;77;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;22;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;11;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;81;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;18;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;8;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;93;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;59;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;33;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;55;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;32;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;16;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;431;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;88;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;42;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;435;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;66;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;31;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;305;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;119;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;66;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;250;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;112;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;39;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;237;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;37;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;15;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;194;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;33;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;10;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;173;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;49;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;18;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;155;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;26;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;9;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;120;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;41;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;18;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;108;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;36;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;22;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;77;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;22;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;11;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;81;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;18;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;8;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;172;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;35;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;19;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;110;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;65;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;41;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;93;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;59;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;33;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;67;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;40;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;28;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;76;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;27;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;55;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;32;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;16;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W26.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W26.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;458;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;91;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;45;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;462;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;69;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;33;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;325;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;127;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;265;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;119;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;245;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;206;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;182;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;51;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;18;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;163;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;27;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;10;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;125;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;43;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;19;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;113;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;81;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;23;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;12;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;84;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;19;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;8;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;177;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;95;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;61;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;34;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;57;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;33;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;16;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;458;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;91;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;45;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;462;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;69;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;33;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;325;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;127;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;70;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;265;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;119;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;41;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;245;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;38;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;16;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;206;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;35;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;182;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;51;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;18;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;163;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;27;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;10;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;125;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;43;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;19;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;113;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;38;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;23;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;81;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;23;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;12;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;84;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;19;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;8;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;177;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;36;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;112;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;42;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;95;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;61;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;34;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;69;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;41;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;29;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;78;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;28;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;13;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;57;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;33;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;16;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W27.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W27.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;474;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;96;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;47;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;478;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;73;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;34;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;339;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;132;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;277;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;125;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;261;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;217;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;193;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;53;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;19;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;173;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;29;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;10;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;132;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;45;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;20;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;119;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;85;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;24;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;12;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;89;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;20;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;8;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;179;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;98;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;63;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;35;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;58;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;34;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;474;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;96;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;47;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;478;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;73;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;34;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;339;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;132;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;73;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;277;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;125;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;43;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;261;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;40;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;17;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;217;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;36;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;11;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;193;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;53;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;19;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;173;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;29;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;10;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;132;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;45;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;20;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;119;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;40;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;85;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;24;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;12;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;89;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;20;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;8;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;179;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;37;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;20;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;116;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;68;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;43;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;98;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;63;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;35;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;71;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;42;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;81;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;58;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;34;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W28.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W28.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;500;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;100;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;50;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;501;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;77;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;36;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;142;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;292;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;129;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;269;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;225;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;199;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;56;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;20;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;180;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;30;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;11;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;137;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;47;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;21;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;124;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;89;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;25;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;13;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;92;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;21;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;9;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;100;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;64;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;36;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;59;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;35;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;500;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;100;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;50;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;501;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;77;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;36;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;352;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;142;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;77;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;292;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;129;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;46;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;269;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;42;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;18;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;225;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;39;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;199;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;56;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;20;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;180;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;30;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;11;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;137;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;47;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;21;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;124;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;42;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;25;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;89;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;25;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;13;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;92;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;21;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;9;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;185;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;38;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;118;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;71;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;44;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;100;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;64;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;36;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;73;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;44;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;30;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;29;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;59;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;35;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W29.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W29.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;530;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;106;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;51;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;520;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;80;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;38;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;368;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;144;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;308;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;134;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;283;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;235;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;212;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;58;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;21;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;185;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;31;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;11;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;143;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;49;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;21;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;94;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;26;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;13;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;96;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;22;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;9;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;190;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;102;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;65;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;36;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;61;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;35;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;17;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;530;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;106;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;51;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;520;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;80;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;38;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;368;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;144;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;80;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;308;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;134;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;48;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;283;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;43;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;235;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;40;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;12;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;212;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;58;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;21;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;185;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;31;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;11;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;143;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;49;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;21;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;130;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;44;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;27;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;94;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;26;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;13;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;96;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;22;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;9;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;190;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;39;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;123;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;73;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;102;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;65;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;36;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;31;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;84;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;30;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;14;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;61;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;35;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;17;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W30.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W30.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;543;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;109;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;54;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;539;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;83;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;39;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;382;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;83;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;317;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;293;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;243;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;218;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;61;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;21;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;195;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;32;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;12;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;148;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;50;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;23;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;97;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;27;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;14;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;100;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;22;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;9;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;193;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;103;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;66;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;37;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;86;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;63;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;36;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;543;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;109;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;54;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;539;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;83;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;39;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;382;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;151;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;83;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;317;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;139;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;50;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;293;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;45;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;19;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;243;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;42;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;218;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;61;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;21;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;195;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;32;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;12;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;148;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;50;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;23;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;134;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;45;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;28;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;97;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;27;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;14;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;100;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;22;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;9;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;193;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;21;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;124;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;74;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;46;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;103;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;66;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;37;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;75;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;45;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;86;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;63;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;36;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W31.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W31.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;567;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;113;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;55;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;565;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;87;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;40;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;397;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;156;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;332;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;145;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;305;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;253;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;226;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;62;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;22;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;200;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;34;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;12;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;153;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;53;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;23;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;137;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;100;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;28;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;14;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;104;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;24;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;10;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;197;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;126;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;47;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;105;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;67;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;38;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;89;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;63;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;37;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;567;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;113;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;55;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;565;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;87;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;40;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;397;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;156;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;85;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;332;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;145;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;51;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;305;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;47;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;20;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;253;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;43;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;13;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;226;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;62;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;22;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;200;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;34;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;12;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;153;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;53;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;23;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;137;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;47;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;29;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;100;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;28;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;14;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;104;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;24;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;10;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;197;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;40;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;126;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;47;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;105;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;67;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;38;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;46;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;32;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;89;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;63;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;37;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W32.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W32.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;581;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;116;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;57;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;574;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;89;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;41;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;407;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;88;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;342;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;149;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;311;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;257;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;232;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;65;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;23;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;210;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;35;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;12;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;157;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;54;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;24;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;143;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;103;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;29;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;107;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;24;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;10;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;199;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;49;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;109;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;69;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;39;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;90;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;65;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;37;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;581;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;116;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;57;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;574;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;89;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;41;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;407;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;161;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;88;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;342;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;149;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;311;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;48;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;257;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;44;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;232;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;65;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;23;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;210;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;35;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;12;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;157;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;54;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;24;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;143;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;48;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;30;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;103;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;29;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;107;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;24;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;10;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;199;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;22;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;128;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;75;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;49;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;109;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;69;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;39;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;78;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;47;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;90;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;31;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;65;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;37;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W33.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W33.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;600;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;120;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;58;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;589;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;93;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;42;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;420;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;91;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;349;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;152;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;323;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;266;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;242;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;66;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;23;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;213;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;36;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;13;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;161;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;55;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;24;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;146;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;31;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;106;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;30;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;109;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;25;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;10;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;201;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;130;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;49;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;109;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;69;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;40;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;79;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;90;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;65;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;38;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;600;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;120;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;58;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;589;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;93;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;42;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;420;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;169;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;91;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;349;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;152;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;54;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;323;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;49;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;21;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;266;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;46;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;242;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;66;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;23;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;213;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;36;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;13;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;161;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;55;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;24;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;146;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;51;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;31;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;106;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;30;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;109;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;25;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;10;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;201;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;41;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;130;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;76;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;49;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;109;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;69;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;40;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;79;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;90;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;15;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;65;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;38;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;18;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W34.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W34.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;614;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;123;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;60;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;595;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;95;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;43;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;426;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;93;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;359;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;155;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;333;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;22;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;47;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;247;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;68;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;24;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;219;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;37;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;13;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;165;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;57;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;25;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;149;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;31;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;109;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;30;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;112;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;25;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;203;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;42;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;132;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;78;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;50;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;110;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;70;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;40;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;65;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;38;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;614;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;123;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;60;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;595;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;95;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;43;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;426;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;174;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;93;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;359;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;155;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;56;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;333;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;51;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;22;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;273;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;47;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;14;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;247;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;68;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;24;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;219;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;37;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;13;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;165;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;57;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;25;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;149;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;31;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;109;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;30;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;112;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;25;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;203;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;42;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;132;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;78;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;50;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;110;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;70;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;40;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;48;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;32;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;65;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;38;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W35.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W35.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;627;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;124;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;61;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;608;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;98;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;44;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;434;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;176;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;94;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;369;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;159;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;336;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;52;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;22;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;277;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;47;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;252;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;70;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;24;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;224;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;38;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;167;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;57;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;25;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;152;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;32;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;112;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;31;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;113;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;26;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;204;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;42;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;132;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;78;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;50;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;111;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;71;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;40;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;38;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;627;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;124;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;61;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;608;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;98;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;44;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;434;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;176;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;94;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;369;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;159;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;57;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;336;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;52;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;22;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;277;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;47;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;252;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;70;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;24;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;224;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;38;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;167;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;57;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;25;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;152;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;52;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;32;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;112;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;31;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;15;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;113;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;26;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;204;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;42;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;132;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;78;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;50;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;111;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;71;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;40;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;91;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;38;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W36.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W36.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;637;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;126;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;63;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;617;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;99;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;45;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;179;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;97;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;162;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;342;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;53;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;23;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;282;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;48;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;258;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;71;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;25;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;225;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;39;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;170;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;58;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;26;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;155;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;54;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;114;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;31;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;16;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;114;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;27;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;205;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;42;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;134;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;50;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;111;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;71;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;41;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;93;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;39;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;637;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;126;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;63;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;617;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;99;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;45;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;179;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;97;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;376;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;162;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;58;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;342;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;53;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;23;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;282;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;48;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;258;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;71;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;25;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;225;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;39;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;170;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;58;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;26;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;155;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;54;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;114;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;31;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;16;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;114;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;27;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;205;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;42;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;134;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;50;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;111;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;71;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;41;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;49;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;93;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;39;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W37.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W37.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;650;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;129;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;63;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;617;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;100;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;45;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;180;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;97;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;384;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;163;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;345;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;53;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;23;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;283;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;49;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;259;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;73;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;25;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;229;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;39;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;172;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;59;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;26;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;156;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;54;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;115;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;32;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;16;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;116;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;27;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;206;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;43;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;134;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;51;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;112;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;71;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;41;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;39;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;650;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;129;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;63;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;617;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;100;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;45;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;443;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;180;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;97;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;384;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;163;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;345;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;53;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;23;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;283;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;49;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;259;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;73;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;25;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;229;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;39;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;172;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;59;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;26;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;156;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;54;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;115;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;32;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;16;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;116;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;27;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;206;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;43;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;134;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;79;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;51;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;112;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;71;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;41;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;80;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;39;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W38.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W38.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;651;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;129;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;63;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;623;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;102;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;45;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;451;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;184;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;98;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;389;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;163;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;347;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;53;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;23;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;287;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;49;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;261;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;73;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;25;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;230;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;40;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;172;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;59;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;26;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;156;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;55;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;116;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;32;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;16;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;116;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;27;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;206;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;43;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;134;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;51;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;112;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;72;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;41;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;81;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;39;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;651;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;129;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;63;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;623;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;102;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;45;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;451;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;184;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;98;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;389;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;163;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;59;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;347;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;53;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;23;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;287;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;49;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;15;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;261;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;73;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;25;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;230;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;40;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;14;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;172;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;59;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;26;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;156;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;55;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;33;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;116;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;32;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;16;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;116;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;27;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;11;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;206;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;43;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;23;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;134;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;80;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;51;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;112;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;72;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;41;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;81;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;50;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;34;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;94;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;33;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;16;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;66;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;39;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;19;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W39.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W39.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W40.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W40.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W41.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W41.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;5;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;5;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W42.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W42.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;5;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;5;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;5;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;0;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;0;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W43.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W43.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;5;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;7;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;5;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;7;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;2;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;0;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W44.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W44.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;6;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;7;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;3;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;3;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;6;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;7;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;3;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;3;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;2;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;3;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;3;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;3;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;0;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;2;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;0;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W45.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W45.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;10;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;10;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;5;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;3;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;3;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;10;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;10;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;1;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;5;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;3;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;3;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;3;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;3;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;0;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W46.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W46.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;10;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;12;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;4;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;4;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;3;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;10;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;12;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;6;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;4;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;2;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;8;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;1;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;5;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;4;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;4;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;3;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;4;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;1;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;3;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;1;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W47.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W47.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;10;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;12;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;3;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;4;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;4;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;2;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;4;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;10;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;12;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;0;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;8;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;3;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;3;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;2;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;1;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;6;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;5;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;2;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;4;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;4;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;2;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;5;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;2;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;5;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;4;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W48.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W48.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;15;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;20;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;13;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;3;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;6;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;5;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;2;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;5;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;15;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;20;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;1;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;13;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;4;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;0;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;3;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;0;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;13;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;8;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;3;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;6;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;5;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;2;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;7;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;2;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;7;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;2;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;5;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W49.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W49.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;15;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;20;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;13;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;5;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;5;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;9;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;6;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;3;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;6;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;3;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;15;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;20;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;13;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;3;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;5;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;6;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;8;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;5;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;5;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;4;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;17;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;3;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;2;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;10;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;7;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;4;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;9;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;6;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;3;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;8;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;3;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;8;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;6;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;3;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;1;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W50.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W50.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;22;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;4;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;23;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;2;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;15;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;9;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;7;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;7;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;3;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;22;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;11;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;7;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;3;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;8;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;4;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;2;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;22;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;4;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;23;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;2;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;15;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;7;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;5;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;0;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;7;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;9;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;7;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;0;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;7;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;6;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;3;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;0;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;3;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;0;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;22;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;4;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;13;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;8;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;11;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;7;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;3;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;9;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;4;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;3;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;9;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;3;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;1;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;8;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;4;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;2;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W51.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W51.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;25;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;5;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;3;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;33;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;3;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;20;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;8;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;9;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;10;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;8;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;4;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;5;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;12;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;9;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;4;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;9;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;4;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;2;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;25;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;5;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;3;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;33;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;3;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;1;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;20;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;6;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;4;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;8;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;8;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;8;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;0;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;9;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;2;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;10;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;8;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;4;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;5;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;25;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;3;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;15;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;10;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;5;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;12;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;9;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;4;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;11;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;10;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;4;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;9;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;4;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;2;1.11;V

--- a/data/input_raw/telbestanden/telbestandY2024W52.csv
+++ b/data/input_raw/telbestanden/telbestandY2024W52.csv
@@ -1,55 +1,55 @@
-Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V
-21PB;2024;B;56604;B Psychologie;SOW;N;N;N;28;1.34
-21PB;2024;B;56604;B Psychologie;SOW;E;N;N;6;1.34
-21PB;2024;B;56604;B Psychologie;SOW;R;N;N;3;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;36;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;3;1.34
-21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;2;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.34
-21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.34
-21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34
-21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;13;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.34
-21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34
-21PB;2024;B;56981;B Politicologie;MAN;N;N;N;11;1.34
-21PB;2024;B;56981;B Politicologie;MAN;E;N;N;4;1.34
-21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;11;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;2;1.34
-21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;11;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;3;1.34
-21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.34
-21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;4;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34
-21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;N;N;N;6;1.34
-21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34
-21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;30;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.11
-21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;17;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.11
-21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.11
-21PB;2024;M;60300;M Informatica;SOW;N;N;N;14;1.11
-21PB;2024;M;60300;M Informatica;SOW;E;N;N;10;1.11
-21PB;2024;M;60300;M Informatica;SOW;R;N;N;4;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;12;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.11
-21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11
-21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;10;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;5;1.11
-21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;3;1.11
+Brincode;Studiejaar;Type_HO;Isatcode;Groepeernaam;Faculteit;Herkomst;Hogerejaars;Herinschrijving;Aantal;meercode_V;Status
+21PB;2024;B;56604;B Psychologie;SOW;N;N;N;28;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;E;N;N;6;1.34;V
+21PB;2024;B;56604;B Psychologie;SOW;R;N;N;3;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;N;N;N;36;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;E;N;N;3;1.34;V
+21PB;2024;B;56551;B Geneeskunde;MED;R;N;N;2;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;N;N;N;23;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;E;N;N;9;1.34;V
+21PB;2024;B;50300;B Kunstmatige Intelligentie;SOW;R;N;N;5;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;N;N;N;11;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;E;N;N;9;1.34;V
+21PB;2024;B;50645;B Bedrijfskunde;MAN;R;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;N;N;N;11;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;E;N;N;2;1.34;V
+21PB;2024;B;56990;B Biomedische Wetenschappen;MED;R;N;N;1;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;N;N;N;13;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;E;N;N;2;1.34;V
+21PB;2024;B;56615;B Communicatiewetenschap;SOW;R;N;N;1;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;N;N;N;11;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;E;N;N;4;1.34;V
+21PB;2024;B;56981;B Politicologie;MAN;R;N;N;1;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;N;N;N;11;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;E;N;N;2;1.34;V
+21PB;2024;B;56034;B Geschiedenis;FdL;R;N;N;1;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;N;N;N;11;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;E;N;N;3;1.34;V
+21PB;2024;B;56980;B Wiskunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;N;N;N;8;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;E;N;N;2;1.34;V
+21PB;2024;B;56984;B Natuurkunde;FNWI;R;N;N;2;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;N;N;N;4;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;E;N;N;1;1.34;V
+21PB;2024;B;56857;B Scheikunde;FNWI;R;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;N;N;N;6;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;E;N;N;1;1.34;V
+21PB;2024;B;56081;B Filosofie;FdL;R;N;N;1;1.34;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;N;N;N;30;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;E;N;N;5;1.11;V
+21PB;2024;M;60139;M Rechtsgeleerdheid;JUR;R;N;N;4;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;N;N;N;17;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;E;N;N;12;1.11;V
+21PB;2024;M;60720;M Cognitive Neuroscience;SOW;R;N;N;7;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;N;N;N;14;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;E;N;N;10;1.11;V
+21PB;2024;M;60300;M Informatica;SOW;R;N;N;4;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;N;N;N;12;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;E;N;N;5;1.11;V
+21PB;2024;M;60710;M Molecular Mechanisms of Disease;FNWI;R;N;N;4;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;N;N;N;13;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;E;N;N;5;1.11;V
+21PB;2024;M;60450;M Bestuurskunde;MAN;R;N;N;2;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;N;N;N;10;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;E;N;N;5;1.11;V
+21PB;2024;M;60815;M Linguistiek;FdL;R;N;N;3;1.11;V

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -27,7 +27,8 @@ Scheidingsteken: `;`
 | `Isatcode` | str | CROHO-code |
 | `Groepeernaam` | str | Naam van de opleiding |
 | `Aantal` | int | Aantal vooraanmelders |
-| `meercode_V` | int | Weegfactor; mag niet 0 zijn (leidt tot deling door nul in ETL) |
+| `meercode_V` | int | Aantal inschrijfverzoeken/inschrijvingen per student (status V/U/I). Wordt gebruikt als weegfactor in `Gewogen vooraanmelders = Aantal / meercode_V`. Voor status A-rijen is deze waarde 0 — die rijen worden door de ETL uitgefilterd. |
+| `Status` | str | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
 | `Herinschrijving` | str | `J` of `N` |
 | `Herkomst` | str | `N` (Nederland), `E` (EER), `R` (rest) |
 

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -43,12 +43,11 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 |----------|------|-------------------|
 | Map bestaat | Hard error | `data/input_raw/telbestanden/` moet bestaan |
 | Bestanden aanwezig | Hard error | Minimaal één bestand met patroon `telbestandY{jaar}W{week}.csv` |
-| Verplichte kolommen | Hard error | `Studiejaar`, `Isatcode`, `Groepeernaam`, `Aantal`, `meercode_V`, `Herinschrijving`, `Herkomst` |
+| Verplichte kolommen | Hard error | `Studiejaar`, `Isatcode`, `Groepeernaam`, `Aantal`, `meercode_V`, `Status`, `Herinschrijving`, `Herkomst` |
 | Weeknummer in bestandsnaam | Hard error | Weeknummer moet tussen 1 en 53 liggen |
 | Collegejaar bereik | Soft error | `Studiejaar` buiten `[huidig jaar − 15, huidig jaar + 2]` |
 | Herkomst geldige waarden | Soft error | Elke waarde in `Herkomst` moet `N`, `E` of `R` zijn |
 | Herinschrijving geldige waarden | Soft error | Elke waarde moet `J` of `N` zijn |
-| meercode_V = 0 | Soft error | Leidt tot deling door nul in ETL |
 | Aantal < 0 | Soft error | Negatieve aantallen zijn inhoudelijk onjuist |
 | Ontbrekende waarden `Aantal` | Waarschuwing / Soft error | > 5% ontbrekend → waarschuwing; > 30% → soft error |
 | Gaten tussen weken | Waarschuwing | Gat van > 2 weken binnen een jaar |

--- a/src/studentprognose/data/etl.py
+++ b/src/studentprognose/data/etl.py
@@ -76,6 +76,10 @@ def _rowbind_and_reformat(telbestanden_dir, output_path, configuration):
 
     data = pd.concat(dataframes, ignore_index=True)
 
+    # Status A = annulering (Studielink PvL §5.12). Voor die rijen is meercode_V
+    # per definitie 0 en horen aantallen semantisch niet bij vooraanmelders.
+    data = data[data["Status"] != "A"].copy()
+
     data["Gewogen vooraanmelders"] = data["Aantal"] / data["meercode_V"]
 
     data.rename(

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -117,7 +117,7 @@ _DEFAULT_VALIDATION_CFG = {
     "telbestand": {
         "required_columns": [
             "Studiejaar", "Isatcode", "Groepeernaam", "Aantal", "meercode_V",
-            "Herinschrijving", "Hogerejaars", "Herkomst",
+            "Status", "Herinschrijving", "Hogerejaars", "Herkomst",
         ],
         "herkomst_allowed": ["N", "E", "R"],
         "herinschrijving_allowed": ["J", "N"],
@@ -371,16 +371,6 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result, required=True):
             _check_categoricals_per_programme(
                 df.assign(**{col: normalized}),
                 col, allowed, "Groepeernaam", filename, result,
-            )
-
-        meercode_v, _ = _coerce_to_numeric(df["meercode_V"])
-        zero_meercode = df[meercode_v == 0]
-        if not zero_meercode.empty:
-            programmes = zero_meercode["Groepeernaam"].dropna().unique()
-            result.soft_errors.append(
-                f"{filename}: meercode_V = 0 (deling door nul in ETL) voor "
-                f"{len(programmes)} opleiding(en): "
-                + _format_programmes(programmes)
             )
 
         neg_aantal = df[df["Aantal"] < 0]

--- a/tests/studentprognose/test_validation.py
+++ b/tests/studentprognose/test_validation.py
@@ -335,6 +335,7 @@ def _make_valid_telbestand(path, year=2024, week=1):
         "Groepeernaam": ["B Opleiding"],
         "Aantal": [10],
         "meercode_V": [2],
+        "Status": ["V"],
         "Herinschrijving": ["N"],
         "Hogerejaars": ["N"],
         "Herkomst": ["N"],
@@ -405,24 +406,6 @@ class TestValidateRawDataIntegration:
         with pytest.raises(SystemExit):
             validate_raw_data(cfg, yes=True)
 
-    def test_zero_meercode_triggers_soft_error_yes_passes(self, tmp_path, monkeypatch):
-        telbestanden_dir = tmp_path / "telbestanden"
-        telbestanden_dir.mkdir()
-        df = pd.DataFrame({
-            "Studiejaar": [2024],
-            "Isatcode": ["12345"],
-            "Groepeernaam": ["B Opleiding"],
-            "Aantal": [10],
-            "meercode_V": [0],
-            "Herinschrijving": ["N"],
-            "Hogerejaars": ["N"],
-            "Herkomst": ["N"],
-        })
-        df.to_csv(telbestanden_dir / "telbestandY2024W01.csv", sep=";", index=False)
-        cfg = _make_configuration(tmp_path, telbestanden_dir)
-        monkeypatch.chdir(tmp_path)
-        validate_raw_data(cfg, yes=True, data_option=DataOption.CUMULATIVE)
-
     def test_invalid_herkomst_prompts_and_n_exits(self, tmp_path, monkeypatch):
         telbestanden_dir = tmp_path / "telbestanden"
         telbestanden_dir.mkdir()
@@ -432,6 +415,7 @@ class TestValidateRawDataIntegration:
             "Groepeernaam": ["B Opleiding"],
             "Aantal": [10],
             "meercode_V": [2],
+            "Status": ["V"],
             "Herinschrijving": ["N"],
             "Hogerejaars": ["N"],
             "Herkomst": ["ONBEKEND"],
@@ -452,6 +436,7 @@ class TestValidateRawDataIntegration:
             "Groepeernaam": ["B Opleiding"],
             "Aantal": [10],
             "meercode_V": [2],
+            "Status": ["V"],
             "Herinschrijving": ["N"],
             "Hogerejaars": ["N"],
             "Herkomst": ["ONBEKEND"],
@@ -470,6 +455,7 @@ class TestValidateRawDataIntegration:
             "Groepeernaam": ["B Opleiding"],
             "Aantal": [10],
             "meercode_V": [2],
+            "Status": ["V"],
             "Herinschrijving": ["N"],
             "Hogerejaars": ["N"],
             "Herkomst": ["N "],  # trailing whitespace
@@ -488,6 +474,7 @@ class TestValidateRawDataIntegration:
             "Groepeernaam": ["B Opleiding"],
             "Aantal": [10],
             "meercode_V": [2],
+            "Status": ["V"],
             "Herinschrijving": ["N"],
             "Hogerejaars": ["N"],
             "Herkomst": ["N"],


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description of Changes

`src/studentprognose/data/etl.py:79` deelde alle rijen van het telbestand door `meercode_V`, ook rijen met `Status = A` (annuleringen). Voor die rijen is `meercode_V` per definitie `0` (zie Studielink PvL §5.12), wat `inf`/`NaN` produceerde in `Gewogen vooraanmelders` en stil doorpropageerde naar interpolatie, cumulatieve sommen en modelinput.

De eerdere aanpak (PR #184) promoveerde de validatie tot hard error op `meercode_V = 0`. Dat was verkeerd: volgens Studielink is `0` een geldige waarde (voor annuleringen), dus die check zou de pipeline laten crashen op praktisch elk normaal telbestand.

### Wijzigingen

- **`src/studentprognose/data/etl.py`**: filter `Status == "A"` rijen vóór de deling op `meercode_V`. Annuleringen horen semantisch niet in `Gewogen/Ongewogen vooraanmelders`.
- **`src/studentprognose/data/validation.py`**: verwijder misleidende soft-error op `meercode_V = 0`. Voeg `Status` toe aan `required_columns` (de ETL heeft die kolom nu nodig).
- **`docs/validatie.md`**: tabelregel voor `meercode_V = 0` verwijderd; `Status` toegevoegd aan verplichte kolommen.
- **`docs/je-data-voorbereiden.md`**: omschrijving van `meercode_V` gecorrigeerd; `Status`-kolom gedocumenteerd.
- **`tests/studentprognose/test_validation.py`**: obsolete validatie-test verwijderd; `Status: ["V"]` toegevoegd aan fixture-DataFrames.

### Bron

Studielink — *Programma van Levering Telbestand Studielink* (versie 2.8, 03-11-2022), §5.12 *De velden "Meercode"*:

> `Meercode_V` geeft het aantal inschrijfverzoeken/inschrijvingen per student aan; hieronder valt elke status behalve de status A.

Voorbeeld op pagina 9, regel 3: `Aantal=8, Meercode_V=0, Meercode_A=1, Status=A` — 8 studenten met enkel een annulering, geen actief verzoek. Toegestane waarden voor `Meercode_V`: `0 t/m 9` (expliciet gecorrigeerd in v2.6 van "1-9" naar "0-9").

## Related Issues

Fixes #203

## Before / After

### Before
- Telbestand met status A-rijen → `Aantal / 0` → `inf`/`NaN` in `Gewogen vooraanmelders` → silent failures downstream.
- Validatie meldde `meercode_V = 0` als soft error (omzeilbaar met `--yes`), maar dat was geen echte datafout.

### After
- Status A-rijen worden vóór de deling uitgefilterd → geen `inf`/`NaN` meer.
- `Aantal` (`Ongewogen vooraanmelders`) telt geen annuleringen meer mee.
- Validatie geeft geen vals alarm meer op `meercode_V = 0`.

## Checklist
- [x] I have tested these changes locally (`uv run pytest` — 273/273 groen)
- [x] My code follows the project's coding standards
- [x] Documentatie (`docs/validatie.md`, `docs/je-data-voorbereiden.md`) bijgewerkt conform de docs-regel in CLAUDE.md