### PR TITLE
fix: save_output=False schrijft geen output_prelim_<modus>.xlsx meer naar disk (#219)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -254,7 +254,7 @@ result = run_pipeline_from_dataframes(
     week=10,
     data_cumulative=df_cum,
     dataset=DataOption.CUMULATIVE,
-    save_output=False,  # geen lokale uitvoerbestanden aanmaken
+    save_output=False,  # geen lokale uitvoerbestanden aanmaken (ook geen tussenresultaat)
 )
 
 if result is not None:

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -256,7 +256,7 @@ def _run_pipeline_core(cfg, datasets, configuration, filtering, cwd, save_output
     _print_summary(datasets, cfg, strategy)
     for year in cfg.years:
         for week in cfg.weeks:
-            _predict_and_postprocess(strategy, cfg, data_cumulative, year, week)
+            _predict_and_postprocess(strategy, cfg, data_cumulative, year, week, save_output)
 
     # Step 7: Save output
     if save_output:
@@ -422,7 +422,7 @@ def _preprocess(strategy, student_year_prediction):
         return None
 
 
-def _predict_and_postprocess(strategy, cfg, data_cumulative, year, week):
+def _predict_and_postprocess(strategy, cfg, data_cumulative, year, week, save_output: bool = True):
     if cfg.student_year_prediction in (
         StudentYearPrediction.FIRST_YEARS,
         StudentYearPrediction.VOLUME,
@@ -446,6 +446,8 @@ def _predict_and_postprocess(strategy, cfg, data_cumulative, year, week):
                 data_cumulative,
                 cfg.skip_years,
             )
+            if save_output:
+                strategy.postprocessor.save_output_prelim()
             if cfg.data_option in (DataOption.CUMULATIVE, DataOption.BOTH_DATASETS):
                 strategy.postprocessor.predict_with_ratio(data_cumulative, year)
                 strategy.postprocessor.add_applicant_data(data_cumulative, year, week)

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -165,6 +165,14 @@ class PostProcessor:
         return data
 
     def prepare_data_for_output_prelim(self, data, year, week, data_cumulative=None, skip_years=0):
+        """Bereken het voorlopige tussenresultaat in ``self.data`` (numerus-fixus-cap,
+        kolomselectie en merges met studentaantallen/cumulatieve aanmelddata).
+
+        Deze methode is puur compute: ze schrijft niets naar schijf. Het wegschrijven
+        gebeurt in :meth:`save_output_prelim`, die de pipeline alleen aanroept wanneer
+        ``save_output=True``. Zo blijft een puur in-memory run (bijv. cloud-pipelines
+        met een read-only bestandssysteem) vrij van disk-writes.
+        """
         self.data = data
         self.data = self._numerus_fixus_cap(self.data, year, week)
 
@@ -210,8 +218,25 @@ class PostProcessor:
                 how="left",
             )
 
+    def save_output_prelim(self):
+        """Schrijf het voorlopige tussenresultaat naar
+        ``data/output/output_prelim_<modus>.xlsx``.
+
+        Gescheiden van :meth:`prepare_data_for_output_prelim` zodat de berekening
+        (numerus-fixus-cap + merges) los staat van de I/O. De pipeline roept deze
+        methode alleen aan wanneer ``save_output=True``; bij een puur in-memory run
+        (``save_output=False``) wordt er niets geschreven — net zoals bij de overige
+        outputs (:meth:`save_output`, :meth:`save_totaal_audit_trail`, dashboard).
+        """
+        if self.data is None:
+            return
         ci_suffix = f"_ci_test_N{self.ci_test_n}" if self.ci_test_n is not None else ""
-        output_path = os.path.join(self.CWD, "data", "output", f"output_prelim_{self.data_option.filename_suffix}{ci_suffix}.xlsx")
+        output_path = os.path.join(
+            self.CWD,
+            "data",
+            "output",
+            f"output_prelim_{self.data_option.filename_suffix}{ci_suffix}.xlsx",
+        )
         self.data.to_excel(output_path, index=False)
 
     def predict_with_ratio(self, data_cumulative, predict_year):

--- a/tests/studentprognose/test_api.py
+++ b/tests/studentprognose/test_api.py
@@ -1,6 +1,8 @@
 """Tests for the public Python API exported from studentprognose.__init__."""
 
 import importlib
+
+import pandas as pd
 import pytest
 
 
@@ -69,6 +71,105 @@ def test_run_pipeline_from_dataframes_rejects_final_week():
 
     with pytest.raises(ValueError, match=str(FINAL_ACADEMIC_WEEK)):
         run_pipeline_from_dataframes(year=2025, week=FINAL_ACADEMIC_WEEK)
