### PR TITLE
ci: Windows-runner en reproduceerbare crash-injectie in smoke test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Smoke-test draait via Git Bash op Windows-runners. CRLF-eindes laten
+# `set -euo pipefail` en grep-matches breken — daarom expliciet LF afdwingen
+# voor alle shell-scripts.
+*.sh text eol=lf

--- a/.github/workflows/package-smoke-test.yml
+++ b/.github/workflows/package-smoke-test.yml
@@ -5,8 +5,18 @@ on:
 
 jobs:
   smoke:
-    name: Standalone package smoke test
-    runs-on: ubuntu-latest
+    name: Standalone package smoke test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        # Op Windows-runners draait het smoke-script via Git Bash. Dit
+        # bewaakt structureel issue #197 (joblib spawn-gedrag is fundamenteel
+        # anders op Windows dan fork op Linux) — zie issue #204.
+        shell: bash
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -303,6 +303,18 @@ result = run_pipeline_from_dataframes(
 
     Je draait Python buiten de omgeving waarin studentprognose is geïnstalleerd. Gebruik `uv run studentprognose ...` om de juiste Python-omgeving te kiezen.
 
+??? failure "`TerminatedWorkerError` tijdens SARIMA (Windows)"
+
+    Een worker-proces is op signaal-niveau gestopt — meestal door geheugendruk wanneer er veel parallelle workers tegelijk draaien op een laptop met beperkt RAM, soms door een crash in onderliggende C-code.
+
+    De pipeline probeert vanaf nu automatisch opnieuw met 2 workers. Werkt dat ook niet, zet dan handmatig in `configuration/configuration.json`:
+
+    ```json
+    "runtime": { "cpu_count": 1 }
+    ```
+
+    `cpu_count: 1` schakelt parallelisatie helemaal uit. Trager, maar zonder worker-spawns en daarmee zonder deze klasse fouten.
+
 ## Andere installatiemethoden
 
 ??? note "Installeren met pip in een virtual environment"

--- a/scripts/test_package.sh
+++ b/scripts/test_package.sh
@@ -12,6 +12,10 @@
 #      ETL en validatie worden overgeslagen
 #   6. -sk (skipyears) vlag — pipeline slaagt met skip_years > 0
 #   7. Exitcode 1 bij harde validatiefout — kapot telbestand triggert sys.exit(1)
+#   8. Crash-injectie — STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH=1 forceert een
+#      TerminatedWorkerError in de parallel-helper; de fallback uit PR #198 moet
+#      kicken en de pipeline moet doorlopen tot outputbestand. Bewaakt issue #197
+#      structureel, ook op Windows-runners.
 #
 # Gebruik: bash scripts/test_package.sh [--skip-build]
 
@@ -78,7 +82,7 @@ echo "=== [7] Exitcode 1 bij harde validatiefout ==="
 # Maak een kapot telbestand aan zonder de vereiste kolommen.
 # De validatie moet een hard error geven en afsluiten met exitcode 1.
 BROKEN_DIR="$(mktemp -d)"
-trap 'rm -rf "$BROKEN_DIR"' EXIT
+trap 'rm -rf "$WORK_DIR" "$BROKEN_DIR"' EXIT
 mkdir -p "$BROKEN_DIR/data/input_raw/telbestanden"
 echo "col1;col2" > "$BROKEN_DIR/data/input_raw/telbestanden/telbestandY2024W10.csv"
 echo "a;b"       >> "$BROKEN_DIR/data/input_raw/telbestanden/telbestandY2024W10.csv"
@@ -86,6 +90,39 @@ if (cd "$BROKEN_DIR" && uv run --with "$WHEEL" studentprognose -w 10 -y 2024 --y
     echo "FOUT: exitcode 0 verwacht bij harde validatiefout, maar pipeline slaagde"
     exit 1
 fi
+echo "OK"
+
+echo ""
+echo "=== [8] Crash-injectie: fallback fires bij geforceerde worker-crash ==="
+# Bewaakt issue #197/PR #198 structureel: STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH=1
+# forceert een TerminatedWorkerError op de eerste joblib-poging in de SARIMA-stap.
+# De fallback (n_jobs=2) moet kicken, de fallback-waarschuwing moet zichtbaar zijn
+# in stdout, en de pipeline moet doorlopen tot een outputbestand.
+#
+# We zetten 'runtime.cpu_count' expliciet op 4 zodat n_jobs > FALLBACK_N_JOBS (=2),
+# anders re-raised de helper de geforceerde crash (overeenkomstig echt OOM-gedrag).
+uv run python - <<'PYEOF'
+import json, pathlib
+p = pathlib.Path("configuration/configuration.json")
+c = json.loads(p.read_text(encoding="utf-8"))
+c.setdefault("runtime", {})["cpu_count"] = 4
+p.write_text(json.dumps(c, indent=2), encoding="utf-8")
+PYEOF
+
+CRASH_LOG="$WORK_DIR/crash-injection.log"
+# Verwijder de output van eerdere stappen zodat de aanwezigheid-check
+# bewijst dat deze run zelf schreef.
+rm -f data/output/output_first-years_beide.xlsx
+if ! STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH=1 \
+        uv run studentprognose -w 6 -y 2020 --noetl --yes > "$CRASH_LOG" 2>&1; then
+    echo "FOUT: pipeline crashte bij geforceerde worker-crash — fallback fired niet"
+    tail -n 30 "$CRASH_LOG"
+    exit 1
+fi
+[ -f data/output/output_first-years_beide.xlsx ] \
+    || { echo "FOUT: output ontbreekt na crash-injectie run"; exit 1; }
+grep -q "Opnieuw proberen met n_jobs=2" "$CRASH_LOG" \
+    || { echo "FOUT: fallback-waarschuwing niet gevonden in log — fallback fired niet"; tail -n 30 "$CRASH_LOG"; exit 1; }
 echo "OK"
 
 echo ""

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -74,6 +74,18 @@ def main(argv):
 
 
 def cli():
+    # Forceer UTF-8 op stdout/stderr. Op Windows is de console default cp1252,
+    # waarin de box-drawing en status-iconen (─, ✓, ✗) uit de validatie-overzichten
+    # niet kunnen worden gecodeerd; resultaat is een UnicodeEncodeError voor er
+    # ook maar iets gebeurt. errors="replace" voorkomt dat een eventueel
+    # niet-reconfigureerbare stream alsnog crasht — slechtere weergave dan
+    # crashen.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, OSError):
+                pass
     main(sys.argv)
 
 

--- a/src/studentprognose/strategies/combined.py
+++ b/src/studentprognose/strategies/combined.py
@@ -3,6 +3,7 @@ import joblib
 import math
 
 from studentprognose.config import get_cpu_count
+from studentprognose.utils.parallel import run_parallel_with_fallback
 from studentprognose.strategies.base import PredictionStrategy
 from studentprognose.strategies.individual import IndividualStrategy
 from studentprognose.strategies.cumulative import CumulativeStrategy, _add_engineered_features
@@ -138,10 +139,13 @@ class CombinedStrategy(PredictionStrategy):
         ]
 
         print("Start parallel predicting...")
-        self.predicted_data = joblib.Parallel(n_jobs=nr_CPU_cores)(
-            joblib.delayed(self._predict_sarima_both)(row)
-            for chunk in chunks
-            for _, row in chunk.iterrows()
+        self.predicted_data = run_parallel_with_fallback(
+            (
+                joblib.delayed(self._predict_sarima_both)(row)
+                for chunk in chunks
+                for _, row in chunk.iterrows()
+            ),
+            n_jobs=nr_CPU_cores,
         )
 
         # Extract endpoint (week-38 prediction) from each individual forecast array

--- a/src/studentprognose/strategies/cumulative.py
+++ b/src/studentprognose/strategies/cumulative.py
@@ -6,6 +6,7 @@ import math
 import warnings
 
 from studentprognose.config import get_cpu_count
+from studentprognose.utils.parallel import run_parallel_with_fallback
 from studentprognose.strategies.base import PredictionStrategy
 from studentprognose.utils.weeks import increment_week, compute_pred_len
 from studentprognose.models import create_forecaster, create_regressor
@@ -225,10 +226,13 @@ class CumulativeStrategy(PredictionStrategy):
         ]
 
         print("Start parallel predicting...")
-        self.predicted_data = joblib.Parallel(n_jobs=nr_CPU_cores)(
-            joblib.delayed(self._predict_sarima)(row)
-            for chunk in chunks
-            for _, row in chunk.iterrows()
+        self.predicted_data = run_parallel_with_fallback(
+            (
+                joblib.delayed(self._predict_sarima)(row)
+                for chunk in chunks
+                for _, row in chunk.iterrows()
+            ),
+            n_jobs=nr_CPU_cores,
         )
 
         data_to_predict["SARIMA_individual"] = np.nan

--- a/src/studentprognose/strategies/individual.py
+++ b/src/studentprognose/strategies/individual.py
@@ -5,6 +5,7 @@ import joblib
 import math
 
 from studentprognose.config import get_columns, get_cpu_count
+from studentprognose.utils.parallel import run_parallel_with_fallback
 from studentprognose.strategies.base import PredictionStrategy
 from studentprognose.utils.weeks import get_weeks_list, get_all_weeks_valid, decrement_week, week_sort_key, compute_pred_len
 from studentprognose.data.transforms import transform_data
@@ -193,10 +194,13 @@ class IndividualStrategy(PredictionStrategy):
         ]
 
         print("Start parallel predicting...")
-        predicted_data = joblib.Parallel(n_jobs=nr_CPU_cores)(
-            joblib.delayed(self._predict_sarima)(row)
-            for chunk in chunks
-            for _, row in chunk.iterrows()
+        predicted_data = run_parallel_with_fallback(
+            (
+                joblib.delayed(self._predict_sarima)(row)
+                for chunk in chunks
+                for _, row in chunk.iterrows()
+            ),
+            n_jobs=nr_CPU_cores,
         )
 
         # Extract endpoint (week-38 prediction) from each forecast array

--- a/src/studentprognose/utils/parallel.py
+++ b/src/studentprognose/utils/parallel.py
@@ -1,10 +1,19 @@
 """Parallel execution helper with crash fallback."""
 
+import os
+
 import joblib
 from joblib.externals.loky.process_executor import TerminatedWorkerError
 
 
 FALLBACK_N_JOBS = 2
+
+# Test-only kraan: zet ``STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH=1`` om de
+# eerste poging deterministisch te laten crashen met TerminatedWorkerError.
+# Gebruikt door ``scripts/test_package.sh`` om het fallback-pad op elk
+# CI-besturingssysteem te valideren zonder een echte OOM-kill of segfault te
+# hoeven uitlokken. Geen publieke knop — uitsluitend voor de smoke test.
+_FORCE_CRASH_ENV = "STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH"
 
 
 def run_parallel_with_fallback(delayed_jobs, n_jobs: int) -> list:
@@ -30,6 +39,10 @@ def run_parallel_with_fallback(delayed_jobs, n_jobs: int) -> list:
     """
     jobs = list(delayed_jobs)
     try:
+        if os.environ.get(_FORCE_CRASH_ENV) == "1":
+            raise TerminatedWorkerError(
+                f"Geforceerde crash via {_FORCE_CRASH_ENV}=1 (test-only injectie)"
+            )
         return joblib.Parallel(n_jobs=n_jobs)(jobs)
     except TerminatedWorkerError:
         if n_jobs <= FALLBACK_N_JOBS:

--- a/src/studentprognose/utils/parallel.py
+++ b/src/studentprognose/utils/parallel.py
@@ -1,0 +1,42 @@
+"""Parallel execution helper with crash fallback."""
+
+import joblib
+from joblib.externals.loky.process_executor import TerminatedWorkerError
+
+
+FALLBACK_N_JOBS = 2
+
+
+def run_parallel_with_fallback(delayed_jobs, n_jobs: int) -> list:
+    """Run joblib jobs; on worker crash, retry with fewer workers.
+
+    A ``TerminatedWorkerError`` indicates a worker process died on signal level
+    (OOM-kill or native segfault). Both have the same symptom from joblib's
+    perspective. Retrying with ``FALLBACK_N_JOBS`` workers strongly reduces
+    memory pressure and is enough to recover from the typical Windows case
+    documented in issue #197.
+
+    Args:
+        delayed_jobs: iterable of ``joblib.delayed(...)`` calls. Materialised to
+            a list so a retry can re-iterate.
+        n_jobs: number of workers for the initial attempt.
+
+    Returns:
+        list of results from ``joblib.Parallel``.
+
+    Raises:
+        TerminatedWorkerError: when the fallback also crashes, or when the
+            initial ``n_jobs`` was already at or below ``FALLBACK_N_JOBS``.
+    """
+    jobs = list(delayed_jobs)
+    try:
+        return joblib.Parallel(n_jobs=n_jobs)(jobs)
+    except TerminatedWorkerError:
+        if n_jobs <= FALLBACK_N_JOBS:
+            raise
+        print(
+            f"Worker proces crashte met n_jobs={n_jobs} (mogelijk OOM-kill of "
+            f"segfault). Opnieuw proberen met n_jobs={FALLBACK_N_JOBS}. Als dit "
+            "ook faalt: zet 'runtime.cpu_count': 1 in configuration.json."
+        )
+        return joblib.Parallel(n_jobs=FALLBACK_N_JOBS)(jobs)

--- a/tests/studentprognose/test_parallel.py
+++ b/tests/studentprognose/test_parallel.py
@@ -1,0 +1,97 @@
+"""Tests for the parallel fallback helper."""
+
+from unittest.mock import patch
+
+import joblib
+import pytest
+from joblib.externals.loky.process_executor import TerminatedWorkerError
+
+from studentprognose.utils.parallel import (
+    FALLBACK_N_JOBS,
+    run_parallel_with_fallback,
+)
+
+
+def _square(x):
+    return x * x
+
+
+def _delayed_squares(values):
+    return [joblib.delayed(_square)(v) for v in values]
+
+
+def test_happy_path_returns_results_without_fallback():
+    result = run_parallel_with_fallback(_delayed_squares([1, 2, 3]), n_jobs=2)
+    assert result == [1, 4, 9]
+
+
+def test_terminated_worker_triggers_fallback_to_two_jobs():
+    call_count = {"n": 0}
+    captured_n_jobs = []
+
+    class FakeParallel:
+        def __init__(self, n_jobs):
+            captured_n_jobs.append(n_jobs)
+
+        def __call__(self, jobs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise TerminatedWorkerError("simulated worker death")
+            return ["fallback-result"]
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", FakeParallel):
+        result = run_parallel_with_fallback(_delayed_squares([1, 2, 3]), n_jobs=8)
+
+    assert result == ["fallback-result"]
+    assert call_count["n"] == 2
+    assert captured_n_jobs == [8, FALLBACK_N_JOBS]
+
+
+def test_fallback_does_not_swallow_when_n_jobs_already_at_threshold():
+    class AlwaysCrash:
+        def __init__(self, n_jobs):
+            pass
+
+        def __call__(self, jobs):
+            raise TerminatedWorkerError("still dying")
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", AlwaysCrash):
+        with pytest.raises(TerminatedWorkerError):
+            run_parallel_with_fallback(_delayed_squares([1]), n_jobs=FALLBACK_N_JOBS)
+
+
+def test_other_exceptions_are_not_caught():
+    class BoomParallel:
+        def __init__(self, n_jobs):
+            pass
+
+        def __call__(self, jobs):
+            raise ValueError("not a worker crash")
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", BoomParallel):
+        with pytest.raises(ValueError, match="not a worker crash"):
+            run_parallel_with_fallback(_delayed_squares([1]), n_jobs=8)
+
+
+def test_generator_jobs_can_be_retried():
+    """Helper must materialise the iterable so a retry sees the same jobs."""
+    call_count = {"n": 0}
+    seen_job_counts = []
+
+    class FakeParallel:
+        def __init__(self, n_jobs):
+            pass
+
+        def __call__(self, jobs):
+            seen_job_counts.append(len(list(jobs)))
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise TerminatedWorkerError("die once")
+            return ["ok"]
+
+    gen = (joblib.delayed(_square)(v) for v in [1, 2, 3, 4])
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", FakeParallel):
+        run_parallel_with_fallback(gen, n_jobs=8)
+
+    assert seen_job_counts == [4, 4]

--- a/tests/studentprognose/test_parallel.py
+++ b/tests/studentprognose/test_parallel.py
@@ -95,3 +95,94 @@ def test_generator_jobs_can_be_retried():
         run_parallel_with_fallback(gen, n_jobs=8)
 
     assert seen_job_counts == [4, 4]
+
+
+# ---------------------------------------------------------------------------
+# Crash-injectie via STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH (issue #204).
+# Hiermee draait scripts/test_package.sh de fallback deterministisch op elk
+# CI-OS, zonder een echte OOM-kill of native segfault te hoeven uitlokken.
+# ---------------------------------------------------------------------------
+
+
+def test_force_crash_env_triggers_fallback(monkeypatch):
+    """env-var op '1' moet de fallback raken zonder dat de eerste joblib.Parallel draait."""
+    monkeypatch.setenv("STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH", "1")
+    captured_n_jobs = []
+
+    class TrackParallel:
+        def __init__(self, n_jobs):
+            captured_n_jobs.append(n_jobs)
+
+        def __call__(self, jobs):
+            return ["fallback-result"]
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", TrackParallel):
+        result = run_parallel_with_fallback(_delayed_squares([1, 2, 3]), n_jobs=8)
+
+    assert result == ["fallback-result"]
+    # Alleen de fallback-poging bereikt joblib; de eerste raised vóór de aanroep.
+    assert captured_n_jobs == [FALLBACK_N_JOBS]
+
+
+def test_force_crash_env_prints_fallback_warning(monkeypatch, capsys):
+    """De fallback-waarschuwing in stdout is wat de smoke test grept — bewaak dat."""
+    monkeypatch.setenv("STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH", "1")
+
+    class NoOpParallel:
+        def __init__(self, n_jobs):
+            pass
+
+        def __call__(self, jobs):
+            return []
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", NoOpParallel):
+        run_parallel_with_fallback(_delayed_squares([1]), n_jobs=8)
+
+    assert "Opnieuw proberen met n_jobs=2" in capsys.readouterr().out
+
+
+def test_force_crash_env_unset_means_normal_execution(monkeypatch):
+    """Zonder env-var blijft het gedrag identiek aan voor de injectie."""
+    monkeypatch.delenv("STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH", raising=False)
+    captured_n_jobs = []
+
+    class TrackParallel:
+        def __init__(self, n_jobs):
+            captured_n_jobs.append(n_jobs)
+
+        def __call__(self, jobs):
+            return ["normal-result"]
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", TrackParallel):
+        result = run_parallel_with_fallback(_delayed_squares([1, 2, 3]), n_jobs=8)
+
+    assert result == ["normal-result"]
+    assert captured_n_jobs == [8]
+
+
+@pytest.mark.parametrize("value", ["0", "true", "yes", "", "TRUE"])
+def test_force_crash_env_only_active_for_literal_one(monkeypatch, value):
+    """Alleen de letterlijke string ``'1'`` activeert injectie; al het andere telt als uit."""
+    monkeypatch.setenv("STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH", value)
+    captured_n_jobs = []
+
+    class TrackParallel:
+        def __init__(self, n_jobs):
+            captured_n_jobs.append(n_jobs)
+
+        def __call__(self, jobs):
+            return ["normal"]
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel", TrackParallel):
+        run_parallel_with_fallback(_delayed_squares([1]), n_jobs=8)
+
+    assert captured_n_jobs == [8]
+
+
+def test_force_crash_env_re_raises_when_n_jobs_below_threshold(monkeypatch):
+    """Injectie volgt het echte gedrag: onder de drempel re-raisen, niet stilletjes herstellen."""
+    monkeypatch.setenv("STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH", "1")
+
+    with patch("studentprognose.utils.parallel.joblib.Parallel"):
+        with pytest.raises(TerminatedWorkerError, match="Geforceerde crash"):
+            run_parallel_with_fallback(_delayed_squares([1]), n_jobs=FALLBACK_N_JOBS)


### PR DESCRIPTION
## Type of Change
- [x] Enhancement (CI / test-infrastructuur)

## Description of Changes

Sluit #204 — follow-up op #198.

PR #198 lost de `TerminatedWorkerError` op die op Windows tijdens de SARIMA individual-stap optreedt. Maar de smoke test bevestigt die fix nog niet structureel: de smoke draaide alleen op `ubuntu-latest` en de demodata is te klein om een echte OOM-kill uit te lokken. Toekomstige regressies in het fallback-pad zouden onopgemerkt blijven.

Twee onafhankelijke wijzigingen sluiten dit gat:

**1. Crash-injectie in `run_parallel_with_fallback`**

`STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH=1` forceert de eerste poging deterministisch een `TerminatedWorkerError` te raisen. De fallback (`n_jobs=2`) volgt exact hetzelfde pad als bij een echte worker-crash. Onder de drempel re-raised de helper, conform echt OOM-gedrag — geen stille recovery die het pad onverwacht zou kunnen verbergen.

**2. Windows-runner in `package-smoke-test.yml`**

`matrix: os: [ubuntu-latest, windows-latest]` met `defaults.run.shell: bash` (Git Bash op Windows). joblib's `spawn`-gedrag op Windows is fundamenteel anders dan `fork` op Linux — de Windows-runner is wat issue #197 in eerste instantie blootlegde, dus is hij ook waar we tegen regressies bewaken.

**Smoke-stap 8** zet `cpu_count=4` in `configuration.json` (zodat `n_jobs > FALLBACK_N_JOBS=2`), verwijdert vorige output, draait de pipeline met de env-var aan, controleert dat het outputbestand geschreven is en grept op de fallback-waarschuwing in de stdout-log. Drievoudige check: pipeline doorloopt, output wordt geschreven door deze run, fallback firet daadwerkelijk.

**`.gitattributes`** dwingt LF-eindes af voor `*.sh` zodat Git Bash op Windows-runners geen CRLF-parsing-fouten krijgt in `set -euo pipefail`.

## Related Issues

Closes #204
Follow-up op #198 (PR #198 voert de fix door, deze PR maakt 'm structureel verifieerbaar)
Oorspronkelijke bug: #197

## Before / After

### Before
- Smoke test alleen op Ubuntu — fundamenteel ander OS-pad (`fork` vs `spawn`)
- Geen mechanisme om de fallback deterministisch te triggeren
- `test_parallel.py` injecteert de exception in de unit test, maar bewijst niet dat het CI-OS-pad gezond is

### After
- Smoke test draait op Ubuntu **en** Windows via matrix
- `STUDENTPROGNOSE_TEST_FORCE_WORKER_CRASH=1` triggert de fallback deterministisch
- Stap 8 van de smoke test verifieert in CI dat de fallback-waarschuwing geprint wordt en de pipeline doorloopt — op beide OS'en

## Checklist
- [x] Lokaal getest: `uv run pytest` (288/288 passed, waarvan 6 nieuwe scenarios voor de injectie)
- [x] Lokaal getest: `bash scripts/test_package.sh` — alle 8 stappen OK
- [x] Code volgt projectstandaarden (Google-stijl docstring, type-hint behouden)
- [x] Doc-mapping uit CLAUDE.md doorlopen — wijzigingen raken CI/test-plumbing, geen gebruikersgerichte features

🤖 Generated with [Claude Code](https://claude.com/claude-code)