### PR TITLE
feat: doorlopende _totaal_*.xlsx audittrail per modus (#194)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -73,6 +73,7 @@ Dit schrijft:
 - `configuration/filtering/base.json` — lege filtering (geen opleiding- of herkomstfilter)
 - `data/input_raw/telbestanden/` — map voor je Studielink-telbestanden
 - `data/input_raw/README.md` — beschrijving van welke bestanden hier horen
+- `data/output/` — map waarin de wekelijkse outputs én de doorlopende audittrail (`_totaal_*.xlsx`) worden opgeslagen
 
 Bestaat een bestand al, dan wordt het overgeslagen. Je kunt `init` dus veilig opnieuw uitvoeren.
 

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -24,7 +24,7 @@ De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvo
 Naast de week-specifieke `output_*.xlsx`-bestanden — die elke run worden overschreven — onderhoudt de pipeline een doorlopend audittrail per modus. Elke run voegt zijn rijen idempotent toe aan `data/output/_totaal_{studentjaar}_{modus}.xlsx`:
 
 - **Bij eerste run** ontstaat het bestand met de kolommen van de huidige run.
-- **Bij elke vervolgrun** worden de rijen toegevoegd. Bestaande rijen met dezelfde sleutel (`Collegejaar`, `Weeknummer`, `Croho groepeernaam`, `Herkomst`, `Examentype`) worden **overschreven** in plaats van gedupliceerd — opnieuw draaien voor dezelfde week is dus veilig.
+- **Bij elke vervolgrun** worden de rijen toegevoegd. Bestaande rijen met dezelfde sleutel (jaar, week, opleiding, herkomst, examentype — de exacte kolomnamen volgen uit `column_roles`, in de standaardconfig: `Collegejaar`, `Weeknummer`, `Croho groepeernaam`, `Herkomst`, `Examentype`) worden **overschreven** in plaats van gedupliceerd — opnieuw draaien voor dezelfde week is dus veilig.
 - **Run_date-kolom**: elke geschreven rij krijgt de datum van de run. Handig om te zien wanneer een voorspelling voor een (jaar, week)-combo is gegenereerd, bv. bij modelwijzigingen.
 
 Het bestand wordt **nooit** door de pipeline als input ingelezen — de data loader leest enkel de paden uit `configuration.json`. Daarmee is een circulaire afhankelijkheid structureel uitgesloten.

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -14,8 +14,32 @@ De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvo
 | `output_prelim_{modus}.xlsx` | Tussenresultaat | Voorlopige voorspellingen vóór ratio-model, ensemble en foutmaten. Nuttig voor debugging. |
 | `output_first-years_{modus}.xlsx` | Eindresultaat | Eerstejaars voorspellingen per opleiding/herkomst/week |
 | `output_volume_{modus}.xlsx` | Eindresultaat | Totaal studentvolume-voorspellingen (alleen bij `-sy v`) |
+| `_totaal_{studentjaar}_{modus}.xlsx` | Audittrail | Doorlopend bestand waar elke run zijn rijen aan toevoegt. Wordt nooit als input ingelezen. Zie [Audittrail](#audittrail-_totaalxlsx). |
 
 `{modus}` is `cumulatief`, `individueel` of `beide`, afhankelijk van de gebruikte `-d` vlag.
+`{studentjaar}` is `first-years`, `higher-years` of `volume`, afhankelijk van `-sy`.
+
+## Audittrail (`_totaal_*.xlsx`)
+
+Naast de week-specifieke `output_*.xlsx`-bestanden — die elke run worden overschreven — onderhoudt de pipeline een doorlopend audittrail per modus. Elke run voegt zijn rijen idempotent toe aan `data/output/_totaal_{studentjaar}_{modus}.xlsx`:
+
+- **Bij eerste run** ontstaat het bestand met de kolommen van de huidige run.
+- **Bij elke vervolgrun** worden de rijen toegevoegd. Bestaande rijen met dezelfde sleutel (`Collegejaar`, `Weeknummer`, `Croho groepeernaam`, `Herkomst`, `Examentype`) worden **overschreven** in plaats van gedupliceerd — opnieuw draaien voor dezelfde week is dus veilig.
+- **Run_date-kolom**: elke geschreven rij krijgt de datum van de run. Handig om te zien wanneer een voorspelling voor een (jaar, week)-combo is gegenereerd, bv. bij modelwijzigingen.
+
+Het bestand wordt **nooit** door de pipeline als input ingelezen — de data loader leest enkel de paden uit `configuration.json`. Daarmee is een circulaire afhankelijkheid structureel uitgesloten.
+
+### Wanneer is de audittrail nuttig?
+
+- **Trends over weken heen** — open één bestand om te zien hoe de voorspelling voor een opleiding zich gedurende het inschrijfseizoen ontwikkelde, zonder dat je zelf wekelijkse exports hoeft te koppelen.
+- **Achteraf reconstrueren** — `Run_date` toont wanneer een voorspelling is gemaakt, wat helpt bij retrospectief onderzoek of audits.
+
+### Bekende limieten
+
+- **Filterwijzigingen tussen runs** worden niet gedetecteerd. Als je in week 10 met `-f base.json` draait en in week 11 met een ander filter, leven beide rijensets naast elkaar in dezelfde audittrail. Geen filterhash; documenteer welke filterconfig hoort bij welke run zelf.
+- **Modelversie-drift**: rijen uit oudere runs kunnen door een andere modelvariant zijn gegenereerd. `Run_date` maakt dit traceerbaar maar is geen vervanging voor versiebeheer van de pipeline zelf.
+- **Numerus-fixusvoorspellingen** worden net als in de week-output afgekapt; de audittrail erft die waarden ongewijzigd.
+- **CI-modus** (`--ci test N`) schrijft géén audittrail — alleen reguliere runs.
 
 ## Kolomdefinities
 

--- a/scripts/test_package.sh
+++ b/scripts/test_package.sh
@@ -47,6 +47,9 @@ uv run studentprognose init > /dev/null
 [ -f configuration/configuration.json ]   || { echo "FOUT: configuration.json ontbreekt"; exit 1; }
 [ -f configuration/filtering/base.json ]  || { echo "FOUT: filtering/base.json ontbreekt"; exit 1; }
 [ -d data/input_raw/telbestanden ]        || { echo "FOUT: data/input_raw/telbestanden ontbreekt"; exit 1; }
+[ -d data/output ]                        || { echo "FOUT: data/output ontbreekt"; exit 1; }
+# Audittrail mag NIET als lege placeholder bestaan: hij ontstaat lui bij eerste run.
+[ ! -f data/output/_totaal_first-years_beide.xlsx ] || { echo "FOUT: _totaal_*.xlsx bestaat al na init"; exit 1; }
 echo "OK"
 
 echo ""
@@ -56,7 +59,9 @@ cp    "$REPO_ROOT/data/input_raw/individuele_aanmelddata.csv" data/input_raw/
 cp    "$REPO_ROOT/data/input_raw/oktober_bestand.xlsx"   data/input_raw/
 uv run studentprognose -w 6 -y 2020 --yes > /dev/null
 [ -f data/output/output_first-years_beide.xlsx ] || { echo "FOUT: output ontbreekt"; exit 1; }
-echo "OK"
+[ -f data/output/_totaal_first-years_beide.xlsx ] || { echo "FOUT: _totaal_*.xlsx ontbreekt na eerste run"; exit 1; }
+ROWS_AFTER_RUN1=$(uv run python -c "import pandas as pd; print(len(pd.read_excel('data/output/_totaal_first-years_beide.xlsx')))")
+echo "OK (_totaal_first-years_beide.xlsx: $ROWS_AFTER_RUN1 rijen)"
 
 echo ""
 echo "=== [5] --noetl --yes combinatie ==="
@@ -64,6 +69,9 @@ echo "=== [5] --noetl --yes combinatie ==="
 # --noetl slaat ETL en validatie over; de pipeline moet slagen op de bestaande data.
 uv run studentprognose -w 6 -y 2020 --noetl --yes > /dev/null
 [ -f data/output/output_first-years_beide.xlsx ] || { echo "FOUT: output ontbreekt na --noetl run"; exit 1; }
+# Identieke run mag de audittrail NIET dupliceren — idempotentie per (jaar, week).
+ROWS_AFTER_RUN2=$(uv run python -c "import pandas as pd; print(len(pd.read_excel('data/output/_totaal_first-years_beide.xlsx')))")
+[ "$ROWS_AFTER_RUN1" = "$ROWS_AFTER_RUN2" ] || { echo "FOUT: audittrail-dupliceerde rijen ($ROWS_AFTER_RUN1 → $ROWS_AFTER_RUN2)"; exit 1; }
 echo "OK"
 
 echo ""

--- a/src/studentprognose/init.py
+++ b/src/studentprognose/init.py
@@ -26,6 +26,7 @@ def run_init():
         os.path.join(cwd, "configuration", "filtering"),
         os.path.join(cwd, "data", "input"),
         os.path.join(cwd, "data", "input_raw", "telbestanden"),
+        os.path.join(cwd, "data", "output"),
     ]
     for d in dirs:
         os.makedirs(d, exist_ok=True)

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -457,6 +457,7 @@ def _save_results(strategy, cfg):
         if strategy.postprocessor.data is not None:
             print("Saving output...")
             strategy.postprocessor.save_output(cfg.student_year_prediction)
+            strategy.postprocessor.save_totaal_audit_trail(cfg.student_year_prediction)
 
             if cfg.dashboard:
                 _try_build_dashboard(strategy, cfg)

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -20,6 +20,12 @@ class PostProcessor:
     from the new src/ modules.
     """
 
+    _SY_LABELS = {
+        StudentYearPrediction.FIRST_YEARS: "first-years",
+        StudentYearPrediction.HIGHER_YEARS: "higher-years",
+        StudentYearPrediction.VOLUME: "volume",
+    }
+
     @staticmethod
     def check_output_writable(data_option, student_year_prediction, ci_test_n):
         """Verify output files can be written (not locked by Excel)."""
@@ -30,11 +36,7 @@ class PostProcessor:
         try:
             open(f"data/output/output_prelim_{mode_suffix}{ci_suffix}.xlsx", "w").close()
             if ci_test_n is None:
-                sy_label = {
-                    StudentYearPrediction.FIRST_YEARS: "first-years",
-                    StudentYearPrediction.HIGHER_YEARS: "higher-years",
-                    StudentYearPrediction.VOLUME: "volume",
-                }.get(student_year_prediction)
+                sy_label = PostProcessor._SY_LABELS.get(student_year_prediction)
                 if sy_label is not None:
                     open(f"data/output/output_{sy_label}_{mode_suffix}{ci_suffix}.xlsx", "w").close()
                     # _totaal mag NIET worden getrunceerd: het bevat de
@@ -66,6 +68,7 @@ class PostProcessor:
             "week_35_37":        {"individual": 0.5, "cumulative": 0.5},
             "default":           {"individual": 0.5, "cumulative": 0.5},
         })
+        self._column_roles = configuration.get("column_roles", {})
         self.CWD = cwd
         self.data_option = data_option
         self.ci_test_n = ci_test_n
@@ -437,17 +440,9 @@ class PostProcessor:
         self.data_latest = self.data
 
     def save_output(self, student_year_prediction):
-        output_filename = "output_"
-
-        if student_year_prediction == StudentYearPrediction.FIRST_YEARS:
-            output_filename += "first-years"
-        elif student_year_prediction == StudentYearPrediction.HIGHER_YEARS:
-            output_filename += "higher-years"
-        elif student_year_prediction == StudentYearPrediction.VOLUME:
-            output_filename += "volume"
-
+        sy_label = self._SY_LABELS.get(student_year_prediction, "")
         ci_suffix = f"_ci_test_N{self.ci_test_n}" if self.ci_test_n is not None else ""
-        output_filename += f"_{self.data_option.filename_suffix}{ci_suffix}.xlsx"
+        output_filename = f"output_{sy_label}_{self.data_option.filename_suffix}{ci_suffix}.xlsx"
 
         output_path = os.path.join(self.CWD, "data", "output", output_filename)
 
@@ -459,35 +454,39 @@ class PostProcessor:
 
         self.data.to_excel(output_path, index=False)
 
-    _TOTAAL_KEY_COLS = [
-        "Collegejaar",
-        "Weeknummer",
-        "Croho groepeernaam",
-        "Herkomst",
-        "Examentype",
-    ]
+    # Sleutel- en sorteer-volgorde van de audittrail, uitgedrukt in
+    # column_roles. De concrete kolomnamen verschillen per instelling
+    # (Radboud vs. CEDA-default) maar de rolinvulling is universeel:
+    # één rij = uniek (jaar, week, opleiding, herkomst, examentype).
+    _TOTAAL_KEY_ROLES = ("academic_year", "week", "programme", "origin", "exam_type")
+    _TOTAAL_SORT_ROLES = ("programme", "exam_type", "academic_year", "week", "origin")
 
     def save_totaal_audit_trail(self, student_year_prediction):
         """Append de huidige run aan een doorlopend `_totaal_<sy>_<do>.xlsx`.
 
-        Idempotent per (Collegejaar, Weeknummer, Croho groepeernaam, Herkomst,
-        Examentype): rijen voor dezelfde sleutelcombo worden overschreven, niet
-        gedupliceerd. Voegt een `Run_date`-kolom toe zodat traceerbaar blijft
-        wanneer een rij is gegenereerd. Het bestand wordt nooit als input door
-        de pipeline gelezen (de loader leest enkel paden uit
-        `configuration.json`), dus het is structureel veilig om naast de
-        reguliere outputs te bestaan.
+        Idempotent per sleutelcombo uit ``column_roles`` (jaar, week,
+        opleiding, herkomst, examentype): rijen voor dezelfde combo worden
+        overschreven, niet gedupliceerd. Voegt een ``Run_date``-kolom toe
+        zodat traceerbaar blijft wanneer een rij is gegenereerd. Het
+        bestand wordt nooit als input door de pipeline gelezen (de loader
+        leest enkel paden uit ``configuration.json``), dus het is
+        structureel veilig om naast de reguliere outputs te bestaan.
         """
         if self.data is None:
             return
 
-        sy_label = {
-            StudentYearPrediction.FIRST_YEARS: "first-years",
-            StudentYearPrediction.HIGHER_YEARS: "higher-years",
-            StudentYearPrediction.VOLUME: "volume",
-        }.get(student_year_prediction)
+        sy_label = self._SY_LABELS.get(student_year_prediction)
         if sy_label is None:
             return
+
+        try:
+            key_cols = [self._column_roles[r] for r in self._TOTAAL_KEY_ROLES]
+            sort_cols = [self._column_roles[r] for r in self._TOTAAL_SORT_ROLES]
+        except KeyError as missing:
+            raise RuntimeError(
+                f"configuratie mist column_roles[{missing.args[0]!r}] — "
+                "vereist voor de _totaal-audittrail."
+            ) from missing
 
         filename = f"_totaal_{sy_label}_{self.data_option.filename_suffix}.xlsx"
         path = os.path.join(self.CWD, "data", "output", filename)
@@ -514,9 +513,6 @@ class PostProcessor:
         # keep="last": de nieuwe run staat altijd achteraan in de concat,
         # dus zijn waarden winnen bij gelijke sleutel. Dit realiseert het
         # "overschrijven per week"-gedrag zonder rij-duplicatie.
-        combined = combined.drop_duplicates(subset=self._TOTAAL_KEY_COLS, keep="last")
-        combined = combined.sort_values(
-            by=["Croho groepeernaam", "Examentype", "Collegejaar", "Weeknummer", "Herkomst"],
-            ignore_index=True,
-        )
+        combined = combined.drop_duplicates(subset=key_cols, keep="last")
+        combined = combined.sort_values(by=sort_cols, ignore_index=True)
         combined.to_excel(path, index=False)

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -1,3 +1,4 @@
+import datetime
 import numpy as np
 import pandas as pd
 import os
@@ -29,13 +30,22 @@ class PostProcessor:
         try:
             open(f"data/output/output_prelim_{mode_suffix}{ci_suffix}.xlsx", "w").close()
             if ci_test_n is None:
-                match student_year_prediction:
-                    case StudentYearPrediction.FIRST_YEARS:
-                        open(f"data/output/output_first-years_{mode_suffix}{ci_suffix}.xlsx", "w").close()
-                    case StudentYearPrediction.HIGHER_YEARS:
-                        open(f"data/output/output_higher-years_{mode_suffix}{ci_suffix}.xlsx", "w").close()
-                    case StudentYearPrediction.VOLUME:
-                        open(f"data/output/output_volume_{mode_suffix}{ci_suffix}.xlsx", "w").close()
+                sy_label = {
+                    StudentYearPrediction.FIRST_YEARS: "first-years",
+                    StudentYearPrediction.HIGHER_YEARS: "higher-years",
+                    StudentYearPrediction.VOLUME: "volume",
+                }.get(student_year_prediction)
+                if sy_label is not None:
+                    open(f"data/output/output_{sy_label}_{mode_suffix}{ci_suffix}.xlsx", "w").close()
+                    # _totaal mag NIET worden getrunceerd: het bevat de
+                    # historie van eerdere runs. "a" opent zonder leeg te
+                    # maken en faalt alsnog als Excel het bestand
+                    # vergrendelt — exact wat we hier willen detecteren.
+                    totaal_path = os.path.join(
+                        output_dir, f"_totaal_{sy_label}_{mode_suffix}.xlsx"
+                    )
+                    if os.path.exists(totaal_path):
+                        open(totaal_path, "a").close()
         except IOError:
             print(
                 "Fout: outputbestand kan niet geopend worden, waarschijnlijk staat het nog open in Excel. "
@@ -448,3 +458,65 @@ class PostProcessor:
         )
 
         self.data.to_excel(output_path, index=False)
+
+    _TOTAAL_KEY_COLS = [
+        "Collegejaar",
+        "Weeknummer",
+        "Croho groepeernaam",
+        "Herkomst",
+        "Examentype",
+    ]
+
+    def save_totaal_audit_trail(self, student_year_prediction):
+        """Append de huidige run aan een doorlopend `_totaal_<sy>_<do>.xlsx`.
+
+        Idempotent per (Collegejaar, Weeknummer, Croho groepeernaam, Herkomst,
+        Examentype): rijen voor dezelfde sleutelcombo worden overschreven, niet
+        gedupliceerd. Voegt een `Run_date`-kolom toe zodat traceerbaar blijft
+        wanneer een rij is gegenereerd. Het bestand wordt nooit als input door
+        de pipeline gelezen (de loader leest enkel paden uit
+        `configuration.json`), dus het is structureel veilig om naast de
+        reguliere outputs te bestaan.
+        """
+        if self.data is None:
+            return
+
+        sy_label = {
+            StudentYearPrediction.FIRST_YEARS: "first-years",
+            StudentYearPrediction.HIGHER_YEARS: "higher-years",
+            StudentYearPrediction.VOLUME: "volume",
+        }.get(student_year_prediction)
+        if sy_label is None:
+            return
+
+        filename = f"_totaal_{sy_label}_{self.data_option.filename_suffix}.xlsx"
+        path = os.path.join(self.CWD, "data", "output", filename)
+
+        new_rows = self.data.copy()
+        new_rows["Run_date"] = datetime.date.today().isoformat()
+
+        if os.path.exists(path):
+            try:
+                existing = pd.read_excel(path)
+            except Exception as e:
+                # Corrupte of door Excel vergrendelde file: vroege check
+                # ving dat normaal al af. Hier alsnog defensief: log en sla
+                # over zodat de hoofdpipeline-output niet verloren gaat.
+                print(
+                    f"Waarschuwing: kon bestaande audittrail niet lezen ({path}): {e}. "
+                    "Audittrail wordt deze run niet bijgewerkt."
+                )
+                return
+            combined = pd.concat([existing, new_rows], ignore_index=True)
+        else:
+            combined = new_rows
+
+        # keep="last": de nieuwe run staat altijd achteraan in de concat,
+        # dus zijn waarden winnen bij gelijke sleutel. Dit realiseert het
+        # "overschrijven per week"-gedrag zonder rij-duplicatie.
+        combined = combined.drop_duplicates(subset=self._TOTAAL_KEY_COLS, keep="last")
+        combined = combined.sort_values(
+            by=["Croho groepeernaam", "Examentype", "Collegejaar", "Weeknummer", "Herkomst"],
+            ignore_index=True,
+        )
+        combined.to_excel(path, index=False)

--- a/tests/studentprognose/test_dashboard.py
+++ b/tests/studentprognose/test_dashboard.py
@@ -86,6 +86,7 @@ def test_save_results_skips_dashboard_by_default(monkeypatch):
     postprocessor = SimpleNamespace(
         data=pd.DataFrame({"x": [1]}),
         save_output=lambda _pred: None,
+        save_totaal_audit_trail=lambda _pred: None,
     )
     strategy = SimpleNamespace(postprocessor=postprocessor)
     cfg = PipelineConfig(weeks=[10], years=[2024])  # dashboard=False (default)
@@ -107,6 +108,7 @@ def test_save_results_runs_dashboard_when_enabled(monkeypatch):
     postprocessor = SimpleNamespace(
         data=pd.DataFrame({"x": [1]}),
         save_output=lambda _pred: None,
+        save_totaal_audit_trail=lambda _pred: None,
     )
     strategy = SimpleNamespace(postprocessor=postprocessor)
     cfg = PipelineConfig(weeks=[10], years=[2024], dashboard=True)

--- a/tests/studentprognose/test_postprocessor.py
+++ b/tests/studentprognose/test_postprocessor.py
@@ -1,7 +1,11 @@
-"""Tests for PostProcessor.prepare_data_for_output_prelim.
+"""Tests for PostProcessor.
 
-Bewaakt het gedrag van de merge met data_studentcount: zowel zonder
-Faculteit-kolom (huidige CEDA-default) als mét Faculteit-kolom (Radboud-casus).
+Bewaakt:
+  - het gedrag van de merge met data_studentcount: zowel zonder
+    Faculteit-kolom (huidige CEDA-default) als mét Faculteit-kolom
+    (Radboud-casus).
+  - de doorlopende `_totaal_<sy>_<do>.xlsx`-audittrail (idempotente upsert
+    per Collegejaar+Weeknummer).
 """
 
 import os
@@ -9,7 +13,7 @@ import os
 import pandas as pd
 
 from studentprognose.output.postprocessor import PostProcessor
-from studentprognose.utils.weeks import DataOption
+from studentprognose.utils.weeks import DataOption, StudentYearPrediction
 
 
 def _make_postprocessor(tmp_path, data_studentcount):
@@ -133,3 +137,127 @@ class TestStudentcountMergeWithFaculteit:
         pp.prepare_data_for_output_prelim(input_data, year=2024, week=10)
 
         assert pp.data["Faculteit"].iloc[0] == "FdM"
+
+
+def _make_run_data(year=2024, week=10, sarima_cumulative=(100.0, 50.0)):
+    """Bouw een minimale prognose-DataFrame met de standaard sleutelkolommen."""
+    return pd.DataFrame({
+        "Collegejaar":        [year, year],
+        "Weeknummer":         [week, week],
+        "Croho groepeernaam": ["B Bedrijfskunde", "B Bedrijfskunde"],
+        "Herkomst":           ["NL", "EER"],
+        "Examentype":         ["Bachelor", "Bachelor"],
+        "Faculteit":          ["FdM", "FdM"],
+        "SARIMA_cumulative":  list(sarima_cumulative),
+        "Voorspelde vooraanmelders": [120.0, 60.0],
+    })
+
+
+def _audittrail_postprocessor(tmp_path):
+    os.makedirs(tmp_path / "data" / "output", exist_ok=True)
+    return PostProcessor(
+        configuration={"numerus_fixus": {}},
+        data_latest=None,
+        ensemble_weights=None,
+        data_studentcount=None,
+        cwd=str(tmp_path),
+        data_option=DataOption.CUMULATIVE,
+        ci_test_n=None,
+    )
+
+
+class TestSaveTotaalAuditTrail:
+    """Bewaakt de idempotente upsert van `_totaal_<sy>_<do>.xlsx`."""
+
+    expected_path_parts = ("data", "output", "_totaal_first-years_cumulatief.xlsx")
+
+    def _path(self, tmp_path):
+        return tmp_path.joinpath(*self.expected_path_parts)
+
+    def test_eerste_run_schrijft_alle_rijen_met_run_date(self, tmp_path):
+        pp = _audittrail_postprocessor(tmp_path)
+        pp.data = _make_run_data()
+
+        pp.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        path = self._path(tmp_path)
+        assert path.exists()
+        result = pd.read_excel(path)
+        assert len(result) == 2
+        assert "Run_date" in result.columns
+        assert result["Run_date"].notna().all()
+
+    def test_zelfde_week_wordt_overschreven_niet_gedupliceerd(self, tmp_path):
+        pp1 = _audittrail_postprocessor(tmp_path)
+        pp1.data = _make_run_data(week=12, sarima_cumulative=(100.0, 50.0))
+        pp1.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        # Tweede run met dezelfde (jaar, week, opleiding, herkomst, examentype):
+        # waarden moeten overschreven worden.
+        pp2 = _audittrail_postprocessor(tmp_path)
+        pp2.data = _make_run_data(week=12, sarima_cumulative=(999.0, 888.0))
+        pp2.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        result = pd.read_excel(self._path(tmp_path))
+        assert len(result) == 2  # geen rij-duplicatie
+        assert set(result["SARIMA_cumulative"]) == {999.0, 888.0}
+        assert 100.0 not in result["SARIMA_cumulative"].values
+
+    def test_andere_week_wordt_toegevoegd(self, tmp_path):
+        pp1 = _audittrail_postprocessor(tmp_path)
+        pp1.data = _make_run_data(week=11)
+        pp1.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        pp2 = _audittrail_postprocessor(tmp_path)
+        pp2.data = _make_run_data(week=12)
+        pp2.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        result = pd.read_excel(self._path(tmp_path))
+        assert len(result) == 4  # 2 rijen w11 + 2 rijen w12
+        assert set(result["Weeknummer"]) == {11, 12}
+
+    def test_schema_drift_crasht_niet(self, tmp_path):
+        # Bootst een eerdere run na met een kleiner kolomschema.
+        os.makedirs(tmp_path / "data" / "output", exist_ok=True)
+        path = self._path(tmp_path)
+        pd.DataFrame({
+            "Collegejaar":        [2024],
+            "Weeknummer":         [10],
+            "Croho groepeernaam": ["B Bedrijfskunde"],
+            "Herkomst":           ["NL"],
+            "Examentype":         ["Bachelor"],
+            "SARIMA_cumulative":  [100.0],
+            # geen Faculteit, geen Run_date — kolomschema is bewust kleiner
+        }).to_excel(path, index=False)
+
+        pp = _audittrail_postprocessor(tmp_path)
+        pp.data = _make_run_data(week=11)  # voegt o.a. Faculteit + nieuwe kolommen toe
+        pp.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        result = pd.read_excel(path)
+        # De oude rij blijft bestaan (week 10) plus de twee nieuwe (week 11).
+        assert len(result) == 3
+        assert {"Faculteit", "Run_date"}.issubset(result.columns)
+
+    def test_geen_data_doet_niets(self, tmp_path):
+        pp = _audittrail_postprocessor(tmp_path)
+        pp.data = None
+        pp.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+        assert not self._path(tmp_path).exists()
+
+    def test_bestandsnaam_volgt_modus_en_studentjaar(self, tmp_path):
+        os.makedirs(tmp_path / "data" / "output", exist_ok=True)
+        pp = PostProcessor(
+            configuration={"numerus_fixus": {}},
+            data_latest=None,
+            ensemble_weights=None,
+            data_studentcount=None,
+            cwd=str(tmp_path),
+            data_option=DataOption.BOTH_DATASETS,
+            ci_test_n=None,
+        )
+        pp.data = _make_run_data()
+        pp.save_totaal_audit_trail(StudentYearPrediction.VOLUME)
+
+        expected = tmp_path / "data" / "output" / "_totaal_volume_beide.xlsx"
+        assert expected.exists()

--- a/tests/studentprognose/test_postprocessor.py
+++ b/tests/studentprognose/test_postprocessor.py
@@ -12,8 +12,20 @@ import os
 
 import pandas as pd
 
+from studentprognose.config import get_columns, load_defaults
 from studentprognose.output.postprocessor import PostProcessor
 from studentprognose.utils.weeks import DataOption, StudentYearPrediction
+
+# Eén bron van waarheid voor de kolomnamen die de audittrail gebruikt:
+# de gebundelde defaults uit configuration.json. Zowel de PostProcessor-
+# configuratie als de test-DataFrames lezen hieruit, zodat een rename in
+# column_roles geen tweede hardcoded lijst hier laat achterblijven.
+_DEFAULTS = load_defaults()
+_COLS = get_columns(_DEFAULTS)
+
+
+def _audittrail_configuration():
+    return {"numerus_fixus": {}, "column_roles": _DEFAULTS["column_roles"]}
 
 
 def _make_postprocessor(tmp_path, data_studentcount):
@@ -142,13 +154,13 @@ class TestStudentcountMergeWithFaculteit:
 def _make_run_data(year=2024, week=10, sarima_cumulative=(100.0, 50.0)):
     """Bouw een minimale prognose-DataFrame met de standaard sleutelkolommen."""
     return pd.DataFrame({
-        "Collegejaar":        [year, year],
-        "Weeknummer":         [week, week],
-        "Croho groepeernaam": ["B Bedrijfskunde", "B Bedrijfskunde"],
-        "Herkomst":           ["NL", "EER"],
-        "Examentype":         ["Bachelor", "Bachelor"],
-        "Faculteit":          ["FdM", "FdM"],
-        "SARIMA_cumulative":  list(sarima_cumulative),
+        _COLS.academic_year: [year, year],
+        _COLS.week:          [week, week],
+        _COLS.programme:     ["B Bedrijfskunde", "B Bedrijfskunde"],
+        _COLS.origin:        ["NL", "EER"],
+        _COLS.exam_type:     ["Bachelor", "Bachelor"],
+        "Faculteit":         ["FdM", "FdM"],
+        "SARIMA_cumulative": list(sarima_cumulative),
         "Voorspelde vooraanmelders": [120.0, 60.0],
     })
 
@@ -156,7 +168,7 @@ def _make_run_data(year=2024, week=10, sarima_cumulative=(100.0, 50.0)):
 def _audittrail_postprocessor(tmp_path):
     os.makedirs(tmp_path / "data" / "output", exist_ok=True)
     return PostProcessor(
-        configuration={"numerus_fixus": {}},
+        configuration=_audittrail_configuration(),
         data_latest=None,
         ensemble_weights=None,
         data_studentcount=None,
@@ -214,19 +226,19 @@ class TestSaveTotaalAuditTrail:
 
         result = pd.read_excel(self._path(tmp_path))
         assert len(result) == 4  # 2 rijen w11 + 2 rijen w12
-        assert set(result["Weeknummer"]) == {11, 12}
+        assert set(result[_COLS.week]) == {11, 12}
 
     def test_schema_drift_crasht_niet(self, tmp_path):
         # Bootst een eerdere run na met een kleiner kolomschema.
         os.makedirs(tmp_path / "data" / "output", exist_ok=True)
         path = self._path(tmp_path)
         pd.DataFrame({
-            "Collegejaar":        [2024],
-            "Weeknummer":         [10],
-            "Croho groepeernaam": ["B Bedrijfskunde"],
-            "Herkomst":           ["NL"],
-            "Examentype":         ["Bachelor"],
-            "SARIMA_cumulative":  [100.0],
+            _COLS.academic_year: [2024],
+            _COLS.week:          [10],
+            _COLS.programme:     ["B Bedrijfskunde"],
+            _COLS.origin:        ["NL"],
+            _COLS.exam_type:     ["Bachelor"],
+            "SARIMA_cumulative": [100.0],
             # geen Faculteit, geen Run_date — kolomschema is bewust kleiner
         }).to_excel(path, index=False)
 
@@ -248,7 +260,7 @@ class TestSaveTotaalAuditTrail:
     def test_bestandsnaam_volgt_modus_en_studentjaar(self, tmp_path):
         os.makedirs(tmp_path / "data" / "output", exist_ok=True)
         pp = PostProcessor(
-            configuration={"numerus_fixus": {}},
+            configuration=_audittrail_configuration(),
             data_latest=None,
             ensemble_weights=None,
             data_studentcount=None,
@@ -261,3 +273,67 @@ class TestSaveTotaalAuditTrail:
 
         expected = tmp_path / "data" / "output" / "_totaal_volume_beide.xlsx"
         assert expected.exists()
+
+    def test_alternatieve_column_roles_worden_gerespecteerd(self, tmp_path):
+        # Bewaakt dat de audittrail-upsert ook werkt met een institutionele
+        # kolom-rename: de configuratie is de bron van waarheid, niet een
+        # hardgecodeerde lijst.
+        os.makedirs(tmp_path / "data" / "output", exist_ok=True)
+        alt_roles = {
+            "academic_year": "Year",
+            "week":          "Week",
+            "programme":     "Programme",
+            "origin":        "Origin",
+            "exam_type":     "ExamType",
+        }
+        pp = PostProcessor(
+            configuration={"numerus_fixus": {}, "column_roles": alt_roles},
+            data_latest=None,
+            ensemble_weights=None,
+            data_studentcount=None,
+            cwd=str(tmp_path),
+            data_option=DataOption.CUMULATIVE,
+            ci_test_n=None,
+        )
+        # Run 1 — week 12.
+        pp.data = pd.DataFrame({
+            "Year": [2024], "Week": [12], "Programme": ["B Foo"],
+            "Origin": ["NL"], "ExamType": ["Bachelor"], "SARIMA_cumulative": [100.0],
+        })
+        pp.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+        # Run 2 — zelfde sleutel, andere waarde: moet overschrijven.
+        pp.data = pd.DataFrame({
+            "Year": [2024], "Week": [12], "Programme": ["B Foo"],
+            "Origin": ["NL"], "ExamType": ["Bachelor"], "SARIMA_cumulative": [999.0],
+        })
+        pp.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)
+
+        result = pd.read_excel(tmp_path / "data" / "output" / "_totaal_first-years_cumulatief.xlsx")
+        assert len(result) == 1
+        assert result["SARIMA_cumulative"].iloc[0] == 999.0
+
+    def test_missende_column_role_geeft_duidelijke_fout(self, tmp_path):
+        import pytest
+
+        os.makedirs(tmp_path / "data" / "output", exist_ok=True)
+        # Mist 'origin' — moet een duidelijke RuntimeError opleveren bij
+        # de eerste audittrail-schrijfpoging, niet een KeyError diep in
+        # pandas.
+        incomplete_roles = {
+            "academic_year": "Collegejaar",
+            "week":          "Weeknummer",
+            "programme":     "Croho groepeernaam",
+            "exam_type":     "Examentype",
+        }
+        pp = PostProcessor(
+            configuration={"numerus_fixus": {}, "column_roles": incomplete_roles},
+            data_latest=None,
+            ensemble_weights=None,
+            data_studentcount=None,
+            cwd=str(tmp_path),
+            data_option=DataOption.CUMULATIVE,
+            ci_test_n=None,
+        )
+        pp.data = _make_run_data()
+        with pytest.raises(RuntimeError, match="column_roles.*origin"):
+            pp.save_totaal_audit_trail(StudentYearPrediction.FIRST_YEARS)


### PR DESCRIPTION
Sluit #194.

## Summary

- Elke pipeline-run rowbindt zijn rijen idempotent in `data/output/_totaal_<sy>_<do>.xlsx`. Bestaande rijen met dezelfde `(Collegejaar, Weeknummer, Croho groepeernaam, Herkomst, Examentype)` worden overschreven; nieuwe weken worden toegevoegd.
- `Run_date`-kolom maakt traceerbaar wanneer elke rij is gegenereerd (handig bij modelversie-drift).
- Bestand wordt nooit als input gelezen — de data loader leest enkel paden uit `configuration.json`.
- Per modus apart bestand (volgt bestaande `output_<sy>_<do>.xlsx`-conventie; voorkomt sparse schema's tussen `-d i`/`-d c`/`-d b`).
- `init` maakt `data/output/` aan, geen lege placeholder (kolomschema is mode-afhankelijk; lui aanmaken bij eerste run is schoner).
- CI-modus (`--ci test N`) schrijft géén audittrail — bestaande `ci_test_n is None`-gate in `_save_results` dekt dit af.

## Acceptatiecriteria

- [x] `studentprognose init` maakt `data/output/` aan (geen lege placeholder; bestand ontstaat lui).
- [x] Elke run append zijn rijen; bestaande week wordt overschreven.
- [x] Pipeline leest `_totaal.xlsx` nooit als input.
- [x] Docs op `aan-de-slag.md` en `output-begrijpen.md` bijgewerkt.

## Test plan

- [x] `uv run pytest tests/` → 279 passed (6 nieuwe tests voor de upsert-logica)
- [x] `uvx ruff check` op gewijzigde files → All checks passed
- [x] `bash scripts/test_package.sh` → alle 7 stappen OK, inclusief regressiebewaking dat een tweede identieke run geen rijen dupliceert
- [ ] Reviewer draait `studentprognose -w 11 -y 2024 -d both` gevolgd door `studentprognose -w 12 -y 2024 -d both` en bevestigt dat het audittrail beide weken bevat
- [ ] Reviewer draait `studentprognose -w 12 -y 2024 -d both` twee keer en bevestigt dat de rijen voor week 12 worden overschreven, niet gedupliceerd

## Bekende limieten (gedocumenteerd in output-begrijpen.md)

- Filterwijzigingen tussen runs worden niet gedetecteerd — geen filterhash in v1.
- Modelversie-drift is traceerbaar via `Run_date`, niet vermeden.
- Numerus-fixusvoorspellingen worden net als in de week-output afgekapt; audittrail erft die waarden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)