### PR TITLE
fix: valideer year/week in run_pipeline_from_dataframes (#218)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -280,6 +280,27 @@ result = run_pipeline_from_dataframes(
 )
 ```
 
+!!! warning "`year`/`week` moeten binnen je trainingsdata vallen"
+    `run_pipeline_from_dataframes` controleert — net als de CLI — of `year` en `week`
+    voorkomen in de meegegeven DataFrames. Valt een van beide buiten bereik, dan krijg je
+    een heldere `ValueError` met de wél beschikbare range, in plaats van een stille `None`
+    of een onverwachte kernel-crash in een notebook.
+
+    ```python
+    # Stel: je data loopt t/m 2025
+    run_pipeline_from_dataframes(
+        year=2030,            # buiten bereik
+        week=10,
+        data_cumulative=df_cum,
+        dataset=DataOption.CUMULATIVE,
+    )
+    # ValueError: year=2030 valt buiten de beschikbare trainingsdata.
+    #   Beschikbare data: jaren 2018-2025, weken 1-52.
+    #   Pas year/week aan binnen deze range, of voeg trainingsdata toe.
+    ```
+
+    Pas `year`/`week` aan binnen de range, of voeg aanvullende trainingsdata toe.
+
 ## Bekende valkuil: stille modus-downgrade
 
 !!! warning "Let op bij `-d b`"

--- a/src/studentprognose/data/range_check.py
+++ b/src/studentprognose/data/range_check.py
@@ -1,0 +1,123 @@
+"""Range-validatie van gevraagde year/week tegen de geladen trainingsdata.
+
+Draait *ná* het laden van de DataFrames — anders dan ``data/validation.py``, dat
+ruwe inputbestanden *vóór* de ETL op datakwaliteit controleert. Dit module checkt
+of de gevraagde ``year``/``week``-combinatie binnen de beschikbare
+``Collegejaar``/``Weeknummer``-range valt.
+
+Pure laag: detecteren en tekst formatteren, géén side effects. De CLI
+(``sys.exit``) en de API (``raise ValueError``) in ``main.py`` beslissen zelf
+hoe ze op een mismatch reageren, bovenop hetzelfde detectieresultaat.
+"""
+
+from typing import NamedTuple, Optional
+
+import pandas as pd
+
+
+class DataRangeMismatch(NamedTuple):
+    """Resultaat van de range-detectie: welke jaren/weken ontbreken en wat wél beschikbaar is."""
+
+    year_range: str  # "2018-2025" of "2025"
+    week_range: str  # "1-52", "10", of "n.v.t." (individueel: geen Weeknummer-kolom)
+    missing_years: list[int]
+    missing_weeks: list[int]
+
+
+def detect_data_range_mismatch(
+    datasets: tuple[Optional[pd.DataFrame], ...],
+    years: list[int],
+    weeks: list[int],
+) -> Optional[DataRangeMismatch]:
+    """Detecteer of gevraagde jaren/weken buiten de beschikbare trainingsdata vallen.
+
+    Pure functie: schrijft niets, beëindigt niets, gooit niets. Geeft ``None`` terug
+    wanneer alles binnen bereik valt (of er geen bruikbare data is), anders een
+    ``DataRangeMismatch`` met de beschikbare range en de ontbrekende waarden. Zowel het
+    CLI-pad (``main._check_data_range``) als het API-pad
+    (``main.run_pipeline_from_dataframes``) bouwen hun eigen melding bovenop dit resultaat.
+
+    Args:
+        datasets: Tuple waarvan de eerste twee elementen ``data_individual`` en
+            ``data_cumulative`` zijn (langere tuples worden via ``*_`` genegeerd).
+        years: Gevraagde jaren.
+        weeks: Gevraagde weken.
+    """
+    data_individual, data_cumulative, *_ = datasets
+
+    # Pick whichever dataset is loaded based on the chosen mode
+    data = data_cumulative if data_cumulative is not None else data_individual
+    if data is None:
+        return None
+
+    available_years = sorted(int(y) for y in data["Collegejaar"].dropna().unique())
+    if not available_years:
+        return None
+
+    missing_years = [y for y in years if y not in available_years]
+
+    # Individual dataset has no Weeknummer column before preprocessing
+    if "Weeknummer" in data.columns:
+        available_weeks = sorted(int(w) for w in data["Weeknummer"].dropna().unique())
+        missing_weeks = [w for w in weeks if w not in available_weeks]
+    else:
+        available_weeks = []
+        missing_weeks = []
+
+    if not (missing_years or missing_weeks):
+        return None
+
+    year_range = _format_range(available_years)
+    # "n.v.t." voorkomt een IndexError op available_weeks[0] wanneer er (nog) geen
+    # weken bekend zijn (individuele dataset vóór preprocessing).
+    week_range = _format_range(available_weeks) if available_weeks else "n.v.t."
+
+    return DataRangeMismatch(year_range, week_range, missing_years, missing_weeks)
+
+
+def _format_range(values: list[int]) -> str:
+    """Formatteer een gesorteerde lijst als ``"min-max"`` (of ``"x"`` bij één waarde)."""
+    return f"{values[0]}-{values[-1]}" if len(values) > 1 else str(values[0])
+
+
+def _format_available(mismatch: DataRangeMismatch) -> str:
+    """Beschrijf de beschikbare data; laat weken weg als die niet bepaald kunnen worden."""
+    if mismatch.week_range == "n.v.t.":
+        return f"jaren {mismatch.year_range}"
+    return f"jaren {mismatch.year_range}, weken {mismatch.week_range}"
+
+
+def format_cli_range_warning(mismatch: DataRangeMismatch) -> str:
+    """Bouw de meerregelige CLI-waarschuwing uit een ``DataRangeMismatch``."""
+    if mismatch.week_range == "n.v.t.":
+        adjust_line = f"  Pas je flags aan tussen -y {mismatch.year_range},"
+    else:
+        adjust_line = (
+            f"  Pas je flags aan tussen -y {mismatch.year_range} "
+            f"en -w {mismatch.week_range},"
+        )
+
+    return "\n".join(
+        [
+            "\nWaarschuwing: de gevraagde combinatie is niet (volledig) beschikbaar in de data.",
+            f"  Beschikbare data: {_format_available(mismatch)}.",
+            adjust_line,
+            "  of voeg nieuwe trainingsdata toe in data/input_raw/ om je gewenste tijdstip te voorspellen.",
+        ]
+    )
+
+
+def format_api_range_error(year: int, week: int, mismatch: DataRangeMismatch) -> str:
+    """Bouw de ValueError-tekst voor het API-pad uit een ``DataRangeMismatch``."""
+    if mismatch.missing_years and mismatch.missing_weeks:
+        subject = f"year={year} en week={week} vallen buiten de beschikbare trainingsdata."
+    elif mismatch.missing_years:
+        subject = f"year={year} valt buiten de beschikbare trainingsdata."
+    else:
+        subject = f"week={week} valt buiten de beschikbare trainingsdata."
+
+    return (
+        f"{subject}\n"
+        f"  Beschikbare data: {_format_available(mismatch)}.\n"
+        "  Pas year/week aan binnen deze range, of voeg trainingsdata toe."
+    )

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-from typing import NamedTuple, Optional
+from typing import Optional
 
 import pandas as pd
 
@@ -9,6 +9,11 @@ from studentprognose.cli import PipelineConfig, parse_args
 from studentprognose.config import load_configuration, load_defaults_filtering, load_filtering
 from studentprognose.data.loader import load_data
 from studentprognose.data.prediction_validator import run_pre_prediction_checks
+from studentprognose.data.range_check import (
+    detect_data_range_mismatch,
+    format_api_range_error,
+    format_cli_range_warning,
+)
 from studentprognose.utils.ci_subset import apply_ci_test_subset
 from studentprognose.output.postprocessor import PostProcessor
 from studentprognose.output.dashboard import DashboardBuilder
@@ -185,11 +190,11 @@ def run_pipeline_from_dataframes(
     # buiten de range van de meegegeven data valt, in plaats van een stille None of een
     # kernel-crash verderop in de pipeline. Draait vóór config-werk (fail fast); de
     # 2-tuple wordt door de detector via `*_` afgehandeld.
-    mismatch = _detect_data_range_mismatch(
+    mismatch = detect_data_range_mismatch(
         (data_individual, data_cumulative), [year], [week]
     )
     if mismatch is not None:
-        raise ValueError(_format_api_range_error(year, week, mismatch))
+        raise ValueError(format_api_range_error(year, week, mismatch))
 
     if configuration is None:
         configuration = load_defaults()
@@ -316,110 +321,14 @@ def _apply_auto_defaults(datasets, cfg):
         print("Geef -w en -y mee om een andere combinatie te gebruiken.")
 
 
-class DataRangeMismatch(NamedTuple):
-    """Resultaat van de range-detectie: welke jaren/weken ontbreken en wat wél beschikbaar is."""
-
-    year_range: str  # "2018-2025" of "2025"
-    week_range: str  # "1-52", "10", of "n.v.t." (individueel: geen Weeknummer-kolom)
-    missing_years: list[int]
-    missing_weeks: list[int]
-
-
-def _detect_data_range_mismatch(datasets, years, weeks) -> Optional[DataRangeMismatch]:
-    """Detecteer of gevraagde jaren/weken buiten de beschikbare trainingsdata vallen.
-
-    Pure functie: schrijft niets, beëindigt niets, gooit niets. Geeft ``None`` terug
-    wanneer alles binnen bereik valt (of er geen bruikbare data is), anders een
-    ``DataRangeMismatch`` met de beschikbare range en de ontbrekende waarden. Zowel het
-    CLI-pad (``_check_data_range``) als het API-pad (``run_pipeline_from_dataframes``)
-    bouwen hun eigen melding bovenop dit resultaat.
-
-    Args:
-        datasets: Tuple waarvan de eerste twee elementen ``data_individual`` en
-            ``data_cumulative`` zijn (langere tuples worden via ``*_`` genegeerd).
-        years: Gevraagde jaren.
-        weeks: Gevraagde weken.
-    """
-    data_individual, data_cumulative, *_ = datasets
-
-    # Pick whichever dataset is loaded based on the chosen mode
-    data = data_cumulative if data_cumulative is not None else data_individual
-    if data is None:
-        return None
-
-    available_years = sorted(int(y) for y in data["Collegejaar"].dropna().unique())
-    if not available_years:
-        return None
-
-    missing_years = [y for y in years if y not in available_years]
-
-    # Individual dataset has no Weeknummer column before preprocessing
-    if "Weeknummer" in data.columns:
-        available_weeks = sorted(int(w) for w in data["Weeknummer"].dropna().unique())
-        missing_weeks = [w for w in weeks if w not in available_weeks]
-    else:
-        available_weeks = []
-        missing_weeks = []
-
-    if not (missing_years or missing_weeks):
-        return None
-
-    year_range = _format_range(available_years)
-    # "n.v.t." voorkomt een IndexError op available_weeks[0] wanneer er (nog) geen
-    # weken bekend zijn (individuele dataset vóór preprocessing).
-    week_range = _format_range(available_weeks) if available_weeks else "n.v.t."
-
-    return DataRangeMismatch(year_range, week_range, missing_years, missing_weeks)
-
-
-def _format_range(values) -> str:
-    """Formatteer een gesorteerde lijst als ``"min-max"`` (of ``"x"`` bij één waarde)."""
-    return f"{values[0]}-{values[-1]}" if len(values) > 1 else str(values[0])
-
-
-def _format_available(mismatch) -> str:
-    """Beschrijf de beschikbare data; laat weken weg als die niet bepaald kunnen worden."""
-    if mismatch.week_range == "n.v.t.":
-        return f"jaren {mismatch.year_range}"
-    return f"jaren {mismatch.year_range}, weken {mismatch.week_range}"
-
-
 def _check_data_range(datasets, cfg):
     """Check if requested years/weeks exist in the loaded data and exit (CLI-pad) if not."""
-    mismatch = _detect_data_range_mismatch(datasets, cfg.years, cfg.weeks)
+    mismatch = detect_data_range_mismatch(datasets, cfg.years, cfg.weeks)
     if mismatch is None:
         return
 
-    print(
-        "\nWaarschuwing: de gevraagde combinatie is niet (volledig) beschikbaar in de data."
-    )
-    print(f"  Beschikbare data: {_format_available(mismatch)}.")
-    if mismatch.week_range == "n.v.t.":
-        print(f"  Pas je flags aan tussen -y {mismatch.year_range},")
-    else:
-        print(
-            f"  Pas je flags aan tussen -y {mismatch.year_range} en -w {mismatch.week_range},"
-        )
-    print(
-        "  of voeg nieuwe trainingsdata toe in data/input_raw/ om je gewenste tijdstip te voorspellen."
-    )
+    print(format_cli_range_warning(mismatch))
     sys.exit(1)
-
-
-def _format_api_range_error(year, week, mismatch) -> str:
-    """Bouw de ValueError-tekst voor het API-pad uit een ``DataRangeMismatch``."""
-    if mismatch.missing_years and mismatch.missing_weeks:
-        subject = f"year={year} en week={week} vallen buiten de beschikbare trainingsdata."
-    elif mismatch.missing_years:
-        subject = f"year={year} valt buiten de beschikbare trainingsdata."
-    else:
-        subject = f"week={week} valt buiten de beschikbare trainingsdata."
-
-    return (
-        f"{subject}\n"
-        f"  Beschikbare data: {_format_available(mismatch)}.\n"
-        "  Pas year/week aan binnen deze range, of voeg trainingsdata toe."
-    )
 
 
 def _print_summary(datasets, cfg, strategy):

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import pandas as pd
 
@@ -151,6 +151,12 @@ def run_pipeline_from_dataframes(
         Het gepostprocessde voorspellings-DataFrame, of ``None`` als geen rijen
         overeenkwamen met de filters of voorspellingscriteria.
 
+    Raises:
+        ValueError: Als ``week`` gelijk is aan ``FINAL_ACADEMIC_WEEK`` (laatste week
+            van het academisch jaar), of als ``year``/``week`` buiten de range van de
+            meegegeven trainingsdata valt. De melding toont de wél beschikbare jaren
+            en weken, zodat je year/week kunt bijstellen of trainingsdata kunt toevoegen.
+
     Example::
 
         import pandas as pd
@@ -174,6 +180,16 @@ def run_pipeline_from_dataframes(
             f"week {FINAL_ACADEMIC_WEEK} is de laatste week van het academisch jaar. "
             f"Kies een eerdere week, bijvoorbeeld week {FINAL_ACADEMIC_WEEK - 1}."
         )
+
+    # Zelfde vangnet als de CLI: faal direct met een heldere melding wanneer year/week
+    # buiten de range van de meegegeven data valt, in plaats van een stille None of een
+    # kernel-crash verderop in de pipeline. Draait vóór config-werk (fail fast); de
+    # 2-tuple wordt door de detector via `*_` afgehandeld.
+    mismatch = _detect_data_range_mismatch(
+        (data_individual, data_cumulative), [year], [week]
+    )
+    if mismatch is not None:
+        raise ValueError(_format_api_range_error(year, week, mismatch))
 
     if configuration is None:
         configuration = load_defaults()
@@ -300,50 +316,110 @@ def _apply_auto_defaults(datasets, cfg):
         print("Geef -w en -y mee om een andere combinatie te gebruiken.")
 
 
-def _check_data_range(datasets, cfg):
-    """Check if requested years/weeks exist in the loaded data and warn if not."""
+class DataRangeMismatch(NamedTuple):
+    """Resultaat van de range-detectie: welke jaren/weken ontbreken en wat wél beschikbaar is."""
+
+    year_range: str  # "2018-2025" of "2025"
+    week_range: str  # "1-52", "10", of "n.v.t." (individueel: geen Weeknummer-kolom)
+    missing_years: list[int]
+    missing_weeks: list[int]
+
+
+def _detect_data_range_mismatch(datasets, years, weeks) -> Optional[DataRangeMismatch]:
+    """Detecteer of gevraagde jaren/weken buiten de beschikbare trainingsdata vallen.
+
+    Pure functie: schrijft niets, beëindigt niets, gooit niets. Geeft ``None`` terug
+    wanneer alles binnen bereik valt (of er geen bruikbare data is), anders een
+    ``DataRangeMismatch`` met de beschikbare range en de ontbrekende waarden. Zowel het
+    CLI-pad (``_check_data_range``) als het API-pad (``run_pipeline_from_dataframes``)
+    bouwen hun eigen melding bovenop dit resultaat.
+
+    Args:
+        datasets: Tuple waarvan de eerste twee elementen ``data_individual`` en
+            ``data_cumulative`` zijn (langere tuples worden via ``*_`` genegeerd).
+        years: Gevraagde jaren.
+        weeks: Gevraagde weken.
+    """
     data_individual, data_cumulative, *_ = datasets
 
     # Pick whichever dataset is loaded based on the chosen mode
     data = data_cumulative if data_cumulative is not None else data_individual
     if data is None:
-        return
+        return None
 
     available_years = sorted(int(y) for y in data["Collegejaar"].dropna().unique())
-
     if not available_years:
-        return
+        return None
 
-    missing_years = [y for y in cfg.years if y not in available_years]
+    missing_years = [y for y in years if y not in available_years]
 
     # Individual dataset has no Weeknummer column before preprocessing
     if "Weeknummer" in data.columns:
         available_weeks = sorted(int(w) for w in data["Weeknummer"].dropna().unique())
-        missing_weeks = [w for w in cfg.weeks if w not in available_weeks]
+        missing_weeks = [w for w in weeks if w not in available_weeks]
     else:
         available_weeks = []
         missing_weeks = []
 
-    if missing_years or missing_weeks:
-        year_range = (
-            f"{available_years[0]}-{available_years[-1]}"
-            if len(available_years) > 1
-            else str(available_years[0])
-        )
-        week_range = (
-            f"{available_weeks[0]}-{available_weeks[-1]}"
-            if len(available_weeks) > 1
-            else str(available_weeks[0])
-        )
+    if not (missing_years or missing_weeks):
+        return None
+
+    year_range = _format_range(available_years)
+    # "n.v.t." voorkomt een IndexError op available_weeks[0] wanneer er (nog) geen
+    # weken bekend zijn (individuele dataset vóór preprocessing).
+    week_range = _format_range(available_weeks) if available_weeks else "n.v.t."
+
+    return DataRangeMismatch(year_range, week_range, missing_years, missing_weeks)
+
+
+def _format_range(values) -> str:
+    """Formatteer een gesorteerde lijst als ``"min-max"`` (of ``"x"`` bij één waarde)."""
+    return f"{values[0]}-{values[-1]}" if len(values) > 1 else str(values[0])
+
+
+def _format_available(mismatch) -> str:
+    """Beschrijf de beschikbare data; laat weken weg als die niet bepaald kunnen worden."""
+    if mismatch.week_range == "n.v.t.":
+        return f"jaren {mismatch.year_range}"
+    return f"jaren {mismatch.year_range}, weken {mismatch.week_range}"
+
+
+def _check_data_range(datasets, cfg):
+    """Check if requested years/weeks exist in the loaded data and exit (CLI-pad) if not."""
+    mismatch = _detect_data_range_mismatch(datasets, cfg.years, cfg.weeks)
+    if mismatch is None:
+        return
+
+    print(
+        "\nWaarschuwing: de gevraagde combinatie is niet (volledig) beschikbaar in de data."
+    )
+    print(f"  Beschikbare data: {_format_available(mismatch)}.")
+    if mismatch.week_range == "n.v.t.":
+        print(f"  Pas je flags aan tussen -y {mismatch.year_range},")
+    else:
         print(
-            "\nWaarschuwing: de gevraagde combinatie is niet (volledig) beschikbaar in de data."
+            f"  Pas je flags aan tussen -y {mismatch.year_range} en -w {mismatch.week_range},"
         )
-        print(f"  Beschikbare data: jaren {year_range}, weken {week_range}.")
-        print(f"  Pas je flags aan tussen -y {year_range} en -w {week_range},")
-        print(
-            "  of voeg nieuwe trainingsdata toe in data/input_raw/ om je gewenste tijdstip te voorspellen."
-        )
-        sys.exit(1)
+    print(
+        "  of voeg nieuwe trainingsdata toe in data/input_raw/ om je gewenste tijdstip te voorspellen."
+    )
+    sys.exit(1)
+
+
+def _format_api_range_error(year, week, mismatch) -> str:
+    """Bouw de ValueError-tekst voor het API-pad uit een ``DataRangeMismatch``."""
+    if mismatch.missing_years and mismatch.missing_weeks:
+        subject = f"year={year} en week={week} vallen buiten de beschikbare trainingsdata."
+    elif mismatch.missing_years:
+        subject = f"year={year} valt buiten de beschikbare trainingsdata."
+    else:
+        subject = f"week={week} valt buiten de beschikbare trainingsdata."
+
+    return (
+        f"{subject}\n"
+        f"  Beschikbare data: {_format_available(mismatch)}.\n"
+        "  Pas year/week aan binnen deze range, of voeg trainingsdata toe."
+    )
 
 
 def _print_summary(datasets, cfg, strategy):

--- a/tests/studentprognose/test_api.py
+++ b/tests/studentprognose/test_api.py
@@ -162,28 +162,62 @@ def test_rejects_week_above_range():
 
 
 def test_detector_individual_only_missing_year_no_indexerror():
-    from studentprognose.main import _detect_data_range_mismatch, _format_api_range_error
+    from studentprognose.data.range_check import (
+        detect_data_range_mismatch,
+        format_api_range_error,
+    )
 
     # Individuele dataset heeft geen Weeknummer-kolom; een ontbrekend jaar mag geen
     # IndexError geven (regressie op de oude available_weeks[0]).
     data_individual = pd.DataFrame(
         {"Collegejaar": [2024, 2025], "Croho groepeernaam": ["B Foo", "B Foo"]}
     )
-    mismatch = _detect_data_range_mismatch((data_individual, None), [2030], [10])
+    mismatch = detect_data_range_mismatch((data_individual, None), [2030], [10])
 
     assert mismatch is not None
     assert mismatch.week_range == "n.v.t."
     assert mismatch.missing_weeks == []
     assert mismatch.missing_years == [2030]
     # De API-melding noemt alleen het jaar — geen verwarrend "n.v.t." voor weken.
-    assert "n.v.t." not in _format_api_range_error(2030, 10, mismatch)
+    assert "n.v.t." not in format_api_range_error(2030, 10, mismatch)
 
 
 def test_detector_in_range_returns_none():
-    from studentprognose.main import _detect_data_range_mismatch
+    from studentprognose.data.range_check import detect_data_range_mismatch
 
     data_cumulative = pd.DataFrame({"Collegejaar": [2025], "Weeknummer": [10]})
-    assert _detect_data_range_mismatch((None, data_cumulative), [2025], [10]) is None
+    assert detect_data_range_mismatch((None, data_cumulative), [2025], [10]) is None
+
+
+def test_format_cli_range_warning_with_weeks_full_string():
+    from studentprognose.data.range_check import DataRangeMismatch, format_cli_range_warning
+
+    mismatch = DataRangeMismatch(
+        year_range="2024-2025", week_range="1-52", missing_years=[2030], missing_weeks=[]
+    )
+    # Volledige string-assert: bewaakt zowel de regelopbouw als de byte-identieke output
+    # die de CLI verwacht (zie ook test_cli_check_data_range_exits).
+    assert format_cli_range_warning(mismatch) == (
+        "\nWaarschuwing: de gevraagde combinatie is niet (volledig) beschikbaar in de data."
+        "\n  Beschikbare data: jaren 2024-2025, weken 1-52."
+        "\n  Pas je flags aan tussen -y 2024-2025 en -w 1-52,"
+        "\n  of voeg nieuwe trainingsdata toe in data/input_raw/ om je gewenste tijdstip te voorspellen."
+    )
+
+
+def test_format_cli_range_warning_nvt_branch_omits_week_flag():
+    from studentprognose.data.range_check import DataRangeMismatch, format_cli_range_warning
+
+    # Individuele dataset zonder Weeknummer-kolom -> week_range "n.v.t.".
+    # Deze tak werd voorheen door geen enkele test geraakt.
+    mismatch = DataRangeMismatch(
+        year_range="2024-2025", week_range="n.v.t.", missing_years=[2030], missing_weeks=[]
+    )
+    warning = format_cli_range_warning(mismatch)
+    assert "  Pas je flags aan tussen -y 2024-2025," in warning
+    assert "-w" not in warning  # geen weekvlag wanneer weken onbekend zijn
+    assert "n.v.t." not in warning  # geen verwarrend "n.v.t." in de gebruikerstekst
+    assert "  Beschikbare data: jaren 2024-2025." in warning
 
 
 def test_cli_check_data_range_exits(capsys):

--- a/tests/studentprognose/test_api.py
+++ b/tests/studentprognose/test_api.py
@@ -1,6 +1,8 @@
 """Tests for the public Python API exported from studentprognose.__init__."""
 
 import importlib
+
+import pandas as pd
 import pytest
 
 
@@ -80,3 +82,125 @@ def test_all_exports_present():
             f"'{name}' is listed in __all__ but cannot be imported from studentprognose"
         )
         assert hasattr(importlib.import_module("studentprognose"), name)
+
+
+# --- Range-validatie van year/week in run_pipeline_from_dataframes (issue #218) ---
+
+
+def _cumulative_frame(years=(2024, 2025), weeks=range(1, 53)):
+    """Minimale cumulatieve trainingsdata: alleen de kolommen die de range-check leest.
+
+    De range-check draait vóór ``_run_pipeline_core``, dus meer kolommen zijn niet nodig.
+    """
+    rows = [(year, week) for year in years for week in weeks]
+    return pd.DataFrame(rows, columns=["Collegejaar", "Weeknummer"])
+
+
+def test_rejects_year_before_training_data():
+    from studentprognose import DataOption, run_pipeline_from_dataframes
+
+    with pytest.raises(ValueError) as exc:
+        run_pipeline_from_dataframes(
+            year=2000,
+            week=10,
+            data_cumulative=_cumulative_frame(),
+            dataset=DataOption.CUMULATIVE,
+            save_output=False,
+        )
+    message = str(exc.value)
+    assert "year=2000" in message
+    assert "2024-2025" in message
+
+
+def test_rejects_year_after_training_data():
+    from studentprognose import DataOption, run_pipeline_from_dataframes
+
+    with pytest.raises(ValueError) as exc:
+        run_pipeline_from_dataframes(
+            year=2030,
+            week=10,
+            data_cumulative=_cumulative_frame(),
+            dataset=DataOption.CUMULATIVE,
+            save_output=False,
+        )
+    message = str(exc.value)
+    assert "year=2030" in message
+    assert "2024-2025" in message
+
+
+def test_rejects_week_below_range():
+    from studentprognose import DataOption, run_pipeline_from_dataframes
+
+    # week=0 passeert de FINAL_ACADEMIC_WEEK (38) guard en moet door de range-check vallen.
+    with pytest.raises(ValueError) as exc:
+        run_pipeline_from_dataframes(
+            year=2025,
+            week=0,
+            data_cumulative=_cumulative_frame(),
+            dataset=DataOption.CUMULATIVE,
+            save_output=False,
+        )
+    message = str(exc.value)
+    assert "week=0" in message
+    assert "1-52" in message
+
+
+def test_rejects_week_above_range():
+    from studentprognose import DataOption, run_pipeline_from_dataframes
+
+    with pytest.raises(ValueError) as exc:
+        run_pipeline_from_dataframes(
+            year=2025,
+            week=53,
+            data_cumulative=_cumulative_frame(),
+            dataset=DataOption.CUMULATIVE,
+            save_output=False,
+        )
+    message = str(exc.value)
+    assert "week=53" in message
+    assert "1-52" in message
+
+
+def test_detector_individual_only_missing_year_no_indexerror():
+    from studentprognose.main import _detect_data_range_mismatch, _format_api_range_error
+
+    # Individuele dataset heeft geen Weeknummer-kolom; een ontbrekend jaar mag geen
+    # IndexError geven (regressie op de oude available_weeks[0]).
+    data_individual = pd.DataFrame(
+        {"Collegejaar": [2024, 2025], "Croho groepeernaam": ["B Foo", "B Foo"]}
+    )
+    mismatch = _detect_data_range_mismatch((data_individual, None), [2030], [10])
+
+    assert mismatch is not None
+    assert mismatch.week_range == "n.v.t."
+    assert mismatch.missing_weeks == []
+    assert mismatch.missing_years == [2030]
+    # De API-melding noemt alleen het jaar — geen verwarrend "n.v.t." voor weken.
+    assert "n.v.t." not in _format_api_range_error(2030, 10, mismatch)
+
+
+def test_detector_in_range_returns_none():
+    from studentprognose.main import _detect_data_range_mismatch
+
+    data_cumulative = pd.DataFrame({"Collegejaar": [2025], "Weeknummer": [10]})
+    assert _detect_data_range_mismatch((None, data_cumulative), [2025], [10]) is None
+
+
+def test_cli_check_data_range_exits(capsys):
+    from studentprognose import PipelineConfig
+    from studentprognose.main import _check_data_range
+
+    data_cumulative = pd.DataFrame({"Collegejaar": [2024, 2025], "Weeknummer": [10, 11]})
+    cfg = PipelineConfig(
+        years=[2030], weeks=[10], years_specified=True, weeks_specified=True
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _check_data_range((None, data_cumulative), cfg)
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert (
+        "Waarschuwing: de gevraagde combinatie is niet (volledig) beschikbaar in de data."
+        in out
+    )
+    assert "jaren 2024-2025" in out


### PR DESCRIPTION
## Context

Closes #218.

`run_pipeline_from_dataframes` (de publieke Python API) accepteerde `year`/`week` zonder te controleren of die binnen de range van de meegegeven trainingsdata vielen. Het CLI-pad doet die check wél, maar de API ging direct naar `_run_pipeline_core`. Gevolg: een out-of-range `year`/`week` leverde óf een **stille `None`** ("No data to save"), óf — in randgevallen met joblib/`statsforecast` (vgl. #197) — een **kernel-crash in Jupyter** zónder traceback. Beide voelen als een onverklaarde crash.

## Wat dit doet

De API krijgt hetzelfde vangnet als de CLI, maar als heldere `ValueError`:

```
year=2030 valt buiten de beschikbare trainingsdata.
  Beschikbare data: jaren 2024-2025, weken 1-52.
  Pas year/week aan binnen deze range, of voeg trainingsdata toe.
