### PR TITLE
feat: filter teldata op instelling via institution_filter (#200)

### DIFF
--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -31,6 +31,7 @@
         "B Opleiding": 0
     },
     "excluded_data_points": [],
+    "institution_filter": [],
     "ensemble_override_cumulative": [
         "B Geneeskunde",
         "B Biomedische Wetenschappen",
@@ -61,7 +62,8 @@
         "enrollments": "Inschrijvingen",
         "higher_education_type": "Type hoger onderwijs",
         "croho_source": "Groepeernaam Croho",
-        "higher_years": "Hogerejaars"
+        "higher_years": "Hogerejaars",
+        "institution": "Korte naam instelling"
     },
     "model_features": {
         "classifier": {

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -14,7 +14,7 @@ De pipeline laadt altijd eerst de **ingebakken standaardwaarden** uit het packag
 - Een ontbrekend veld in jouw bestand valt automatisch terug op de standaardwaarde.
 - Als het configuratiebestand helemaal niet bestaat, worden de standaardwaarden gebruikt en verschijnt er een waarschuwing.
 
-Het bestand heeft de volgende secties: `paths`, `runtime`, `model_config`, `numerus_fixus`, `excluded_data_points`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights` en `columns`.
+Het bestand heeft de volgende secties: `paths`, `runtime`, `model_config`, `numerus_fixus`, `excluded_data_points`, `institution_filter`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights` en `columns`.
 
 ## `paths` — bestandspaden
 
@@ -191,6 +191,45 @@ Een lege lijst (`[]`) schakelt uitsluiting volledig uit — dit is de standaard.
 
 !!! warning "Gebruik dit bewust"
     Elk uitgesloten datapunt verkleint de trainingsset. Bij kleine opleidingen kan dat de modelkwaliteit ernstig verslechteren. Beperk uitsluiting tot jaren waarvan je kunt aantonen dat de data structureel fout of onvergelijkbaar is.
+
+## `institution_filter` — filteren op instelling
+
+De teldata (Studielink-telbestanden of de cumulatieve teldata) kan rijen van **meerdere instellingen** bevatten, elk herkenbaar aan een instellingscode (BRIN). Met `institution_filter` beperk je de pipeline tot één of meer instellingen.
+
+```json
+{
+    "institution_filter": ["21PB"]
+}
+```
+
+| Waarde | Gedrag |
+|--------|--------|
+| `[]` (standaard) | **Alle instellingen** in de teldata worden meegenomen |
+| `["21PB"]` | Alleen instelling `21PB` (bv. Radboud) |
+| `["21PB", "21AB"]` | Meerdere instellingen tegelijk |
+
+### Standaardgedrag
+
+De standaard is een **lege lijst** (`[]`): er wordt niet gefilterd. Dit is bewust gekozen zodat bestaande configuraties met data van één instelling ongewijzigd blijven werken.
+
+!!! warning "Meerdere instellingen zonder filter worden samengeteld"
+    De cumulatieve voorbewerking aggregeert per opleiding **zonder** de instellingskolom. Bevat je teldata meer dan één instelling en laat je `institution_filter` leeg, dan worden de cijfers van dezelfde opleiding (bv. "B Psychologie") van verschillende instellingen **bij elkaar opgeteld** tot een betekenisloos totaal. De pipeline geeft in dat geval een waarschuwing. Zet `institution_filter` op je eigen instellingscode(s) om alleen je eigen instelling te modelleren.
+
+Een onbekende code (die in geen enkele rij voorkomt) levert een duidelijke foutmelding op met de wél beschikbare instellingen, zodat je de code direct kunt corrigeren.
+
+### Instellingskolom aanpassen
+
+De kolom die de instelling identificeert heet standaard `Korte naam instelling` (het Radboud-formaat ná de ETL). Gebruik je de ruwe Studielink-teldata, dan heet die kolom `Brincode`. Stel de kolomnaam in via de rol `institution` onder `column_roles`:
+
+```json
+{
+    "column_roles": {
+        "institution": "Brincode"
+    }
+}
+```
+
+Werk je met de cumulatieve teldata ná de ETL, dan klopt de standaard (`Korte naam instelling`) en hoef je deze rol niet aan te passen.
 
 ## `ensemble_override_cumulative` — ensemble-uitzondering per opleiding
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -43,6 +43,10 @@ De velden hieronder zijn de kolommen die de demo-telbestanden bevatten en die de
 | `meercode_V` | int | §5.12 | Gemiddeld aantal aanmeldingen per student met status V/U/I. Wordt door de ETL als deler gebruikt: `Gewogen vooraanmelders = Aantal / meercode_V`. Voor status A-rijen is deze waarde 0 — die rijen worden door de ETL uitgefilterd. |
 | `Status` | str | §5.13 | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
 
+#### Meerdere instellingen in de teldata
+
+De volledige Studielink-teldata bevat rijen van **alle instellingen**, elk herkenbaar aan de `Brincode` (ná de ETL: `Korte naam instelling`). Wil je maar één instelling — meestal je eigen — modelleren, zet dan `institution_filter` in je configuratie. Laat je dat leeg terwijl er meerdere instellingen in de data zitten, dan worden hun cijfers per opleiding bij elkaar opgeteld; de pipeline waarschuwt hiervoor. Zie [`institution_filter`](configuratie.md#institution_filter-filteren-op-instelling).
+
 #### Afwijkende bestandsnamen
 
 Gebruikt jouw instelling een andere conventie dan `telbestandY{jaar}W{week}.csv`? Geef in `configuration.json` één of meer eigen patronen op:

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -79,6 +79,9 @@ Vóór elke modelrun voert de pipeline drie aanvullende checks uit op de **cumul
 !!! note "Alleen actief als cumulatieve data beschikbaar is"
     De pre-prediction checks worden overgeslagen als de pipeline zonder cumulatieve data draait (individueel-enkel modus, `-d i`). In dat geval is er geen `Gewogen vooraanmelders`-kolom om te valideren.
 
+!!! warning "Teldata met meerdere instellingen"
+    Bevat je cumulatieve teldata rijen van meer dan één instelling (`Korte naam instelling` / `Brincode`) en heb je `institution_filter` leeg gelaten, dan geeft de voorbewerking een waarschuwing. De cijfers van verschillende instellingen worden dan namelijk per opleiding samengeteld — zelden bedoeld. Filter op je eigen instelling via [`institution_filter`](configuratie.md#institution_filter-filteren-op-instelling).
+
 | Check | Type | Wat wordt gecheckt |
 |-------|------|-------------------|
 | Decimaalintegriteit | Hard stop | `Gewogen vooraanmelders` bevat strings met komma's of niet-numerieke waarden |

--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -63,6 +63,8 @@ def load_configuration(file_path: str) -> dict:
 
     if "excluded_data_points" in cfg:
         _validate_excluded_data_points(cfg["excluded_data_points"], file_path)
+    if "institution_filter" in cfg:
+        _validate_institution_filter(cfg["institution_filter"], file_path)
     _validate_model_config(cfg, file_path)
     _validate_runtime(cfg, file_path)
     _validate_telbestand_filename_patterns(cfg, file_path)
@@ -152,6 +154,30 @@ def _validate_excluded_data_points(rules, file_path):
                     f"De combinatie sluit nooit rijen uit."
                 )
                 sys.exit(1)
+
+
+def _validate_institution_filter(value, file_path):
+    """Valideer 'institution_filter': een lijst met instellingscodes (strings).
+
+    Een lege lijst (of ontbrekende sleutel) is geldig en betekent "alle
+    instellingen". Faalt fast bij een verkeerd type, zodat een configuratiefout
+    niet pas diep in de preprocessing als KeyError opduikt.
+    """
+    if not isinstance(value, list):
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'institution_filter' moet een lijst zijn, niet {type(value).__name__}."
+        )
+        sys.exit(1)
+
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            print(
+                f"Configuratiefout in {file_path}: "
+                f"'institution_filter[{i}]' moet een string zijn (instellingscode), "
+                f"niet {type(item).__name__}."
+            )
+            sys.exit(1)
 
 
 def _validate_model_config(cfg, file_path):

--- a/src/studentprognose/configuration/configuration.json
+++ b/src/studentprognose/configuration/configuration.json
@@ -33,6 +33,7 @@
     },
     "numerus_fixus": {},
     "excluded_data_points": [],
+    "institution_filter": [],
     "ensemble_override_cumulative": [],
     "exclude_from_combined": [],
     "ensemble_weights": {
@@ -57,7 +58,8 @@
         "enrollments": "Inschrijvingen",
         "higher_education_type": "Type hoger onderwijs",
         "croho_source": "Groepeernaam Croho",
-        "higher_years": "Hogerejaars"
+        "higher_years": "Hogerejaars",
+        "institution": "Korte naam instelling"
     },
     "model_features": {
         "classifier": {

--- a/src/studentprognose/data/preprocessing/institution_filter.py
+++ b/src/studentprognose/data/preprocessing/institution_filter.py
@@ -1,0 +1,76 @@
+import warnings
+
+import pandas as pd
+
+
+def apply_institution_filter(
+    data: pd.DataFrame,
+    institution_filter: list[str],
+    institution_column: str = "Korte naam instelling",
+) -> pd.DataFrame:
+    """Beperk de teldata tot één of meer instellingen.
+
+    De teldata (telbestanden / Studielink-teldata) kan rijen van meerdere
+    instellingen bevatten. Deze functie wordt toegepast **vóór** de cumulatieve
+    aggregatie, want die groepeert per opleiding zónder de instellingskolom: zou
+    je niet filteren, dan worden cijfers van dezelfde opleiding (bv. "B
+    Psychologie") van verschillende instellingen bij elkaar opgeteld tot een
+    betekenisloos totaal.
+
+    Gedrag:
+
+    - ``institution_filter`` leeg: er wordt niet gefilterd. Bevat de data méér
+      dan één instelling, dan volgt een waarschuwing — de aggregatie telt de
+      instellingen anders samen.
+    - ``institution_filter`` gezet, maar ``institution_column`` ontbreekt in de
+      data: ``ValueError`` (config/data-mismatch).
+    - ``institution_filter`` gezet, maar geen enkele rij matcht: ``ValueError``
+      met de wél beschikbare instellingen, zodat de gebruiker de code direct kan
+      corrigeren in plaats van een stille lege uitvoer te krijgen.
+
+    Args:
+        data: Cumulatieve teldata vóór aggregatie.
+        institution_filter: Lijst met instellingscodes (bv. BRIN ``["21PB"]``).
+            Een lege lijst betekent "alle instellingen".
+        institution_column: Naam van de kolom die de instelling identificeert.
+            Standaard ``"Korte naam instelling"``; bij Studielink-teldata
+            doorgaans ``"Brincode"`` (instelbaar via ``column_roles.institution``).
+
+    Returns:
+        De (eventueel) gefilterde data. Het oorspronkelijke DataFrame wordt niet
+        gewijzigd.
+    """
+    if not institution_filter:
+        if institution_column in data.columns:
+            n_institutions = data[institution_column].nunique(dropna=True)
+            if n_institutions > 1:
+                warnings.warn(
+                    f"De teldata bevat {n_institutions} instellingen, maar "
+                    f"'institution_filter' is leeg. Hun cijfers worden per opleiding "
+                    f"bij elkaar opgeteld, wat zelden bedoeld is. Zet "
+                    f"'institution_filter' in configuration.json op je eigen "
+                    f"instellingscode(s) om alleen die instelling te modelleren.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        return data
+
+    if institution_column not in data.columns:
+        raise ValueError(
+            f"'institution_filter' is gezet, maar de instellingskolom "
+            f"{institution_column!r} ontbreekt in de teldata. Beschikbare kolommen: "
+            f"{sorted(data.columns)}. Controleer 'column_roles.institution' in je "
+            f"configuratie."
+        )
+
+    available = sorted(data[institution_column].dropna().unique())
+    filtered = data[data[institution_column].isin(institution_filter)]
+
+    if filtered.empty:
+        raise ValueError(
+            f"'institution_filter' {institution_filter} matcht geen enkele rij in de "
+            f"teldata. Beschikbare instellingen: {available}. Controleer of de codes "
+            f"exact overeenkomen (hoofdlettergevoelig)."
+        )
+
+    return filtered

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -393,6 +393,9 @@ def _print_summary(datasets, cfg, strategy):
 
     print(f"\n{'=' * 40}")
     print(f"  Dataset:       {cfg.data_option.filename_suffix}")
+    institution_filter = getattr(strategy, "institution_filter", [])
+    if institution_filter:
+        print(f"  Instelling(en): {', '.join(str(i) for i in institution_filter)}")
     print(f"  Trainingsdata: jaren {train_year_str}")
     print(f"  Voorspelling:  jaar {cfg.years}, vanaf week {cfg.weeks}")
     for i, detail in enumerate(pred_details):

--- a/src/studentprognose/strategies/base.py
+++ b/src/studentprognose/strategies/base.py
@@ -16,6 +16,14 @@ class PredictionStrategy(ABC):
         self.min_training_year = configuration.get("model_config", {}).get("min_training_year", 2016)
         self.excluded_data_points = configuration.get("excluded_data_points", [])
 
+        # Instellingsfilter: beperkt de teldata tot één of meer instellingen.
+        # Leeg = alle instellingen. De kolomnaam is configureerbaar omdat het
+        # Radboud-formaat "Korte naam instelling" gebruikt en Studielink "Brincode".
+        self.institution_filter = configuration.get("institution_filter", [])
+        self.institution_column = configuration.get("column_roles", {}).get(
+            "institution", "Korte naam instelling"
+        )
+
         self.postprocessor = PostProcessor(
             configuration, data_latest, ensemble_weights,
             data_studentcount, cwd, data_option, ci_test_n,

--- a/src/studentprognose/strategies/cumulative.py
+++ b/src/studentprognose/strategies/cumulative.py
@@ -14,6 +14,7 @@ from studentprognose.models.sarima import predict_with_sarima_cumulative, _get_t
 from studentprognose.models.xgboost_regressor import predict_with_xgboost
 from studentprognose.data.transforms import TRANSFORM_GROUP_COLS
 from studentprognose.data.preprocessing.excluded_data_points import apply_excluded_data_points
+from studentprognose.data.preprocessing.institution_filter import apply_institution_filter
 
 _EPS = 1e-8
 _LAGS = [2, 5]
@@ -149,6 +150,13 @@ class CumulativeStrategy(PredictionStrategy):
 
         data.loc[(data["Examentype"] == "Pre-master"), "Hogerejaars"] = "Nee"
         data = data[data["Hogerejaars"] == "Nee"]
+
+        # Filter op instelling vóór de aggregatie: de groupby hieronder groepeert
+        # per opleiding zónder de instellingskolom, dus na deze stap is niet meer
+        # te onderscheiden van welke instelling een rij kwam.
+        data = apply_institution_filter(
+            data, self.institution_filter, self.institution_column
+        )
 
         data = (
             data.groupby([

--- a/tests/studentprognose/test_institution_filter.py
+++ b/tests/studentprognose/test_institution_filter.py
@@ -1,0 +1,231 @@
+"""Tests voor het instellingsfilter (issue #200).
+
+Dekt zowel de pure filterfunctie ``apply_institution_filter`` als de
+configuratievalidatie ``_validate_institution_filter`` en de integratie via
+``load_configuration``.
+"""
+
+import json
+import warnings
+
+import pandas as pd
+import pytest
+
+from studentprognose.config import load_configuration, _validate_institution_filter
+from studentprognose.data.preprocessing.institution_filter import apply_institution_filter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _multi_institution_df():
+    """Teldata met dezelfde opleiding bij twee instellingen (Radboud + UvA)."""
+    return pd.DataFrame({
+        "Korte naam instelling": ["21PB", "21PB", "21AB", "21AB"],
+        "Collegejaar": [2024, 2024, 2024, 2024],
+        "Croho groepeernaam": ["B Psychologie", "B Biologie", "B Psychologie", "B Biologie"],
+        "Herkomst": ["NL", "NL", "NL", "NL"],
+        "Ongewogen vooraanmelders": [30, 10, 50, 20],
+    })
+
+
+# ---------------------------------------------------------------------------
+# apply_institution_filter
+# ---------------------------------------------------------------------------
+
+class TestApplyInstitutionFilter:
+    def test_empty_filter_single_institution_returns_all_no_warning(self):
+        df = _multi_institution_df()
+        df = df[df["Korte naam instelling"] == "21PB"]  # één instelling
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = apply_institution_filter(df, [])
+        assert len(result) == len(df)
+        assert len(w) == 0  # geen waarschuwing bij één instelling
+
+    def test_empty_filter_multi_institution_warns(self):
+        df = _multi_institution_df()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = apply_institution_filter(df, [])
+        assert len(result) == len(df)  # niets verwijderd
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "2 instellingen" in str(w[0].message)
+
+    def test_filter_to_one_institution_keeps_only_that_institution(self):
+        df = _multi_institution_df()
+        result = apply_institution_filter(df, ["21PB"])
+        assert set(result["Korte naam instelling"]) == {"21PB"}
+        assert len(result) == 2
+
+    def test_filter_prevents_cross_institution_aggregation(self):
+        # Kern van issue #200: zonder filter zou een latere groupby per opleiding
+        # de twee instellingen optellen (30 + 50 = 80 voor B Psychologie). Na
+        # filteren op 21PB blijft alleen Radboud's 30 over.
+        df = _multi_institution_df()
+        result = apply_institution_filter(df, ["21PB"])
+        psy = result[result["Croho groepeernaam"] == "B Psychologie"]
+        assert psy["Ongewogen vooraanmelders"].sum() == 30
+
+    def test_filter_multiple_institutions(self):
+        df = _multi_institution_df()
+        result = apply_institution_filter(df, ["21PB", "21AB"])
+        assert set(result["Korte naam instelling"]) == {"21PB", "21AB"}
+        assert len(result) == 4
+
+    def test_filter_no_match_raises_with_available(self):
+        df = _multi_institution_df()
+        with pytest.raises(ValueError) as exc:
+            apply_institution_filter(df, ["99XX"])
+        # De foutmelding noemt de wél beschikbare instellingen.
+        assert "21PB" in str(exc.value)
+        assert "21AB" in str(exc.value)
+
+    def test_missing_column_with_filter_raises(self):
+        df = _multi_institution_df().drop(columns=["Korte naam instelling"])
+        with pytest.raises(ValueError) as exc:
+            apply_institution_filter(df, ["21PB"])
+        assert "Korte naam instelling" in str(exc.value)
+
+    def test_missing_column_without_filter_is_noop(self):
+        # Geen instellingskolom én geen filter (bv. individuele data): geen fout.
+        df = _multi_institution_df().drop(columns=["Korte naam instelling"])
+        result = apply_institution_filter(df, [])
+        assert len(result) == len(df)
+
+    def test_custom_column_name(self):
+        # Studielink gebruikt "Brincode" i.p.v. "Korte naam instelling".
+        df = _multi_institution_df().rename(columns={"Korte naam instelling": "Brincode"})
+        result = apply_institution_filter(df, ["21PB"], institution_column="Brincode")
+        assert set(result["Brincode"]) == {"21PB"}
+
+    def test_does_not_mutate_input(self):
+        df = _multi_institution_df()
+        original_len = len(df)
+        apply_institution_filter(df, ["21PB"])
+        assert len(df) == original_len
+
+
+# ---------------------------------------------------------------------------
+# _validate_institution_filter
+# ---------------------------------------------------------------------------
+
+class TestValidateInstitutionFilter:
+    def test_empty_list_is_valid(self):
+        _validate_institution_filter([], "cfg.json")  # geen exception
+
+    def test_valid_list_passes(self):
+        _validate_institution_filter(["21PB", "21AB"], "cfg.json")
+
+    def test_non_list_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            _validate_institution_filter("21PB", "cfg.json")
+        assert exc.value.code == 1
+
+    def test_non_string_element_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            _validate_institution_filter([21], "cfg.json")
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# load_configuration — institution_filter integratie
+# ---------------------------------------------------------------------------
+
+class TestLoadConfigurationInstitutionFilter:
+    def test_default_is_empty_list(self, tmp_path):
+        # Geen institution_filter in het gebruikersbestand: defaults leveren [].
+        cfg = {"numerus_fixus": {}}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        result = load_configuration(str(f))
+        assert result.get("institution_filter") == []
+
+    def test_valid_institution_filter_loads(self, tmp_path):
+        cfg = {"numerus_fixus": {}, "institution_filter": ["21PB"]}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        result = load_configuration(str(f))
+        assert result["institution_filter"] == ["21PB"]
+
+    def test_invalid_institution_filter_exits(self, tmp_path):
+        cfg = {"numerus_fixus": {}, "institution_filter": "21PB"}
+        f = tmp_path / "configuration.json"
+        f.write_text(json.dumps(cfg))
+        with pytest.raises(SystemExit):
+            load_configuration(str(f))
+
+    def test_default_config_exposes_institution_role(self):
+        from studentprognose.config import load_defaults
+
+        defaults = load_defaults()
+        assert defaults["column_roles"]["institution"] == "Korte naam instelling"
+        assert defaults["institution_filter"] == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: CumulativeStrategy.preprocess() met multi-instelling teldata
+# ---------------------------------------------------------------------------
+
+def _multi_institution_cumulative():
+    """Volledige cumulatieve teldata voor twee instellingen, één opleiding."""
+    from studentprognose.config import load_defaults
+
+    def rows(inst, base):
+        return [
+            {
+                "Korte naam instelling": inst, "Collegejaar": 2024,
+                "Weeknummer rapportage": wk, "Weeknummer": wk, "Faculteit": "SOW",
+                "Type hoger onderwijs": "Bachelor", "Groepeernaam Croho": "B Psychologie",
+                "Naam Croho opleiding Nederlands": "B Psychologie", "Croho": "56604",
+                "Herinschrijving": "Nee", "Hogerejaars": "Nee", "Herkomst": "NL",
+                "Gewogen vooraanmelders": base + wk, "Ongewogen vooraanmelders": base + wk,
+                "Aantal aanmelders met 1 aanmelding": 1, "Inschrijvingen": 0,
+            }
+            for wk in range(1, 39)
+        ]
+
+    data = pd.DataFrame(rows("21PB", 100) + rows("21AB", 500))
+    return data, load_defaults()
+
+
+def _make_cumulative_strategy(data, cfg):
+    from studentprognose.strategies.cumulative import CumulativeStrategy
+    from studentprognose.utils.weeks import DataOption
+
+    return CumulativeStrategy(
+        data, None, cfg, None, cfg["ensemble_weights"], "/tmp",
+        DataOption.CUMULATIVE, None,
+    )
+
+
+class TestCumulativeStrategyInstitutionFilter:
+    def test_filter_prevents_cross_institution_summing_in_preprocess(self):
+        # Issue #200 acceptatiecriterium: getest met data van meerdere instellingen.
+        # Met filter op 21PB blijft alleen Radboud's reeks over (week 38 = 138),
+        # niet de som over beide instellingen (138 + 538 = 676).
+        data, cfg = _multi_institution_cumulative()
+        cfg["institution_filter"] = ["21PB"]
+        strategy = _make_cumulative_strategy(data, cfg)
+
+        assert strategy.institution_filter == ["21PB"]
+        out = strategy.preprocess()
+        wk38 = out[(out["Weeknummer"] == 38) & (out["Croho groepeernaam"] == "B Psychologie")]
+        assert wk38["Gewogen vooraanmelders"].sum() == 138
+
+    def test_no_filter_sums_across_institutions_and_warns(self):
+        data, cfg = _multi_institution_cumulative()  # geen institution_filter
+        strategy = _make_cumulative_strategy(data, cfg)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            out = strategy.preprocess()
+
+        assert any(
+            issubclass(x.category, UserWarning) and "instellingen" in str(x.message)
+            for x in w
+        )
+        wk38 = out[(out["Weeknummer"] == 38) & (out["Croho groepeernaam"] == "B Psychologie")]
+        assert wk38["Gewogen vooraanmelders"].sum() == 676


### PR DESCRIPTION
Closes #200

## Probleem

De teldata (Studielink-telbestanden / cumulatieve teldata) kan rijen van **meerdere instellingen** bevatten, elk herkenbaar aan een instellingscode (BRIN, kolom `Korte naam instelling`). Er was geen manier om op je eigen of een specifieke instelling te filteren.

Dit is niet alleen een gemaksprobleem maar ook een **correctheidsprobleem**: `CumulativeStrategy.preprocess()` aggregeert per opleiding mét een `groupby` die de instellingskolom *niet* bevat. Bevat de data meerdere instellingen, dan worden cijfers van dezelfde opleiding (bv. "B Psychologie" van Radboud + UvA) bij elkaar opgeteld tot een betekenisloos totaal.

## Oplossing

Een config-optie `institution_filter` (lijst met BRIN-codes) die de teldata beperkt **vóór** de aggregatie.

```json
{ "institution_filter": ["21PB"] }
```

| Waarde | Gedrag |
|--------|--------|
| `[]` (default) | Alle instellingen — backward compatible |
| `["21PB"]` | Alleen die instelling |
| `["21PB", "21AB"]` | Meerdere tegelijk |

### Default-gedrag (vastgelegd & gedocumenteerd)

Default is een **lege lijst** = niet filteren, zodat bestaande single-instelling setups ongewijzigd blijven. Bevat de teldata méér dan één instelling terwijl de filter leeg is, dan volgt een **waarschuwing** (de cijfers worden anders samengeteld). Een onbekende code geeft een duidelijke fout met de wél beschikbare instellingen.

### Configureerbare kolomnaam

De instellingskolom is instelbaar via `column_roles.institution` (default `"Korte naam instelling"`; Studielink-teldata gebruikt `"Brincode"`), conform de projectconventie "geen gehardcodeerde instellingsnamen in gedeelde code".

## Wijzigingen

- **`data/preprocessing/institution_filter.py`** — pure functie `apply_institution_filter()` (zelfde patroon als `apply_excluded_data_points`)
- **`strategies/base.py`** — leest `institution_filter` + `column_roles.institution` uit config
- **`strategies/cumulative.py`** — past de filter toe vóór de groupby in `preprocess()`
- **`config.py`** — `_validate_institution_filter` (lijst van strings, fail-fast)
- **`main.py`** — `_print_summary` toont gekozen instelling(en)
- **`configuration.json`** (×2) — `institution_filter: []` + `column_roles.institution`
- **`tests/test_institution_filter.py`** — 20 tests incl. end-to-end multi-instelling
- **docs** — `configuratie.md`, `je-data-voorbereiden.md`, `validatie.md`

## Acceptatiecriteria

- [x] Config-optie om op één of meerdere instellingen te filteren
- [x] Default-gedrag vastgelegd en gedocumenteerd (leeg = alle instellingen, met waarschuwing bij meerdere)
- [x] Getest met data van meerdere instellingen (unit + end-to-end)

## Verificatie

- `uv run pytest` → 345 passed
- `uvx ruff check` → clean
- `uv run --group docs mkdocs build --strict` → exit 0
- Smoke test (`--ci test 2 -d both -w 12 -y 2024`) → loopt door, ongewijzigd gedrag met default

🤖 Generated with [Claude Code](https://claude.com/claude-code)