### PR TITLE
feat: configureerbare bestandsnaampatronen voor telbestanden (#199)

### DIFF
--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -35,6 +35,33 @@ Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
 | `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (afgeleid uit telbestand studenten) |
 | `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
 
+## `telbestand_filename_patterns` — bestandsnaampatronen voor telbestanden
+
+Standaard: `["telbestandY{year}W{week}"]`
+
+De pipeline herkent telbestanden in `path_raw_telbestanden` aan hun bestandsnaam. Instellingen met afwijkende naamconventies kunnen hier hun eigen patroon opgeven. De ETL en de validatie gebruiken hetzelfde patroon om jaar en weeknummer uit de bestandsnaam te halen.
+
+**Placeholder-syntax:**
+
+- `{year}` — vierdigit collegejaar (bijv. `2024`)
+- `{week}` — weeknummer (1–2 cijfers, gevalideerd op bereik 1–53)
+- Alle andere karakters worden letterlijk gematcht. Punten, streepjes en underscores zijn veilig (`re.escape` op de achtergrond).
+
+**Voorbeelden:**
+
+```json
+{
+    "telbestand_filename_patterns": [
+        "telbestandY{year}W{week}",
+        "VU_telbestand_{year}_W{week}"
+    ]
+}
+```
+
+Met meerdere patronen kan de pipeline bestanden van verschillende leveranciers naast elkaar verwerken — handig tijdens een migratie van oude naar nieuwe naamgeving.
+
+**Foutgedrag:** Een patroon zonder `{year}` of `{week}` leidt tot een configuratiefout en stopt de pipeline direct, met een melding die het probleempatroon noemt.
+
 ## `runtime` — uitvoerparameters
 
 Instellingen die bepalen hoe de pipeline zich gedraagt tijdens uitvoer (los van de modelkeuze).

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -18,7 +18,7 @@ Zie de [volledige dataflow](https://github.com/cedanl/studentprognose/blob/main/
 ### Studielink telbestanden
 
 Map: `data/input_raw/telbestanden/`
-Bestandsnaampatroon: `telbestandY{jaar}W{week}.csv` (bijv. `telbestandY2024W10.csv`)
+Bestandsnaampatroon: `telbestandY{jaar}W{week}.csv` (bijv. `telbestandY2024W10.csv`) — configureerbaar, zie [Afwijkende bestandsnamen](#afwijkende-bestandsnamen) hieronder.
 Scheidingsteken: `;`
 
 | Kolom | Type | Omschrijving |
@@ -31,6 +31,21 @@ Scheidingsteken: `;`
 | `Status` | str | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
 | `Herinschrijving` | str | `J` of `N` |
 | `Herkomst` | str | `N` (Nederland), `E` (EER), `R` (rest) |
+
+#### Afwijkende bestandsnamen
+
+Gebruikt jouw instelling een andere conventie dan `telbestandY{jaar}W{week}.csv`? Geef in `configuration.json` één of meer eigen patronen op:
+
+```json
+{
+    "telbestand_filename_patterns": [
+        "telbestandY{year}W{week}",
+        "VU_telbestand_{year}_W{week}"
+    ]
+}
+```
+
+Placeholders zijn `{year}` (vier cijfers) en `{week}` (één of twee cijfers). Andere karakters worden letterlijk gematcht — punten en streepjes zijn veilig. Meerdere patronen tegelijk zijn handig tijdens een migratie van oude naar nieuwe naamgeving. Zie [`telbestand_filename_patterns`](configuratie.md#telbestand_filename_patterns-bestandsnaampatronen-voor-telbestanden) voor de volledige uitleg.
 
 ### Individuele aanmelddata
 

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -42,7 +42,7 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 | Controle | Type | Wat wordt gecheckt |
 |----------|------|-------------------|
 | Map bestaat | Hard error | `data/input_raw/telbestanden/` moet bestaan |
-| Bestanden aanwezig | Hard error | Minimaal één bestand met patroon `telbestandY{jaar}W{week}.csv` |
+| Bestanden aanwezig | Hard error | Minimaal één bestand dat matcht met `telbestand_filename_patterns` (default: `telbestandY{jaar}W{week}.csv`) |
 | Verplichte kolommen | Hard error | `Studiejaar`, `Isatcode`, `Groepeernaam`, `Aantal`, `meercode_V`, `Status`, `Herinschrijving`, `Herkomst` |
 | Weeknummer in bestandsnaam | Hard error | Weeknummer moet tussen 1 en 53 liggen |
 | Collegejaar bereik | Soft error | `Studiejaar` buiten `[huidig jaar − 15, huidig jaar + 2]` |

--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -4,6 +4,8 @@ import sys
 from importlib.resources import files
 from types import SimpleNamespace
 
+from studentprognose.utils.telbestand_filenames import _placeholder_to_regex
+
 _VALID_RULE_KEYS = {"year", "year_before", "year_after", "herkomst", "examentype", "opleiding"}
 
 _VALID_TIMESERIES_MODELS = {"sarima", "ets", "theta", "auto_arima"}
@@ -63,6 +65,7 @@ def load_configuration(file_path: str) -> dict:
         _validate_excluded_data_points(cfg["excluded_data_points"], file_path)
     _validate_model_config(cfg, file_path)
     _validate_runtime(cfg, file_path)
+    _validate_telbestand_filename_patterns(cfg, file_path)
     return cfg
 
 
@@ -180,6 +183,48 @@ def _validate_model_config(cfg, file_path):
             f"Geldige opties: {sorted(_VALID_CLASSIFIER_MODELS)}."
         )
         sys.exit(1)
+
+
+def _validate_telbestand_filename_patterns(cfg, file_path):
+    """Fail fast op ongeldige telbestand-bestandsnaampatronen.
+
+    Een patroon moet zowel ``{year}`` als ``{week}`` bevatten — anders kan de
+    pipeline geen jaar/week uit de bestandsnaam destilleren. Ontbrekende
+    sleutel, lege lijst, lege string of lijst van geldige strings worden alle
+    geaccepteerd; ``compile_patterns`` valt terug op de default waar nodig.
+    """
+    raw = cfg.get("telbestand_filename_patterns")
+    if raw is None or raw == [] or raw == "":
+        return
+
+    if isinstance(raw, str):
+        candidates = [raw]
+    elif isinstance(raw, list):
+        candidates = raw
+    else:
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'telbestand_filename_patterns' moet een string of lijst van strings zijn, "
+            f"niet {type(raw).__name__}."
+        )
+        sys.exit(1)
+
+    for i, pattern in enumerate(candidates):
+        if not isinstance(pattern, str):
+            print(
+                f"Configuratiefout in {file_path}: "
+                f"'telbestand_filename_patterns[{i}]' moet een string zijn, "
+                f"niet {type(pattern).__name__}."
+            )
+            sys.exit(1)
+        try:
+            _placeholder_to_regex(pattern)
+        except ValueError as exc:
+            print(
+                f"Configuratiefout in {file_path}: {exc} "
+                f"Voorbeeld: \"telbestandY{{year}}W{{week}}\"."
+            )
+            sys.exit(1)
 
 
 def _validate_runtime(cfg, file_path):

--- a/src/studentprognose/configuration/configuration.json
+++ b/src/studentprognose/configuration/configuration.json
@@ -14,6 +14,7 @@
         "path_raw_telbestanden": "data/input_raw/telbestanden",
         "path_raw_individueel": "data/input_raw/individuele_aanmelddata.csv"
     },
+    "telbestand_filename_patterns": ["telbestandY{year}W{week}"],
     "runtime": {
         "cpu_count": null
     },

--- a/src/studentprognose/data/etl.py
+++ b/src/studentprognose/data/etl.py
@@ -1,10 +1,15 @@
 import os
-import re
 import shutil
 
 import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
+
+from studentprognose.utils.telbestand_filenames import (
+    compile_patterns,
+    match_telbestand,
+)
+
 
 def run_etl(configuration):
     """Run the full ETL pipeline: raw external data → data/input/ files."""
@@ -59,15 +64,16 @@ def run_etl(configuration):
 def _rowbind_and_reformat(telbestanden_dir, output_path, configuration):
     """Merge weekly Studielink CSVs into one cumulative file."""
     dataframes = []
+    patterns = compile_patterns(configuration)
 
     for filename in sorted(os.listdir(telbestanden_dir)):
-        match = re.search(r"telbestandY(\d{4})W(\d+)", filename)
+        match = match_telbestand(filename, patterns)
         if not match:
             continue
 
         filepath = os.path.join(telbestanden_dir, filename)
         data = pd.read_csv(filepath, sep=";", low_memory=False)
-        data["Weeknummer"] = int(match.group(2))
+        data["Weeknummer"] = int(match.group("week"))
         dataframes.append(data)
 
     if not dataframes:

--- a/src/studentprognose/data/validation.py
+++ b/src/studentprognose/data/validation.py
@@ -65,11 +65,15 @@ Een nieuw validatiecheck toevoegen
 
 import datetime
 import os
-import re
 import sys
 from dataclasses import dataclass, field
 
 import pandas as pd
+
+from studentprognose.utils.telbestand_filenames import (
+    compile_patterns,
+    match_telbestand,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -159,8 +163,9 @@ def validate_raw_data(configuration, yes=False, data_option=None):
 
     paths = configuration["paths"]
     cwd = os.getcwd()
+    telbestand_patterns = compile_patterns(configuration)
 
-    _print_file_overview(cwd, paths)
+    _print_file_overview(cwd, paths, telbestand_patterns)
 
     # Top-level merge: voegt flat overrides toe (bijv. nan_error_threshold).
     # Nested sub-dicts (telbestand, individueel, oktober) worden hier shallow
@@ -174,8 +179,14 @@ def validate_raw_data(configuration, yes=False, data_option=None):
 
     needs_telbestanden, needs_individueel = _required_files_for(data_option)
 
-    _validate_telbestanden(cwd, paths, validation_cfg, result, required=needs_telbestanden)
-    _validate_individueel(cwd, paths, validation_cfg, columns_cfg, result, required=needs_individueel)
+    _validate_telbestanden(
+        cwd, paths, validation_cfg, telbestand_patterns, result,
+        required=needs_telbestanden,
+    )
+    _validate_individueel(
+        cwd, paths, validation_cfg, columns_cfg, telbestand_patterns, result,
+        required=needs_individueel,
+    )
     _validate_oktober(cwd, paths, validation_cfg, columns_cfg, result)
 
     _handle_result(result, yes)
@@ -201,13 +212,18 @@ def _required_files_for(data_option):
 # File overview table
 # ---------------------------------------------------------------------------
 
-def _check_file_presence(cwd, paths):
+def _check_file_presence(cwd, paths, telbestand_patterns=None):
     """Check which input files exist and return a list of (label, relative_path, found, required_for)."""
+    if telbestand_patterns is None:
+        telbestand_patterns = compile_patterns(None)
+
     telbestanden_rel = paths.get("path_raw_telbestanden", "data/input_raw/telbestanden")
     telbestanden_dir = os.path.join(cwd, telbestanden_rel)
     telbestanden_ok = (
         os.path.isdir(telbestanden_dir)
-        and any(re.search(r"telbestandY\d{4}W\d+", f) for f in os.listdir(telbestanden_dir))
+        and any(
+            match_telbestand(f, telbestand_patterns) for f in os.listdir(telbestanden_dir)
+        )
     )
 
     individueel_rel = paths.get("path_raw_individueel", "data/input_raw/individuele_aanmelddata.csv")
@@ -223,9 +239,9 @@ def _check_file_presence(cwd, paths):
     ]
 
 
-def _print_file_overview(cwd, paths):
+def _print_file_overview(cwd, paths, telbestand_patterns=None):
     """Print a table showing which input files are present and which run modes are available."""
-    files = _check_file_presence(cwd, paths)
+    files = _check_file_presence(cwd, paths, telbestand_patterns)
 
     col_file = max(len(f[0]) for f in files)
     col_status = 8
@@ -272,7 +288,9 @@ def _print_file_overview(cwd, paths):
 # Per-file validators
 # ---------------------------------------------------------------------------
 
-def _validate_telbestanden(cwd, paths, validation_cfg, result, required=True):
+def _validate_telbestanden(
+    cwd, paths, validation_cfg, telbestand_patterns, result, required=True,
+):
     telbestanden_dir = os.path.join(
         cwd, paths.get("path_raw_telbestanden", "data/input_raw/telbestanden")
     )
@@ -293,18 +311,19 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result, required=True):
 
     files = sorted([
         f for f in os.listdir(telbestanden_dir)
-        if re.search(r"telbestandY\d{4}W\d+", f)
+        if match_telbestand(f, telbestand_patterns)
     ])
 
     if not files:
         if required:
