### PR TITLE
docs: herformuleer 'Wat voorspelt -w 16 -y 2025?' — inschrijvingen, niet-fixus voorbeeld, wekelijks draaien (#193)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -112,9 +112,9 @@ Welke bestanden je dan precies in `data/input/` nodig hebt — en in welk formaa
 
 ## Wat voorspelt `-w 16 -y 2025`?
 
-Voor `studentprognose` is `-w` de **peilweek** (kalenderweek 1–52) en `-y` het **collegejaar** waarvoor je een prognose wilt. Met `-w 16 -y 2025` zeg je dus: *"gebruik alle vooraanmelddata tot en met week 16 van collegejaar 2025 en geef me een prognose voor het eindcohort van datzelfde collegejaar"*.
+Voor `studentprognose` is `-w` de **peilweek** (kalenderweek 1–52) en `-y` het **collegejaar** waarvoor je een prognose wilt. Met `-w 16 -y 2025` zeg je dus: *"gebruik alle vooraanmelddata tot en met week 16 van collegejaar 2025 en geef me een prognose voor het uiteindelijke aantal inschrijvingen voor datzelfde collegejaar"*.
 
-!!! example "Voorbeeld-run · B Psychologie · NL (demodata)"
+!!! example "Voorbeeld-run · B Bedrijfskunde · NL (demodata)"
     **178** vooraanmelders @ wk 16 (peilmoment) &nbsp;→&nbsp; **520** verwacht @ wk 38 &nbsp;→&nbsp; **400** ingeschreven (77% yield)
 
 === "Week voor week"
@@ -127,10 +127,13 @@ Voor `studentprognose` is `-w` de **peilweek** (kalenderweek 1–52) en `-y` het
 
     <iframe src="../assets/plots/whatif_slope.html" width="100%" height="420" frameborder="0" style="border-radius: 8px;"></iframe>
 
-    Drie kerngetallen op één schaal: peilmoment → SARIMA-extrapolatie naar wk 38 → verwacht eindcohort. De badges tussen de punten kwantificeren de overgangen — eerst de groei (×2.92 in vooraanmelders), daarna de yield (77% conversie naar ingeschreven).
+    Drie kerngetallen op één schaal: peilmoment → SARIMA-extrapolatie naar wk 38 → verwachte inschrijvingen. De badges tussen de punten kwantificeren de overgangen — eerst de groei (×2.92 in vooraanmelders), daarna de yield (77% conversie naar ingeschreven).
+
+!!! info "Waarom elke week opnieuw draaien?"
+    Een prognose op één peilweek geeft je het beeld van *dat* moment. Door de pipeline wekelijks te draaien volg je de trends en fluctuaties in vooraanmeldingen mee — bijvoorbeeld het knikpunt rond de 1-mei-deadline of een achterblijvende naloop in de zomer. Zo zie je vroege signalen om je capaciteits- en marketingbeslissingen tijdig bij te sturen, in plaats van pas na het seizoen één eindprognose te hebben.
 
 !!! tip "Andere peilweek of collegejaar?"
-    Vervang `-w 16` door je eigen peilweek (1–52) en `-y 2025` door het collegejaar dat je wilt voorspellen. De pipeline pakt automatisch de data tot en met die week om het eindcohort van datzelfde collegejaar te schatten.
+    Vervang `-w 16` door je eigen peilweek (1–52) en `-y 2025` door het collegejaar dat je wilt voorspellen. De pipeline pakt automatisch de data tot en met die week om het uiteindelijke aantal inschrijvingen voor datzelfde collegejaar te schatten.
 
 ## Eerste run
 


### PR DESCRIPTION
## Summary

Lost issue #193 op: de sectie *"Wat voorspelt `-w 16 -y 2025`?"* in `docs/aan-de-slag.md` was te technisch en gebruikte een misleidend voorbeeld.

- **"Eindcohort" verwijderd (3x)** → vervangen door "uiteindelijke aantal inschrijvingen" / "verwachte inschrijvingen". Formulering blijft expliciet op **inschrijvingen** (niet aanmeldingen) en vermijdt "week 39 / volgend collegejaar" (zit nog in aanmeldseizoen).
- **B Psychologie → B Bedrijfskunde** in het paarse `!!! example`-blok. Psychologie is een fixusopleiding met fundamenteel andere prognose-dynamiek; Bedrijfskunde is een niet-fixus bachelor en zit al in de demodata.
- **Nieuw `!!! info`-blok "Waarom elke week opnieuw draaien?"** toegevoegd tussen de tabs en de configuratie-tip. Legt uit dat je wekelijks draait om trends en fluctuaties in vooraanmeldingen te volgen (1-mei-deadline, zomer-naloop), niet alleen voor één eindprognose.

## Acceptatiecriteria

- [x] Geen "eindcohort" meer in `docs/aan-de-slag.md` — `grep -n "eindcohort" docs/aan-de-slag.md` → 0 matches
- [x] Paarse `!!! example`-blok toont een niet-fixus opleiding (B Bedrijfskunde)
- [x] Sectie bevat een korte toelichting (3 zinnen) over de waarde van wekelijks draaien voor trendanalyse

## Scope

- `docs/aan-de-slag.md` (regels 113–136)
- Plot-iframes (`whatif_timeline.html`, `whatif_slope.html`): gecheckt — bevatten geen "B Psychologie" of "eindcohort", geen rebuild nodig.

## Test plan

- [ ] `uv run mkdocs serve` lokaal bekijken en visueel controleren dat het nieuwe `!!! info`-blok correct rendert
- [ ] Doorlezen op samenhang met de visualisaties (1-mei-deadline en zomer-naloop in tekst vs. plot)

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)