```

De melding noemt gericht `year`, `week`, of beide, afhankelijk van wat buiten bereik valt.

## Aanpak

De range-validatie is een **op zichzelf staand concern** en woont daarom in een nieuw module `src/studentprognose/data/range_check.py` (naast `validation.py`/`prediction_validator.py`), niet in de orchestratie-entrypoint `main.py`:

- **Pure laag** (`range_check.py`): `detect_data_range_mismatch()` geeft een `DataRangeMismatch` of `None` terug; `format_api_range_error()` en `format_cli_range_warning()` bouwen de meldingen. Geen `print`/`sys.exit`/`raise` — puur detecteren + formatteren.
- **Dunne handlers** (`main.py`): de CLI doet `print(format_cli_range_warning(...))` + `sys.exit(1)`; de API gooit `raise ValueError(format_api_range_error(...))`. Eén gedeelde detector, geen duplicatie van de detectielogica.
- De API-check draait direct ná de `FINAL_ACADEMIC_WEEK`-guard (fail fast, vóór config-werk).
- **Bonus (latente bug):** de oude check crashte met een `IndexError` op `available_weeks[0]` wanneer de individuele dataset (geen `Weeknummer`-kolom) een ontbrekend jaar had. De detector geeft nu netjes `week_range="n.v.t."`.

> **Twee commits.** `5e672552` is de fix zelf; `d2ba9a0a` is een refactor die de logica uit `main.py` (587 → 496 regels) naar `data/range_check.py` haalt, type-hints toevoegt op alle functies (CLAUDE.md-conventie), en de tests laat importeren uit de nieuwe module i.p.v. uit de entry-point (smell opgelost). Het waarneembare gedrag — CLI-stdout én API-`ValueError` — is byte-identiek.

## Docs

- `Raises:`-sectie toegevoegd aan de docstring van `run_pipeline_from_dataframes`.
- `docs/aan-de-slag.md` (sectie *Cloud-gebruik*): `!!! warning`-admonitie over de nieuwe `ValueError`, conform de verplichte docs-check (wijziging in `main.py`/Python API → `docs/aan-de-slag.md`). De refactor is gedragsbehoudend, dus geen aanvullende docs nodig.

## Tests (`tests/studentprognose/test_api.py`)

| Test | Bewaakt |
|------|---------|
| year vóór trainingsdata | `ValueError` + beschikbare jaren-range |
| year ná trainingsdata | `ValueError` + beschikbare jaren-range |
| week ≤ 0 | `ValueError` (passeert de `==38`-guard) |
| week > 52 | `ValueError` |
| individueel-only, ontbrekend jaar | geen `IndexError`, `week_range="n.v.t."`, geen `"n.v.t."` in API-melding |
| in-range | detector geeft `None` (geen false positive) |
| CLI-regressie | `sys.exit(1)` met exitcode 1 + ongewijzigde tekst |
| `format_cli_range_warning`, met-weken | volledige CLI-waarschuwingstekst (byte-identiek) |
| `format_cli_range_warning`, `n.v.t.`-tak | geen `-w`-vlag, geen `"n.v.t."` in tekst (eerder ongedekt) |

## Verificatie

- `uv run pytest` → **334 passed** (incl. 9 nieuwe API-tests)
- `ruff check` → clean
- Gedragsbehoud van de refactor geverifieerd: `format_cli_range_warning()` reproduceert de oude losse `print()`-keten byte-identiek (incl. leidende `\n` en trailing newline), en de API-`ValueError`-tekst is regel-voor-regel gelijk.
- Smoke test (`bash scripts/test_package.sh`) → 8/8 stappen OK op de fix-commit; de refactor raakt alleen het mismatch-pad en is gedragsbehoudend (in-range happy-path ongewijzigd).

## Acceptatiecriteria

- [x] API raised `ValueError` met beschikbare year/week-range bij out-of-range input
- [x] Foutmelding toont concreet welke jaren/weken beschikbaar zijn
- [x] CLI-gedrag ongewijzigd (zelfde tekst + `sys.exit(1)`)
- [x] Docstring documenteert de nieuwe `ValueError`
- [x] `docs/aan-de-slag.md` documenteert de constraint
- [x] Nieuwe tests voor year vóór/ná, week ≤ 0, week > 52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