+            pattern_examples = ", ".join(f"{p.raw}.csv" for p in telbestand_patterns)
             result.hard_errors.append(
                 f"Geen telbestanden gevonden in {telbestanden_dir} "
-                f"(verwacht patroon: telbestandY{{jaar}}W{{week}}.csv){hint}"
+                f"(verwachte patronen: {pattern_examples}){hint}"
             )
         return
 
-    _check_telbestand_completeness(files, validation_cfg, result)
+    _check_telbestand_completeness(files, validation_cfg, telbestand_patterns, result)
 
     current_year = datetime.date.today().year
     year_min = current_year - validation_cfg["collegejaar_min_offset"]
@@ -335,9 +354,9 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result, required=True):
             )
             continue
 
-        match = re.search(r"telbestandY(\d{4})W(\d+)", filename)
+        match = match_telbestand(filename, telbestand_patterns)
         if match:
-            week_nr = int(match.group(2))
+            week_nr = int(match.group("week"))
             if not (weeknummer_min <= week_nr <= weeknummer_max):
                 result.hard_errors.append(
                     f"{filename}: weeknummer {week_nr} valt buiten verwacht bereik "
@@ -386,7 +405,9 @@ def _validate_telbestanden(cwd, paths, validation_cfg, result, required=True):
             _check_nan_rate(df, col, filename, nan_warn, nan_error, result)
 
 
-def _validate_individueel(cwd, paths, validation_cfg, columns_cfg, result, required=True):
+def _validate_individueel(
+    cwd, paths, validation_cfg, columns_cfg, telbestand_patterns, result, required=True,
+):
     path = os.path.join(
         cwd, paths.get("path_raw_individueel", "data/input_raw/individuele_aanmelddata.csv")
     )
@@ -398,7 +419,10 @@ def _validate_individueel(cwd, paths, validation_cfg, columns_cfg, result, requi
             )
             has_telbestanden = (
                 os.path.isdir(telbestanden_dir)
-                and any(re.search(r"telbestandY\d{4}W\d+", f) for f in os.listdir(telbestanden_dir))
+                and any(
+                    match_telbestand(f, telbestand_patterns)
+                    for f in os.listdir(telbestanden_dir)
+                )
             )
             hint = (
                 " — Tip: draai met `-d cumulative` om alleen de telbestanden te gebruiken."
@@ -530,13 +554,13 @@ def _coerce_to_numeric(series):
     return coerced, True
 
 
-def _check_telbestand_completeness(files, validation_cfg, result):
+def _check_telbestand_completeness(files, validation_cfg, telbestand_patterns, result):
     """Warn when there are unexpected gaps (> 2 weeks) between telbestanden within a year."""
     weeks_per_year = {}
     for filename in files:
-        match = re.search(r"telbestandY(\d{4})W(\d+)", filename)
+        match = match_telbestand(filename, telbestand_patterns)
         if match:
-            year, week = int(match.group(1)), int(match.group(2))
+            year, week = int(match.group("year")), int(match.group("week"))
             weeks_per_year.setdefault(year, []).append(week)
 
     for year, weeks in sorted(weeks_per_year.items()):

--- a/src/studentprognose/init.py
+++ b/src/studentprognose/init.py
@@ -11,7 +11,7 @@ Plaats hier je ruwe Studielink-exportbestanden:
 
 | Bestand/map | Beschrijving |
 |---|---|
-| `telbestanden/` | Wekelijkse Studielink-telbestanden (`telbestandY<jaar>W<week>.csv`) |
+| `telbestanden/` | Wekelijkse Studielink-telbestanden (default: `telbestandY<jaar>W<week>.csv`, instelbaar via `telbestand_filename_patterns`) |
 | `individuele_aanmelddata.csv` | Individuele vooraanmeldingen per student |
 | `oktober_bestand.xlsx` | Telbestand studenten (eigen levering instelling — voor studentaantallen) |
 
@@ -58,7 +58,9 @@ def run_init():
 Volgende stappen:
 
   1. Plaats je telbestanden in:     data/input_raw/telbestanden/
-                                    (bestandsnamen: telbestandY<jaar>W<week>.csv)
+                                    (default-naam: telbestandY<jaar>W<week>.csv;
+                                     overschrijf via telbestand_filename_patterns
+                                     als je instelling een andere conventie gebruikt)
   2. Plaats je individuele data in: data/input_raw/individuele_aanmelddata.csv
   3. Optioneel — telbestand studenten:
                                     data/input_raw/oktober_bestand.xlsx

--- a/src/studentprognose/utils/telbestand_filenames.py
+++ b/src/studentprognose/utils/telbestand_filenames.py
@@ -1,0 +1,116 @@
+"""Configureerbaar matchen van telbestand-bestandsnamen.
+
+Instellingen leveren telbestanden aan met afwijkende naamconventies (Studielink
+gebruikt ``telbestandY2024W10.csv``, andere instellingen mogelijk
+``VU_telbestand_2024_W10.csv``). Deze module vertaalt simpele
+placeholder-patronen uit ``configuration.json`` naar regex-objecten zonder dat
+de gebruiker regex-syntax hoeft te kennen.
+
+Gebruik
+-------
+.. code-block:: python
+
+    patterns = compile_patterns(configuration)
+    match = match_telbestand("telbestandY2024W10.csv", patterns)
+    if match:
+        year = int(match.group("year"))
+        week = int(match.group("week"))
+
+Placeholder-syntax
+------------------
+``{year}`` en ``{week}`` zijn de enige placeholders. Alle andere karakters in
+het patroon worden letterlijk gematcht (punten, streepjes, underscores zijn
+veilig). Voorbeelden:
+
+- ``telbestandY{year}W{week}`` (default, Studielink)
+- ``VU_telbestand_{year}_W{week}``
+- ``tel.{year}.{week}``
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+DEFAULT_TELBESTAND_PATTERN = "telbestandY{year}W{week}"
+
+_YEAR_REGEX = r"(?P<year>\d{4})"
+_WEEK_REGEX = r"(?P<week>\d+)"
+_PLACEHOLDER_TOKEN = re.compile(r"\{(year|week)\}")
+
+
+class TelbestandPattern(NamedTuple):
+    """Een gecompileerd telbestand-patroon, met behoud van de leesbare bron.
+
+    ``raw`` is wat de gebruiker in ``configuration.json`` heeft geschreven
+    (bijv. ``"telbestandY{year}W{week}"``) en wordt gebruikt in foutmeldingen.
+    ``regex`` is de gecompileerde versie met named groups ``year`` en ``week``.
+    """
+
+    raw: str
+    regex: re.Pattern[str]
+
+
+def _placeholder_to_regex(pattern: str) -> str:
+    """Vertaal een placeholder-patroon naar een regex-string.
+
+    Raises
+    ------
+    ValueError
+        Als ``{year}`` of ``{week}`` ontbreekt in het patroon.
+    """
+    if "{year}" not in pattern or "{week}" not in pattern:
+        raise ValueError(
+            f"Telbestand-patroon {pattern!r} mist de placeholders "
+            f"{{year}} en/of {{week}}."
+        )
+
+    parts: list[str] = []
+    cursor = 0
+    for match in _PLACEHOLDER_TOKEN.finditer(pattern):
+        parts.append(re.escape(pattern[cursor : match.start()]))
+        parts.append(_YEAR_REGEX if match.group(1) == "year" else _WEEK_REGEX)
+        cursor = match.end()
+    parts.append(re.escape(pattern[cursor:]))
+    return "".join(parts)
+
+
+def compile_patterns(configuration: dict | None) -> list[TelbestandPattern]:
+    """Compileer telbestand-patronen uit configuratie.
+
+    Accepteert ``None``, een lege of ontbrekende sleutel, een string, of een
+    lijst van strings. Een lege lijst valt terug op het defaultpatroon.
+
+    Raises
+    ------
+    ValueError
+        Als een patroon de placeholders ``{year}`` of ``{week}`` mist.
+    """
+    raw = (configuration or {}).get("telbestand_filename_patterns")
+
+    if raw is None or raw == [] or raw == "":
+        raw_patterns: list[str] = [DEFAULT_TELBESTAND_PATTERN]
+    elif isinstance(raw, str):
+        raw_patterns = [raw]
+    else:
+        raw_patterns = list(raw)
+
+    return [
+        TelbestandPattern(raw=p, regex=re.compile(_placeholder_to_regex(p)))
+        for p in raw_patterns
+    ]
+
+
+def match_telbestand(
+    filename: str, compiled_patterns: list[TelbestandPattern]
+) -> re.Match[str] | None:
+    """Match een bestandsnaam tegen de gecompileerde patronen.
+
+    Returns het eerste match-object (met named groups ``year`` en ``week``)
+    of ``None`` als geen patroon matcht.
+    """
+    for pattern in compiled_patterns:
+        match = pattern.regex.search(filename)
+        if match is not None:
+            return match
+    return None

--- a/tests/studentprognose/test_etl_telbestanden.py
+++ b/tests/studentprognose/test_etl_telbestanden.py
@@ -1,0 +1,95 @@
+"""Integratietests voor de ETL-rowbind met configureerbare bestandsnaampatronen (issue #199)."""
+
+import pandas as pd
+import pytest
+
+from studentprognose.data.etl import _rowbind_and_reformat
+
+
+def _write_telbestand(path, week):
+    """Schrijf een minimaal valide Studielink-telbestand naar ``path``."""
+    df = pd.DataFrame(
+        [
+            {
+                "Brincode": "21PB",
+                "Studiejaar": 2024,
+                "Type_HO": "B",
+                "Isatcode": 56604,
+                "Groepeernaam": "Test Opleiding",
+                "Faculteit": "FacA",
+                "Herkomst": "N",
+                "Hogerejaars": "N",
+                "Herinschrijving": "N",
+                "Aantal": 28,
+                "meercode_V": 1.34,
+                "Status": "V",
+            }
+        ]
+    )
+    df.to_csv(path, sep=";", index=False)
+
+
+class TestRowbindWithFilenamePatterns:
+    def test_default_pattern_reads_studielink_filename(self, tmp_path):
+        tel_dir = tmp_path / "telbestanden"
+        tel_dir.mkdir()
+        _write_telbestand(tel_dir / "telbestandY2024W10.csv", week=10)
+
+        output = tmp_path / "cumulatief.csv"
+        _rowbind_and_reformat(str(tel_dir), str(output), {})
+
+        result = pd.read_csv(output, sep=";")
+        assert result["Weeknummer"].iloc[0] == 10
+        assert result["Collegejaar"].iloc[0] == 2024
+
+    def test_custom_pattern_reads_alternative_filename(self, tmp_path):
+        tel_dir = tmp_path / "telbestanden"
+        tel_dir.mkdir()
+        _write_telbestand(tel_dir / "VU_telbestand_2024_W10.csv", week=10)
+
+        config = {"telbestand_filename_patterns": ["VU_telbestand_{year}_W{week}"]}
+        output = tmp_path / "cumulatief.csv"
+        _rowbind_and_reformat(str(tel_dir), str(output), config)
+
+        result = pd.read_csv(output, sep=";")
+        assert result["Weeknummer"].iloc[0] == 10
+
+    def test_multiple_patterns_processed_together(self, tmp_path):
+        """Bestanden met verschillende naamconventies worden samengevoegd."""
+        tel_dir = tmp_path / "telbestanden"
+        tel_dir.mkdir()
+        _write_telbestand(tel_dir / "telbestandY2024W10.csv", week=10)
+        _write_telbestand(tel_dir / "VU_telbestand_2024_W11.csv", week=11)
+
+        config = {
+            "telbestand_filename_patterns": [
+                "telbestandY{year}W{week}",
+                "VU_telbestand_{year}_W{week}",
+            ]
+        }
+        output = tmp_path / "cumulatief.csv"
+        _rowbind_and_reformat(str(tel_dir), str(output), config)
+
+        result = pd.read_csv(output, sep=";")
+        assert sorted(result["Weeknummer"].tolist()) == [10, 11]
+
+    def test_unknown_filenames_are_skipped(self, tmp_path, capsys):
+        tel_dir = tmp_path / "telbestanden"
+        tel_dir.mkdir()
+        (tel_dir / "random_file.csv").write_text("x;y\n1;2\n")
+
+        output = tmp_path / "cumulatief.csv"
+        _rowbind_and_reformat(str(tel_dir), str(output), {})
+
+        assert not output.exists()
+        assert "no telbestand files found" in capsys.readouterr().out
+
+    def test_invalid_pattern_raises_clear_error(self, tmp_path):
+        tel_dir = tmp_path / "telbestanden"
+        tel_dir.mkdir()
+        _write_telbestand(tel_dir / "telbestandY2024W10.csv", week=10)
+        output = tmp_path / "cumulatief.csv"
+        config = {"telbestand_filename_patterns": ["foo_{year}_only"]}
+
+        with pytest.raises(ValueError, match="placeholders"):
+            _rowbind_and_reformat(str(tel_dir), str(output), config)

--- a/tests/studentprognose/test_telbestand_filenames.py
+++ b/tests/studentprognose/test_telbestand_filenames.py
@@ -1,0 +1,178 @@
+"""Tests voor configureerbare telbestand-naampatronen (issue #199)."""
+
+import pytest
+
+from studentprognose.config import _validate_telbestand_filename_patterns
+from studentprognose.utils.telbestand_filenames import (
+    DEFAULT_TELBESTAND_PATTERN,
+    TelbestandPattern,
+    compile_patterns,
+    match_telbestand,
+)
+
+
+class TestCompilePatterns:
+    def test_uses_default_when_config_is_none(self):
+        patterns = compile_patterns(None)
+        assert len(patterns) == 1
+        assert patterns[0].raw == DEFAULT_TELBESTAND_PATTERN
+
+    def test_uses_default_when_key_missing(self):
+        patterns = compile_patterns({})
+        assert patterns[0].raw == DEFAULT_TELBESTAND_PATTERN
+
+    def test_uses_default_when_value_is_empty_list(self):
+        patterns = compile_patterns({"telbestand_filename_patterns": []})
+        assert patterns[0].raw == DEFAULT_TELBESTAND_PATTERN
+
+    def test_uses_default_when_value_is_empty_string(self):
+        patterns = compile_patterns({"telbestand_filename_patterns": ""})
+        assert patterns[0].raw == DEFAULT_TELBESTAND_PATTERN
+
+    def test_accepts_single_string_value(self):
+        patterns = compile_patterns(
+            {"telbestand_filename_patterns": "foo_{year}_w{week}"}
+        )
+        assert len(patterns) == 1
+        assert patterns[0].raw == "foo_{year}_w{week}"
+
+    def test_accepts_list_value(self):
+        patterns = compile_patterns(
+            {"telbestand_filename_patterns": ["a_{year}_{week}", "b_{year}_{week}"]}
+        )
+        assert [p.raw for p in patterns] == ["a_{year}_{week}", "b_{year}_{week}"]
+
+    def test_returned_items_are_TelbestandPattern(self):
+        patterns = compile_patterns(None)
+        assert isinstance(patterns[0], TelbestandPattern)
+
+    def test_missing_both_placeholders_raises(self):
+        with pytest.raises(ValueError, match="placeholders"):
+            compile_patterns({"telbestand_filename_patterns": ["telbestandY2024W10"]})
+
+    def test_missing_year_placeholder_raises(self):
+        with pytest.raises(ValueError, match="placeholders"):
+            compile_patterns({"telbestand_filename_patterns": ["foo_W{week}"]})
+
+    def test_missing_week_placeholder_raises(self):
+        with pytest.raises(ValueError, match="placeholders"):
+            compile_patterns({"telbestand_filename_patterns": ["foo_Y{year}"]})
+
+    def test_literal_chars_are_escaped(self):
+        """Punten en andere regex-metakarakters moeten letterlijk worden gematcht."""
+        patterns = compile_patterns(
+            {"telbestand_filename_patterns": ["tel.{year}.{week}"]}
+        )
+        assert match_telbestand("tel.2024.10.csv", patterns) is not None
+        # Punt is geen wildcard meer:
+        assert match_telbestand("telX2024X10.csv", patterns) is None
+
+
+class TestMatchTelbestand:
+    def test_default_pattern_extracts_year_and_week(self):
+        patterns = compile_patterns(None)
+        match = match_telbestand("telbestandY2024W10.csv", patterns)
+        assert match.group("year") == "2024"
+        assert match.group("week") == "10"
+
+    def test_default_pattern_handles_single_digit_week(self):
+        patterns = compile_patterns(None)
+        match = match_telbestand("telbestandY2024W5.csv", patterns)
+        assert match.group("week") == "5"
+
+    def test_default_pattern_handles_zero_padded_week(self):
+        patterns = compile_patterns(None)
+        match = match_telbestand("telbestandY2024W05.csv", patterns)
+        assert match.group("week") == "05"
+
+    def test_returns_none_for_non_matching_name(self):
+        patterns = compile_patterns(None)
+        assert match_telbestand("random.csv", patterns) is None
+
+    def test_custom_pattern_matches_alternative_naming(self):
+        patterns = compile_patterns(
+            {"telbestand_filename_patterns": ["VU_telbestand_{year}_W{week}"]}
+        )
+        match = match_telbestand("VU_telbestand_2024_W42.csv", patterns)
+        assert match.group("year") == "2024"
+        assert match.group("week") == "42"
+
+    def test_first_matching_pattern_wins(self):
+        patterns = compile_patterns(
+            {
+                "telbestand_filename_patterns": [
+                    "telbestandY{year}W{week}",
+                    "foo_{year}_{week}",
+                ]
+            }
+        )
+        match = match_telbestand("telbestandY2024W10.csv", patterns)
+        assert match.group("year") == "2024"
+        assert match.group("week") == "10"
+
+    def test_fallback_to_second_pattern(self):
+        patterns = compile_patterns(
+            {
+                "telbestand_filename_patterns": [
+                    "telbestandY{year}W{week}",
+                    "foo_{year}_{week}",
+                ]
+            }
+        )
+        match = match_telbestand("foo_2024_42.csv", patterns)
+        assert match.group("year") == "2024"
+        assert match.group("week") == "42"
+
+
+class TestValidateTelbestandFilenamePatterns:
+    def test_missing_key_passes(self):
+        _validate_telbestand_filename_patterns({}, "cfg.json")
+
+    def test_empty_list_passes(self):
+        _validate_telbestand_filename_patterns(
+            {"telbestand_filename_patterns": []}, "cfg.json"
+        )
+
+    def test_default_pattern_passes(self):
+        _validate_telbestand_filename_patterns(
+            {"telbestand_filename_patterns": [DEFAULT_TELBESTAND_PATTERN]},
+            "cfg.json",
+        )
+
+    def test_single_string_passes(self):
+        _validate_telbestand_filename_patterns(
+            {"telbestand_filename_patterns": "foo_{year}_{week}"},
+            "cfg.json",
+        )
+
+    def test_wrong_type_exits_with_message(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _validate_telbestand_filename_patterns(
+                {"telbestand_filename_patterns": {"year": "{year}"}},
+                "cfg.json",
+            )
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Configuratiefout in cfg.json" in out
+        assert "telbestand_filename_patterns" in out
+
+    def test_non_string_in_list_exits(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _validate_telbestand_filename_patterns(
+                {"telbestand_filename_patterns": [123]},
+                "cfg.json",
+            )
+        assert exc.value.code == 1
+        assert "moet een string zijn" in capsys.readouterr().out
+
+    def test_missing_placeholders_exits_with_message(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _validate_telbestand_filename_patterns(
+                {"telbestand_filename_patterns": ["telbestandY2024W10"]},
+                "cfg.json",
+            )
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Configuratiefout in cfg.json" in out
+        assert "{year}" in out and "{week}" in out
+        assert "telbestandY2024W10" in out

--- a/tests/studentprognose/test_validation.py
+++ b/tests/studentprognose/test_validation.py
@@ -21,7 +21,10 @@ from studentprognose.data.validation import (
     _DEFAULT_VALIDATION_CFG,
     validate_raw_data,
 )
+from studentprognose.utils.telbestand_filenames import compile_patterns
 from studentprognose.utils.weeks import DataOption
+
+_DEFAULT_PATTERNS = compile_patterns(None)
 
 
 # ---------------------------------------------------------------------------
@@ -133,19 +136,19 @@ class TestCheckTelbestandCompleteness:
     def test_consecutive_weeks_no_warning(self):
         r = ValidationResult()
         files = [f"telbestandY2024W{w:02d}.csv" for w in range(1, 10)]
-        _check_telbestand_completeness(files, {}, r)
+        _check_telbestand_completeness(files, {}, _DEFAULT_PATTERNS, r)
         assert not r.warnings
 
     def test_small_gap_no_warning(self):
         r = ValidationResult()
         files = ["telbestandY2024W01.csv", "telbestandY2024W03.csv"]
-        _check_telbestand_completeness(files, {}, r)
+        _check_telbestand_completeness(files, {}, _DEFAULT_PATTERNS, r)
         assert not r.warnings
 
     def test_large_gap_produces_warning(self):
         r = ValidationResult()
         files = ["telbestandY2024W01.csv", "telbestandY2024W10.csv"]
-        _check_telbestand_completeness(files, {}, r)
+        _check_telbestand_completeness(files, {}, _DEFAULT_PATTERNS, r)
         assert len(r.warnings) == 1
         assert "2024" in r.warnings[0]
 
@@ -155,7 +158,7 @@ class TestCheckTelbestandCompleteness:
             "telbestandY2023W01.csv", "telbestandY2023W02.csv",
             "telbestandY2024W01.csv", "telbestandY2024W15.csv",
         ]
-        _check_telbestand_completeness(files, {}, r)
+        _check_telbestand_completeness(files, {}, _DEFAULT_PATTERNS, r)
         assert len(r.warnings) == 1
         assert "2024" in r.warnings[0]
 


### PR DESCRIPTION
## Summary

- Lost issue #199 op door instellingen toe te staan hun eigen Studielink-bestandsnaam-conventie te configureren via `telbestand_filename_patterns` in `configuration.json`
- Eén centrale helper (`utils/telbestand_filenames.py`) is de single source of truth voor het matchen — gebruikt door zowel de ETL als de validatie
- Placeholders `{year}` en `{week}` worden veilig naar regex vertaald (`re.escape` op de literal delen); ongeldige patronen falen direct bij config-load met een duidelijke melding
- Standaardgedrag (`telbestandY{jaar}W{week}.csv`) blijft ongewijzigd voor bestaande gebruikers

## Waarom deze aanpak

- **Geen regex in de config.** Analisten en onderzoekers — de doelgroep van deze tool — schrijven `VU_telbestand_{year}_W{week}`, niet `(?P<year>\d{4})`.
- **Lijst i.p.v. single string.** Tijdens een migratie van oude → nieuwe naamgeving kunnen meerdere patronen tegelijk actief zijn; eerste match wint.
- **Fail-fast bij config-load** voorkomt cryptische runtime errors diep in de pipeline.

## Wat valt er buiten scope

Punt 2 van het oorspronkelijke issue (extra VU-kolommen zoals `Type_HO`, `meercode_V`, `Status`, …) is verplaatst naar issue #206 (PvL-spec alignment), omdat 18 van de 22 VU-kolommen onderdeel zijn van de officiële Studielink PvL §5 en die afhandeling daar thuishoort.

## Test plan

- [x] 25 nieuwe unit tests in `tests/studentprognose/test_telbestand_filenames.py` (placeholder→regex, escaping, list/string/null inputs, first-match-wins)
- [x] 5 nieuwe integratietests in `tests/studentprognose/test_etl_telbestanden.py` (ETL met custom namen, multi-pattern, onbekende namen worden overgeslagen, ongeldig patroon faalt netjes)
- [x] Volledige testsuite groen: 303/303 passed
- [x] `ruff check` clean op alle gewijzigde bestanden
- [x] `mkdocs build --strict` introduceert geen nieuwe waarschuwingen
- [x] Documentatie bijgewerkt: `configuratie.md` (nieuwe sectie met VU-voorbeeld), `je-data-voorbereiden.md` (cross-link + override-snippet), `validatie.md`, `init.py` scaffolding-prompt

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)