+
+
+def _make_prediction_frame():
+    """Minimale voorspelling met exact de kolommen die de postprocessor selecteert."""
+    return pd.DataFrame({
+        "Croho groepeernaam": ["B Foo"],
+        "Faculteit":          ["FdM"],
+        "Examentype":         ["Bachelor"],
+        "Collegejaar":        [2025],
+        "Herkomst":           ["NL"],
+        "Weeknummer":         [10],
+        "SARIMA_cumulative":  [100.0],
+        "SARIMA_individual":  [110.0],
+        "Voorspelde vooraanmelders": [120.0],
+    })
+
+
+def _install_fake_strategy(monkeypatch, data_option):
+    """Vervang create_strategy door een lichtgewicht fake.
+
+    Doel: de save_output-gating in de orchestratielaag end-to-end via de publieke
+    ``run_pipeline_from_dataframes`` testen, zónder de zware SARIMA/XGBoost-compute
+    (conform de projectconventie dat unit tests de volledige pipeline niet draaien).
+    De fake gebruikt een ECHTE PostProcessor, zodat de echte ``save_output_prelim``-
+    schrijfpoging daadwerkelijk wordt gegate.
+    """
+    import studentprognose.main as main_mod
+    from studentprognose.config import load_defaults
+    from studentprognose.output.postprocessor import PostProcessor
+
+    class _FakeStrategy:
+        def __init__(self, cwd, opt):
+            configuration = load_defaults()
+            self.postprocessor = PostProcessor(
+                configuration=configuration,
+                data_latest=None,
+                ensemble_weights=None,
+                data_studentcount=None,
+                cwd=cwd,
+                data_option=opt,
+                ci_test_n=None,
+            )
+            self.numerus_fixus_list = configuration["numerus_fixus"]
+            self.programme_filtering = []
+
+        def preprocess(self):
+            return None
+
+        def set_filtering(self, *args, **kwargs):
+            pass
+
+        def predict_nr_of_students(self, year, week, skip_years=0):
+            return _make_prediction_frame()
+
+    def _fake_create_strategy(cfg, datasets, configuration, cwd):
+        return _FakeStrategy(cwd, cfg.data_option)
+
+    monkeypatch.setattr(main_mod, "create_strategy", _fake_create_strategy)
+
+
+@pytest.mark.parametrize("save_output, expect_files", [(False, False), (True, True)])
+def test_run_pipeline_respects_save_output(tmp_path, monkeypatch, save_output, expect_files):
+    """save_output=False schrijft niets naar data/output/; save_output=True wel (issue #219)."""
+    from studentprognose import run_pipeline_from_dataframes, DataOption
+
+    _install_fake_strategy(monkeypatch, DataOption.INDIVIDUAL)
+    # tmp_path als cwd: zowel check_output_writable (os.getcwd()) als de
+    # postprocessor (self.CWD) schrijven dan binnen tmp_path.
+    monkeypatch.chdir(tmp_path)
+
+    data_individual = pd.DataFrame({
+        "Collegejaar": [2025],
+        "Croho groepeernaam": ["B Foo"],
+    })
+
+    run_pipeline_from_dataframes(
+        year=2025,
+        week=10,
+        data_individual=data_individual,
+        dataset=DataOption.INDIVIDUAL,
+        save_output=save_output,
+    )
+
+    output_dir = tmp_path / "data" / "output"
+    written = {p.name for p in output_dir.glob("*")} if output_dir.exists() else set()
+
+    if expect_files:
+        # Criterium: bij save_output=True blijven álle outputtypen behouden —
+        # het tussenresultaat, het eindresultaat én de audittrail.
+        expected = {
+            "output_prelim_individueel.xlsx",
+            "output_first-years_individueel.xlsx",
+            "_totaal_first-years_individueel.xlsx",
+        }
+        assert expected <= written, f"ontbrekende outputs: {expected - written}"
+    else:
+        assert written == set(), (
+            f"save_output=False mag niets schrijven, maar vond {sorted(written)}"
+        )
 
 
 def test_all_exports_present():

--- a/tests/studentprognose/test_postprocessor.py
+++ b/tests/studentprognose/test_postprocessor.py
@@ -151,6 +151,42 @@ class TestStudentcountMergeWithFaculteit:
         assert pp.data["Faculteit"].iloc[0] == "FdM"
 
 
