### PR TITLE
fix(api): normaliseer programmesleutel in run_pipeline_from_dataframes

### DIFF
--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -9,7 +9,7 @@ from studentprognose.cli import PipelineConfig, parse_args
 from studentprognose.config import (
     load_configuration, load_defaults_filtering, load_filtering, get_final_academic_week,
 )
-from studentprognose.data.loader import load_data
+from studentprognose.data.loader import load_data, _normalize_programme_code
 from studentprognose.data.prediction_validator import run_pre_prediction_checks
 from studentprognose.data.range_check import (
     detect_data_range_mismatch,
@@ -224,6 +224,22 @@ def run_pipeline_from_dataframes(
         noetl=True,
         yes=True,
     )
+
+    # De in-memory route slaat load_data over en mist daarmee de
+    # programmesleutel-normalisatie. Pas die hier alsnog toe (zelfde sleutel-rollen
+    # als load_data) op kopieën — anders lekt een object/string-sleutel uit de
+    # meegegeven DataFrames in self.data en crasht een latere merge op str-vs-Int64.
+    # Kopiëren voorkomt dat we de DataFrames van de aanroeper muteren.
+    _roles = configuration.get("column_roles", {})
+    if data_cumulative is not None:
+        data_cumulative = data_cumulative.copy()
+        _normalize_programme_code(data_cumulative, _roles.get("croho_source"))
+    if data_student_numbers is not None:
+        data_student_numbers = data_student_numbers.copy()
+        _normalize_programme_code(data_student_numbers, _roles.get("programme"))
+    if data_weighted_ensemble is not None:
+        data_weighted_ensemble = data_weighted_ensemble.copy()
+        _normalize_programme_code(data_weighted_ensemble, "Programme")
 
     datasets = (
         data_individual,

--- a/src/studentprognose/output/postprocessor.py
+++ b/src/studentprognose/output/postprocessor.py
@@ -307,10 +307,11 @@ class PostProcessor:
         # idx[0],idx[1],idx[2]... — self.data kan na eerder filteren een
         # niet-aaneengesloten index hebben waardoor idx[has_value] anders
         # naar de verkeerde rijen zou wijzen.
-        merged = (
-            self.data.loc[idx, key_cols]
-            .reset_index(drop=True)
-            .merge(snapshot, on=key_cols, how="left")
+        merged = merge_on_programme_key(
+            self.data.loc[idx, key_cols].reset_index(drop=True),
+            snapshot,
+            on=key_cols,
+            how="left",
         )
 
         for col in update_cols:

--- a/tests/studentprognose/test_api.py
+++ b/tests/studentprognose/test_api.py
@@ -176,6 +176,48 @@ def test_run_pipeline_respects_save_output(tmp_path, monkeypatch, save_output, e
         )
 
 
+def test_run_pipeline_from_dataframes_normalizes_programme_key(monkeypatch):
+    """Regressie: de in-memory route normaliseert de programmesleutel (object/str
+    -> Int64), net als load_data. Zonder dit lekt een object-sleutel uit de
+    meegegeven DataFrames in self.data en crasht een latere merge op str-vs-Int64
+    (de fout die cloud-/Fabric-gebruikers zagen)."""
+    import studentprognose.main as main_mod
+    from studentprognose import run_pipeline_from_dataframes, DataOption
+    from studentprognose.config import load_defaults
+
+    captured = {}
+
+    def _fake_core(cfg, datasets, configuration, filtering, cwd, save_output=True):
+        captured["datasets"] = datasets
+        return None
+
+    monkeypatch.setattr(main_mod, "_run_pipeline_core", _fake_core)
+
+    # Object/string-sleutel zoals een Fabric-bron levert.
+    df_cum = pd.DataFrame({
+        "Collegejaar": [2024], "Weeknummer": [10],
+        "Groepeernaam Croho": ["56604"],
+    })
+    label = pd.DataFrame({
+        "Collegejaar": [2024], "Herkomst": ["NL"], "Examentype": ["Bachelor"],
+        "Croho groepeernaam": ["56604"], "Aantal_studenten": [120],
+    })
+
+    run_pipeline_from_dataframes(
+        year=2024, week=10,
+        data_cumulative=df_cum, data_student_numbers=label,
+        dataset=DataOption.CUMULATIVE, configuration=load_defaults(),
+        save_output=False,
+    )
+
+    _, cum, lbl, _, _ = captured["datasets"]
+    assert str(cum["Groepeernaam Croho"].dtype) == "Int64"
+    assert str(lbl["Croho groepeernaam"].dtype) == "Int64"
+    # De DataFrames van de aanroeper mogen niet in place gemuteerd zijn.
+    assert str(df_cum["Groepeernaam Croho"].dtype) != "Int64"
+    assert str(label["Croho groepeernaam"].dtype) != "Int64"
+
+
 def test_all_exports_present():
     import studentprognose
 


### PR DESCRIPTION
### Probleem

De in-memory route `run_pipeline_from_dataframes` (Python/cloud-API) slaat `load_data` over en miste daarmee de programmesleutel-normalisatie uit de Isatcode-migratie (#238). Een object/string-sleutel in de meegegeven DataFrames lekte in `self.data`: `merge_on_programme_key` castte de sleutel naar string, waarna een latere `.merge` in `add_applicant_data` crashte:

```
ValueError: You are trying to merge on object and Int64 columns for key 'Croho groepeernaam'
```

Dit trof cloud-/Fabric-gebruikers van de DataFrame-API (de CLI/bestandsroute was niet geraakt, want die gaat via `load_data`).

### Fix

- `run_pipeline_from_dataframes` normaliseert nu `data_cumulative`, `data_student_numbers` en `data_weighted_ensemble` (zelfde sleutel-rollen als `load_data`) op **kopieën**, zodat de DataFrames van de aanroeper niet muteren.
- `add_applicant_data` gebruikt de dtype-veilige `merge_on_programme_key` i.p.v. een gewone `.merge` (defense-in-depth).

### Test

Regressietest in `test_api.py`: een object-sleutel in het label wordt in de in-memory route naar `Int64` genormaliseerd zonder de input te muteren. Alle 398 unit tests groen; CLI-modi (`cumulative`/`both`) en de in-memory reproductie bevestigd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)