### PR TITLE
docs: Studielink PvL-referentie + volledige input_raw kolomdocumentatie (#201)

### DIFF
--- a/data/input_raw/README.md
+++ b/data/input_raw/README.md
@@ -12,6 +12,12 @@ De meegeleverde bestanden bevatten **synthetische demodata**.
 | `oktober_bestand.xlsx` | Eigen levering instelling (telbestand studenten) | Werkelijke inschrijvingen per opleiding/herkomst/jaar (ground truth) |
 | `individuele_aanmelddata.csv` | SIS / datawarehouse instelling | Per-student aanmeldingen met persoonskenmerken |
 
+## Kolomspecificaties
+
+- **Volledige kolomdefinities per bestand** — zie [`data/metadata/data_dictionary.csv`](../metadata/data_dictionary.csv).
+- **Studielink telbestanden** volgen het officiële *Programma van Levering Telbestand Studielink* (Stichting Studielink, versie Definitief 2.8, 3 november 2022). PDF: <https://www.tignl.eu/downloads/studielink/pvl%20telbestand%20studielink.pdf>. Alle veldverwijzingen (`§5.x`) in de data dictionary verwijzen naar paragrafen in dit document.
+- **Korte versie voor analisten** — zie [`docs/je-data-voorbereiden.md`](../../docs/je-data-voorbereiden.md).
+
 ## Dataflow
 
 ```

--- a/data/metadata/data_dictionary.csv
+++ b/data/metadata/data_dictionary.csv
@@ -43,3 +43,54 @@ MAPE ensemble,Mean Absolute Percentage Error van ensemble: gemiddelde percentage
 MAPE ratio,Mean Absolute Percentage Error van ratio: gemiddelde percentage afwijking.,Gemiddelde(|Voorspelling - Werkelijk| / Werkelijk × 100%),11.8%,Evaluatie,output,output_first-years.xlsx,Float,Percentage (0-100+)
 MAPE sarima cumulative,Mean Absolute Percentage Error van SARIMA cumulative: gemiddelde percentage afwijking.,Gemiddelde(|Voorspelling - Werkelijk| / Werkelijk × 100%),18.3%,Evaluatie,output,output_first-years.xlsx,Float,Percentage (0-100+)
 MAPE sarima individual,Mean Absolute Percentage Error van SARIMA individual: gemiddelde percentage afwijking.,Gemiddelde(|Voorspelling - Werkelijk| / Werkelijk × 100%),,Evaluatie,output,output_first-years.xlsx,Float,Percentage (0-100+) or NaN
+,,,,,,,,
+Brincode,"BRIN-code van de instelling (PvL §5.2). ETL hernoemt naar 'Korte naam instelling'.",-,21PD,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String,4-digit BRIN
+Studiejaar,"Collegejaar waarop de telling betrekking heeft (PvL §5.7). ETL hernoemt naar 'Collegejaar'.",-,2024,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),Integer,YYYY
+Type_HO,"Type hoger onderwijs (PvL §5.5). ETL hernoemt naar 'Type hoger onderwijs'.",-,B,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String (Categorical),B | M | etc.
+Isatcode,"CROHO-code van de opleiding (PvL §5.4). ETL hernoemt naar 'Croho'.",-,56826,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String,6-digit code
+Groepeernaam,Naam van de opleiding (afgeleid/verrijkt veld - niet in PvL). ETL kopieert naar 'Groepeernaam Croho' en 'Naam Croho opleiding Nederlands'.,-,B Bedrijfskunde,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String,Text
+Faculteit,Faculteit van de opleiding (afgeleid/verrijkt veld - niet in PvL). Wordt door de ETL leeg gezet als de kolom ontbreekt.,-,FdM,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String,Alphanumeric code
+Herkomst,"Herkomst student (PvL §5.10). ETL hertaalt naar 'NL' / 'EER' / 'Niet-EER'.",-,N,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String (Categorical),N | E | R
+Hogerejaars,"Indicator hogerejaars (PvL §5.14). ETL hertaalt naar 'Ja' / 'Nee'.",-,N,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String (Boolean),J | N
+Herinschrijving,"Indicator herinschrijving (PvL §5.15). ETL hertaalt naar 'Ja' / 'Nee'.",-,N,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String (Boolean),J | N
+Aantal,"Aantal (voor)aanmeldingen voor deze combinatie van velden (PvL §5.17). ETL hernoemt naar 'Ongewogen vooraanmelders'.",-,25,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),Integer,Non-negative integer
+meercode_V,"Gemiddeld aantal aanmeldingen per student met status V/U/I (PvL §5.12). Gebruikt als deler in Gewogen vooraanmelders = Aantal / meercode_V. Voor status A is deze waarde 0; die rijen worden door de ETL gefilterd.",-,1.29,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),Float,Positive decimal ≥ 1 (of 0 voor status A)
+Status,"Status van de aanmelding (PvL §5.13). Rijen met 'A' worden uit de aggregatie gefilterd.",-,V,Verleden/Heden,input_raw,telbestandY{jaar}W{week}.csv (Studielink),String (Categorical),V | I | U | A
+,,,,,,,,
+Sleutel,Unieke studentidentifier per aanmelding,-,STUD-12345,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Alphanumeric
+Datum Verzoek Inschr,Datum van vooraanmelding (bepaalt de aanmeldweek),-,2024-03-15,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),Date,YYYY-MM-DD
+Ingangsdatum,Ingangsdatum van de inschrijving,-,2024-09-01,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),Date,YYYY-MM-DD
+Collegejaar,Collegejaar van de aanmelding,-,2024,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),Integer,YYYY
+Datum intrekking vooraanmelding,Weeknummer van intrekking (leeg als niet ingetrokken),-,18,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),Integer or empty,1-52
+Inschrijfstatus,Inschrijfstatus; mapping naar 0/1 via configuration.json status_mapping,-,Ingeschreven,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Categorical),Zie status_mapping
+Faculteit,Faculteit van de opleiding,-,FdM,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Alphanumeric code
+Examentype,Type examen,-,Bachelor,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Categorical),Bachelor | Master | Pre-master
+Croho,CROHO-code van de opleiding,-,56826,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,6-digit code
+Croho groepeernaam,Gegroepeerde opleidingsnaam volgens CROHO-indeling,-,B Bedrijfskunde,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+Opleiding,Specifieke opleidingsnaam (variant binnen CROHO-groep),-,Bachelor Bedrijfskunde,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+Hoofdopleiding,Markering hoofdopleiding bij duale studies,-,Ja,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Boolean),Ja | Nee
+Eerstejaars croho jaar,Jaar waarin student eerstejaars is in deze CROHO,-,2024,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),Integer,YYYY
+Is eerstejaars croho opleiding,Indicator eerstejaars binnen deze CROHO-opleiding,-,Ja,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Boolean),Ja | Nee
+Is hogerejaars,Indicator hogerejaars,-,Nee,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Boolean),Ja | Nee
+BBC ontvangen,Indicator BBC (Bewijs van Betaald Collegegeld) ontvangen,-,Ja,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Boolean),Ja | Nee
+Type vooropleiding,Type vooropleiding,-,VWO,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+Nationaliteit,Nationaliteit student,-,Nederlandse,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+EER,EER-indicator,-,Ja,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Boolean),Ja | Nee
+Geslacht,Geslacht student,-,V,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String (Categorical),M | V | O
+Geverifieerd adres postcode,Geverifieerde postcode van het woonadres,-,6525XZ,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Postcode
+Geverifieerd adres plaats,Geverifieerde plaats van het woonadres,-,Nijmegen,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+Geverifieerd adres land,Geverifieerd land van het woonadres,-,Nederland,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+Studieadres postcode,Postcode van het studieadres,-,6525XZ,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Postcode
+Studieadres land,Land van het studieadres,-,Nederland,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+School code eerste vooropleiding,School-code eerste vooropleiding,-,12AB,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Alphanumeric
+School eerste vooropleiding,Naam school eerste vooropleiding,-,Stedelijk Gymnasium,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Text
+Plaats code eerste vooropleiding,Plaats-code eerste vooropleiding,-,NIJ,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,Alphanumeric
+Land code eerste vooropleiding,Land-code eerste vooropleiding,-,NL,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),String,2-letter ISO
+Aantal studenten,Tellerveld (meestal 1 per rij),-,1,Verleden/Heden,input_raw,individuele_aanmelddata.csv (Osiris/Usis),Integer,Non-negative integer
+,,,,,,,,
+Collegejaar,Collegejaar waarop de inschrijving betrekking heeft,-,2024,Verleden,input_raw,oktober_bestand.xlsx (eigen levering instelling),Integer,YYYY
+Groepeernaam Croho,Naam van de opleiding,-,B Bedrijfskunde,Verleden,input_raw,oktober_bestand.xlsx (eigen levering instelling),String,Text
+Aantal eerstejaars croho,Aantal eerstejaars in deze CROHO-opleiding,-,87,Verleden,input_raw,oktober_bestand.xlsx (eigen levering instelling),Integer,Non-negative integer
+EER-NL-nietEER,"Herkomstgroep: NL, EER of Niet-EER",-,NL,Verleden,input_raw,oktober_bestand.xlsx (eigen levering instelling),String (Categorical),NL | EER | Niet-EER
+Examentype code,"Type examen: B (Bachelor) of M (Master)",-,B,Verleden,input_raw,oktober_bestand.xlsx (eigen levering instelling),String (Categorical),B | M
+Aantal Hoofdinschrijvingen,Aantal hoofdinschrijvingen,-,85,Verleden,input_raw,oktober_bestand.xlsx (eigen levering instelling),Integer,Non-negative integer

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -261,7 +261,7 @@ Maakt het mogelijk dat instellingen andere kolomnamen gebruiken dan de kanonieke
 
 Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
 
-`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
+`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `Is hogerejaars`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
 
 ### `oktober` — telbestand studenten
 
@@ -271,7 +271,9 @@ De sleutel heet `oktober` om historische redenen — zie [Je data voorbereiden](
 
 ### `cumulative` — Studielink cumulatieve data
 
-`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
+`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Hogerejaars`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
+
+Dit zijn de kolommen ná de ETL-transformatie (na het inlezen en hernoemen van de ruwe Studielink-velden). Zie [Studielink telbestanden](je-data-voorbereiden.md#studielink-telbestanden) voor de mapping van ruwe PvL-velden naar deze kanonieke namen.
 
 ## `validation` — validatiedrempels overschrijven
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -21,16 +21,27 @@ Map: `data/input_raw/telbestanden/`
 Bestandsnaampatroon: `telbestandY{jaar}W{week}.csv` (bijv. `telbestandY2024W10.csv`) — configureerbaar, zie [Afwijkende bestandsnamen](#afwijkende-bestandsnamen) hieronder.
 Scheidingsteken: `;`
 
-| Kolom | Type | Omschrijving |
-|-------|------|-------------|
-| `Studiejaar` | int | Collegejaar (bijv. `2024`) |
-| `Isatcode` | str | CROHO-code |
-| `Groepeernaam` | str | Naam van de opleiding |
-| `Aantal` | int | Aantal vooraanmelders |
-| `meercode_V` | int | Aantal inschrijfverzoeken/inschrijvingen per student (status V/U/I). Wordt gebruikt als weegfactor in `Gewogen vooraanmelders = Aantal / meercode_V`. Voor status A-rijen is deze waarde 0 — die rijen worden door de ETL uitgefilterd. |
-| `Status` | str | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
-| `Herinschrijving` | str | `J` of `N` |
-| `Herkomst` | str | `N` (Nederland), `E` (EER), `R` (rest) |
+!!! info "Officiële Studielink-specificatie"
+    Studielink levert de telbestanden volgens het *Programma van Levering Telbestand Studielink* (Stichting Studielink, versie Definitief 2.8, 3 november 2022). Dat document beschrijft alle velden, codetabellen en leveringskalender. PDF: [pvl telbestand studielink.pdf](https://www.tignl.eu/downloads/studielink/pvl%20telbestand%20studielink.pdf).
+
+    De §-verwijzingen in de tabel hieronder verwijzen naar paragrafen in dit document. De pipeline gebruikt een **subset** van de PvL-velden (zie [#206](https://github.com/cedanl/studentprognose/issues/206) voor de status van demo-data t.o.v. de volledige PvL).
+
+De velden hieronder zijn de kolommen die de demo-telbestanden bevatten en die de ETL daadwerkelijk inleest:
+
+| Kolom | Type | PvL § | Omschrijving |
+|-------|------|-------|-------------|
+| `Brincode` | str | §5.2 | BRIN-code van de instelling. ETL hernoemt naar `Korte naam instelling`. |
+| `Studiejaar` | int | §5.7 | Collegejaar (bijv. `2024`). ETL hernoemt naar `Collegejaar`. |
+| `Type_HO` | str | §5.5 | Type hoger onderwijs (`B` = Bachelor, `M` = Master, etc.). ETL hernoemt naar `Type hoger onderwijs`. |
+| `Isatcode` | str | §5.4 | CROHO-code van de opleiding. ETL hernoemt naar `Croho`. |
+| `Groepeernaam` | str | — | Naam van de opleiding (afgeleid/verrijkt veld, niet in PvL). ETL kopieert naar `Groepeernaam Croho` én `Naam Croho opleiding Nederlands`. |
+| `Faculteit` | str | — | Faculteit van de opleiding (afgeleid/verrijkt veld, niet in PvL). Wordt door de ETL leeg gezet als de kolom ontbreekt. |
+| `Herkomst` | str | §5.10 | `N` (Nederland), `E` (EER), `R` (rest). ETL hertaalt naar `NL` / `EER` / `Niet-EER`. |
+| `Hogerejaars` | str | §5.14 | `J` of `N`. ETL hertaalt naar `Ja` / `Nee`. |
+| `Herinschrijving` | str | §5.15 | `J` of `N`. ETL hertaalt naar `Ja` / `Nee`. |
+| `Aantal` | int | §5.17 | Aantal (voor)aanmeldingen. ETL hernoemt naar `Ongewogen vooraanmelders`. |
+| `meercode_V` | int | §5.12 | Gemiddeld aantal aanmeldingen per student met status V/U/I. Wordt door de ETL als deler gebruikt: `Gewogen vooraanmelders = Aantal / meercode_V`. Voor status A-rijen is deze waarde 0 — die rijen worden door de ETL uitgefilterd. |
+| `Status` | str | §5.13 | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
 
 #### Afwijkende bestandsnamen
 
@@ -50,27 +61,45 @@ Placeholders zijn `{year}` (vier cijfers) en `{week}` (één of twee cijfers). A
 ### Individuele aanmelddata
 
 Pad: `data/input_raw/individuele_aanmelddata.csv`
-Bron: Osiris / Usis
+Bron: Osiris / Usis (Studenten Informatie Systeem of datawarehouse van jouw instelling)
 Scheidingsteken: `;`
 
-Verplichte kolommen (kanonieke namen — pas aan via `configuration.json` als jouw instelling andere namen gebruikt):
+Volledige kolommenlijst (kanonieke namen — pas aan via `configuration.json` als jouw instelling andere namen gebruikt). De *Rol* geeft aan hoe de pipeline het veld gebruikt: **sleutel** = unieke identifier per aanmelding; **basis** = gebruikt door alle individuele stappen (filtering, deadlinebepaling, output-aggregatie); **classifier** = feature in het XGBoost classifier-model voor inschrijfkans; **info** = wel ingelezen, niet door modellen gebruikt.
 
-| Canonieke naam | Omschrijving |
-|----------------|-------------|
-| `Sleutel` | Unieke studentidentifier |
-| `Datum Verzoek Inschr` | Datum van vooraanmelding |
-| `Ingangsdatum` | Ingangsdatum inschrijving |
-| `Collegejaar` | Collegejaar |
-| `Datum intrekking vooraanmelding` | Weeknummer van intrekking (leeg als niet ingetrokken) |
-| `Inschrijfstatus` | Zie `status_mapping` in configuratie |
-| `Faculteit` | Faculteit |
-| `Examentype` | `Bachelor` of `Master` |
-| `Croho` | CROHO-code |
-| `Croho groepeernaam` | Naam van de opleiding |
-| `Nationaliteit` | Nationaliteit student |
-| `EER` | EER-indicator |
-| `Geslacht` | Geslacht |
-| `Type vooropleiding` | Type vooropleiding |
+| Canonieke naam | Rol | Omschrijving |
+|----------------|------|-------------|
+| `Sleutel` | sleutel | Unieke studentidentifier |
+| `Datum Verzoek Inschr` | basis | Datum van vooraanmelding (bepaalt aanmeldweek) |
+| `Ingangsdatum` | basis | Ingangsdatum inschrijving |
+| `Collegejaar` | basis, classifier | Collegejaar |
+| `Datum intrekking vooraanmelding` | basis | Weeknummer van intrekking (leeg als niet ingetrokken) |
+| `Inschrijfstatus` | basis | Zie `status_mapping` in configuratie |
+| `Faculteit` | classifier | Faculteit |
+| `Examentype` | basis, classifier | `Bachelor` of `Master` |
+| `Croho` | basis | CROHO-code |
+| `Croho groepeernaam` | basis, classifier | Naam van de opleiding |
+| `Opleiding` | classifier | Specifieke opleidingsnaam (variant binnen CROHO-groep) |
+| `Hoofdopleiding` | info | Markering hoofdopleiding bij duale studies |
+| `Eerstejaars croho jaar` | basis | Jaar waarin student eerstejaars is in deze CROHO |
+| `Is eerstejaars croho opleiding` | basis | Indicator eerstejaars binnen deze CROHO-opleiding |
+| `Is hogerejaars` | basis | Indicator of student hogerejaars is (`Ja` / `Nee`) |
+| `BBC ontvangen` | info | Indicator BBC (Bewijs van Betaald Collegegeld) ontvangen |
+| `Type vooropleiding` | classifier | Type vooropleiding |
+| `Nationaliteit` | classifier | Nationaliteit student |
+| `EER` | classifier | EER-indicator |
+| `Geslacht` | classifier | Geslacht |
+| `Geverifieerd adres postcode` | classifier | Geverifieerde postcode woonadres |
+| `Geverifieerd adres plaats` | classifier | Geverifieerde plaats woonadres |
+| `Geverifieerd adres land` | classifier | Geverifieerd land woonadres |
+| `Studieadres postcode` | classifier | Postcode studieadres |
+| `Studieadres land` | classifier | Land studieadres |
+| `School code eerste vooropleiding` | classifier | School-code eerste vooropleiding |
+| `School eerste vooropleiding` | classifier | Naam school eerste vooropleiding |
+| `Plaats code eerste vooropleiding` | classifier | Plaats-code eerste vooropleiding |
+| `Land code eerste vooropleiding` | classifier | Land-code eerste vooropleiding |
+| `Aantal studenten` | basis | Tellerveld (meestal `1` per rij) |
+
+De classifier-features (`numeric`/`categorical`) zijn instelbaar in `configuration.json` onder `model_features.classifier` — zie [Configuratie](configuratie.md#columns-kolomnamen-mapping). Velden met rol *info* mogen leeg of ontbrekend zijn zonder dat het model breekt.
 
 ### Telbestand studenten
 


### PR DESCRIPTION
Closes #201.

## Summary

- **Officiële Studielink-referentie toegevoegd.** Link naar *Programma van Levering Telbestand Studielink* (Stichting Studielink, v2.8 - 03-11-2022) in `docs/je-data-voorbereiden.md` en `data/input_raw/README.md`. PDF: <https://www.tignl.eu/downloads/studielink/pvl%20telbestand%20studielink.pdf>.
- **Input_raw kolommen volledig in MkDocs.** Studielink telbestand-tabel van 8 naar 12 kolommen (Brincode, Type_HO, Faculteit, Hogerejaars ontbraken) met PvL §-verwijzingen per veld. Individuele aanmelddata van 14 naar 30 kolommen met *Rol*-kolom (sleutel/basis/classifier/info) zodat analisten zien hoe elk veld door de pipeline wordt gebruikt.
- **Input_raw kolommen in data dictionary.** 48 nieuwe rijen in `data/metadata/data_dictionary.csv` (12 telbestand + 30 individueel + 6 oktober) met PvL §-referenties waar relevant.
- **Config ↔ docs in sync getrokken.** `Hogerejaars` toegevoegd aan `cumulative`-lijst en `Is hogerejaars` aan `individual`-lijst in `docs/configuratie.md` (stonden wel in `configuration/configuration.json` maar ontbraken in docs).

## Acceptatiecriteria #201

- [x] Kolomnamen van `input_raw` staan in de data dictionary
- [x] Kolomnamen van `input_raw` staan in MkDocs
- [x] URL naar Studielink teldata is opgenomen als referentie
- [x] Cumulative config-kolommen zijn vergeleken met MkDocs en gelijkgetrokken
- [x] Idem voor Studielink-telbestanden

## Cross-check (geverifieerd met script)

| Sectie | docs ↔ `configuration.json` |
|--------|------------------------------|
| `cumulative` | 16/16 in sync |
| `individual` | 30/30 in sync |
| `oktober` | 6/6 in sync |

| Bestand | data dictionary ↔ demo file |
|---------|------------------------------|
| Studielink telbestand | 12/12 in sync |
| `individuele_aanmelddata.csv` | 30/30 in sync |
| `oktober_bestand.xlsx` | 6/6 in sync |

## Test plan

- [x] `uv run pytest` — 325 passed
- [x] `uv run mkdocs build --strict` — bouwt; nieuwe interne anchor (`#columns-kolomnamen-mapping`) werkt. De 4 resterende anchor-warnings zijn pre-existing op `main` en out-of-scope voor deze PR.
- [ ] Reviewer: open de docs lokaal (`uv run mkdocs serve`) en bekijk `docs/je-data-voorbereiden.md` en `docs/configuratie.md`.

## Gerelateerd

Issue #206 (demo-telbestanden vs PvL-spec) wordt aangehaald in de docs als context voor analisten die zich afvragen waarom de demo een subset van de PvL-velden bevat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)