+class TestOutputPrelimWriteIsGated:
+    """Bewaakt de compute/I-O-splitsing van het voorlopige tussenresultaat (issue #219).
+
+    ``prepare_data_for_output_prelim`` is puur compute en mag niets wegschrijven; het
+    wegschrijven gebeurt expliciet via ``save_output_prelim``. Zo blijft een
+    ``save_output=False``-run vrij van disk-writes.
+    """
+
+    def _output_dir(self, tmp_path):
+        return tmp_path / "data" / "output"
+
+    def test_prepare_does_not_write_any_file(self, tmp_path):
+        pp = _make_postprocessor(tmp_path, data_studentcount=None)
+        pp.prepare_data_for_output_prelim(_make_input_data(), year=2024, week=10)
+
+        # Compute is uitgevoerd...
+        assert pp.data is not None
+        # ...maar er is niets weggeschreven.
+        assert list(self._output_dir(tmp_path).glob("*")) == []
+
+    def test_save_output_prelim_writes_file(self, tmp_path):
+        pp = _make_postprocessor(tmp_path, data_studentcount=None)
+        pp.prepare_data_for_output_prelim(_make_input_data(), year=2024, week=10)
+        pp.save_output_prelim()
+
+        expected = self._output_dir(tmp_path) / "output_prelim_cumulatief.xlsx"
+        assert expected.exists()
+
+    def test_save_output_prelim_without_data_is_noop(self, tmp_path):
+        pp = _make_postprocessor(tmp_path, data_studentcount=None)
+        pp.data = None
+        pp.save_output_prelim()
+
+        assert list(self._output_dir(tmp_path).glob("*")) == []
+
+
 def _make_run_data(year=2024, week=10, sarima_cumulative=(100.0, 50.0)):
     """Bouw een minimale prognose-DataFrame met de standaard sleutelkolommen."""
     return pd.DataFrame({


### PR DESCRIPTION
## Wat & waarom

Closes #219.

`prepare_data_for_output_prelim` mengde **compute en I/O**: het tussenresultaat `output_prelim_<modus>.xlsx` werd **onvoorwaardelijk** weggeschreven, óók bij `save_output=False`. In een read-only omgeving (AWS Lambda, Azure Function, Databricks zonder lokaal volume) crashte de pipeline daardoor op precies de schrijfactie die de gebruiker met `save_output=False` wilde overslaan.

## Aanpak (Optie 2 uit de issue — compute/I-O-splitsing)

- `prepare_data_for_output_prelim` → **puur compute** (geen disk-write meer).
- Nieuwe `save_output_prelim()` → de write, met `if self.data is None`-guard; spiegelt de bestaande `save_output()`.
- `main.py:_predict_and_postprocess` roept `save_output_prelim()` aan **op exact hetzelfde call-punt**, gegate met `if save_output:`. Daardoor blijft de inhoud bij `save_output=True` byte-identiek en zit de gate centraal bij de andere gates (`check_output_writable`, `_save_results`).

Geverifieerd: de prelim was via `grep` op alle `to_excel`/`makedirs`/`open` de **enige** ongate'de write in het compute-pad — alle overige outputs zaten al achter `save_output`.

## Acceptatiecriteria

- [x] `save_output=False` → geen bestanden in `data/output/` aangemaakt/overschreven
- [x] `save_output=True` → identiek gedrag (`output_prelim_*`, `output_*`, `_totaal_*` worden geschreven)
- [x] `check_output_writable` alleen bij `save_output=True` (ongewijzigd)
- [x] Nieuwe test in `tests/studentprognose/test_api.py` met `tmp_path` als cwd
- [x] Docstring `run_pipeline_from_dataframes` blijft inhoudelijk kloppen (ongewijzigd)

## Tests

- `test_postprocessor.py`: `prepare_*` schrijft niets / `save_output_prelim()` schrijft wel / None-guard is no-op.
- `test_api.py`: geparametriseerde end-to-end gate-test via `run_pipeline_from_dataframes` (fake-strategy om SARIMA/XGBoost te vermijden, conform de conventie dat unit tests de volledige pipeline niet draaien) — `False` ⇒ `data/output/` leeg, `True` ⇒ alle drie de outputtypen aanwezig.
- `uv run pytest` → **330 passed**. `ruff check` → clean.

## Docs-check (CLAUDE.md-tabel doorlopen — verplicht)

| Geraakt | Pagina | Actie |
|---|---|---|
| `main.py` (gating) | `docs/aan-de-slag.md` | `save_output=False`-comment gepreciseerd: "ook geen tussenresultaat" |
| Outputbestanden/schema | `docs/output-begrijpen.md` | prelim-bestand + schema ongewijzigd → geen wijziging nodig |

🤖 Generated with [Claude Code](https://claude.com/claude-code)