### PR TITLE
feat: evaluatiemetrieken per model met evaluate_predictions en pivot_metrics

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -215,11 +215,20 @@ from studentprognose import (
     load_data,                     # laad data vanaf schijf als DataFrames
     run_pipeline_cli,              # volledige CLI-pipeline (accepteert argv-lijst)
     run_pipeline_from_dataframes,  # pipeline met DataFrames in-memory
+    evaluate_predictions,          # output → scalaire evaluatiemetrieken per model
+    pivot_metrics,                 # metrieken → model × jaar/week-matrix (backtest)
+    to_mlflow_metrics,             # metrieken afvlakken voor mlflow.log_metrics (Fabric)
     PipelineConfig,                # configuratie-dataclass voor de pipeline
     DataOption,                    # enum: INDIVIDUAL / CUMULATIVE / BOTH_DATASETS
     StudentYearPrediction,         # enum: FIRST_YEARS / VOLUME
 )
 ```
+
+!!! tip "Het model evalueren"
+    `evaluate_predictions` zet de pipeline-output om in scalaire metrieken (MAE, MAPE,
+    WAPE, RMSE, bias, R²) per model; `pivot_metrics` vat een backtest over meerdere jaren
+    samen tot een model × jaar-matrix; en `to_mlflow_metrics` levert ze klaar voor MLflow
+    in MS Fabric / Databricks. Zie [Output begrijpen → Het model evalueren](output-begrijpen.md#het-model-evalueren-evaluate_predictions).
 
 ### Minimaal werkend voorbeeld (bestandsgebaseerd)
 

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -135,6 +135,94 @@ Zie [Ensemble](methodologie/ensemble.md) voor uitleg over hoe de gewichten tot s
 
 MAE en MAPE worden berekend **exclusief numerus-fixusopleidingen**. Voor deze opleidingen worden de foutkolommen op `NaN` gezet. De reden: bij numerus-fixusopleidingen wordt het voorspelde aantal afgekapt op de capaciteitslimiet, waardoor de modelfouten niet vergelijkbaar zijn met reguliere opleidingen.
 
+## Het model evalueren (`evaluate_predictions`)
+
+De per-rij `MAE_*`/`MAPE_*`-kolommen hierboven zijn handig om één rij te lezen, maar voor **modelevaluatie** wil je geaggregeerde, scalaire metrieken (één getal per model). Daarvoor levert het pakket `evaluate_predictions`:
+
+```python
+from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, DataOption
+
+result = run_pipeline_from_dataframes(
+    year=2023, week=12,
+    data_cumulative=df_cum, data_student_numbers=df_sc,
+    dataset=DataOption.CUMULATIVE, save_output=False,
+)
+
+metrics = evaluate_predictions(result, week=12)
+print(metrics)
+```
+
+De functie vergelijkt elke voorspelkolom met de gerealiseerde `Aantal_studenten` en geeft per model één rij terug met:
+
+| Metriek | Betekenis | Interpretatie |
+|---------|-----------|---------------|
+| `n` | aantal meegetelde (opleiding × herkomst)-rijen | klein `n` → metriek is ruisgevoelig |
+| `mae` | Mean Absolute Error | gemiddelde afwijking in studenten |
+| `mape` | Mean Absolute Percentage Error (fractie) | elke opleiding telt even zwaar — kleine opleidingen domineren |
+| `wape` | Weighted APE = `Σ\|fout\| / Σ\|werkelijk\|` (fractie) | instellingsbrede procentuele fout, robuust tegen kleine opleidingen |
+| `rmse` | Root Mean Squared Error | straft grote uitschieters zwaarder |
+| `bias` | gemiddelde `voorspeld − werkelijk` | positief = structurele overschatting |
+| `r2` | determinatiecoëfficiënt | aandeel verklaarde variantie |
+
+`mape` en `wape` zijn fracties (`0.08` betekent 8%). De metrieken gebruiken dezelfde primitieven en numerus-fixus-uitsluiting als de `MAE_*`-kolommen, dus ze zijn consistent met de rest van de output.
+
+!!! warning "Evalueren kan alleen via een backtest"
+    Een model evalueren betekent voorspellingen vergelijken met de **gerealiseerde** instroom. Voor het lopende, nog niet afgeronde collegejaar bestaat die realisatie nog niet — `Aantal_studenten` is dan leeg en `evaluate_predictions` geeft een foutmelding. Evalueer daarom een **afgerond** collegejaar (bijv. voorspel `year=2023` terwijl je de realisatie van 2023 als `data_student_numbers` meegeeft). De modellen trainen sowieso alleen op jaren vóór het voorspeljaar, dus zo'n backtest lekt geen toekomstinformatie.
+
+!!! tip "Geef altijd `week` mee bij cumulatieve output"
+    In het cumulatieve spoor draagt alleen de **peilweekrij** de `SARIMA_cumulative`-voorspelling; latere weken bevatten enkel de vooraanmeldcurve (met `NaN` als voorspelling). Zonder `week=`-filter mengt `Prognose_ratio` bovendien meerdere weken. Geef de gebruikte peilweek mee (`evaluate_predictions(result, week=12)`) voor een zuivere, één-rij-per-opleiding vergelijking tussen modellen.
+
+Segmenteer met `group_by` (bijv. `group_by="Examentype"` of `group_by=["Examentype", "Herkomst"]`) om te zien waar een model structureel afwijkt.
+
+### Backtesten over meerdere jaren (`pivot_metrics`)
+
+Eén afgerond jaar is **één datapunt**: de instroom schommelt jaar-op-jaar om redenen buiten het model. Voor een eerlijk beeld backtest je daarom meerdere afgeronde jaren op dezelfde peilweek, evalueer je per jaar met `group_by="Collegejaar"`, en draai je het resultaat met `pivot_metrics` tot een model × jaar-matrix:
+
+```python
+import pandas as pd
+from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, pivot_metrics, DataOption
+
+WEEK = 10
+frames = [
+    run_pipeline_from_dataframes(
+        year=jaar, week=WEEK, data_cumulative=df_cum,
+        data_student_numbers=df_sc, dataset=DataOption.CUMULATIVE, save_output=False,
+    )
+    for jaar in (2021, 2022, 2023)            # afgeronde jaren met realisatie
+]
+
+metrics = evaluate_predictions(pd.concat(frames, ignore_index=True),
+                               week=WEEK, group_by="Collegejaar")
+print(pivot_metrics(metrics, value="wape", over="Collegejaar").round(3))
+```
+
+```text
+                    2021   2022   2023   mean    min    max  n_groups
+prediction
+Prognose_ratio     0.078  0.071  0.069  0.073  0.069  0.078         3
+SARIMA_cumulative  0.063  0.058  0.066  0.062  0.058  0.066         3
+```
+
+De `mean`-kolom is het gemiddelde over de jaren; `min`/`max` tonen de spreiding. Ligt de jaar-op-jaar spreiding in dezelfde orde als het verschil tussen modellen, trek dan geen harde conclusie uit één jaar. Kies met `value=` een andere metriek (`"mae"`, `"mape"`, …) en met `over=` een andere as (bijv. `over="Weeknummer"` voor de accuraatheid-over-tijd-curve bij één jaar).
+
+### Metrieken loggen in MS Fabric / Databricks (MLflow)
+
+Beide platforms hebben **MLflow** als ingebouwde experiment-tracker. `to_mlflow_metrics` vlakt het resultaat af tot een dict die je direct kunt loggen, zodat de metrieken in de Fabric/Databricks ML-experiment-UI verschijnen en over runs (jaar/peilweek) vergelijkbaar zijn:
+
+```python
+import mlflow
+from studentprognose import evaluate_predictions, to_mlflow_metrics
+
+metrics = evaluate_predictions(result, week=WEEK)
+
+with mlflow.start_run(run_name=f"prognose_{YEAR}_wk{WEEK}"):
+    mlflow.log_params({"year": YEAR, "week": WEEK, "dataset": "cumulatief"})
+    mlflow.log_metrics(to_mlflow_metrics(metrics))
+    mlflow.log_table(metrics, "metrics.json")  # volledige tabel als artifact
+```
+
+`mlflow` zit standaard in de Fabric- en Databricks-runtime; in een Fabric-notebook worden runs automatisch aan het gekoppelde experiment gehangen. Wil je geen MLflow gebruiken, dan kun je het `metrics`-DataFrame ook gewoon naar een Lakehouse/Delta-tabel wegschrijven voor je eigen monitoring.
+
 ## Interactief dashboard
 
 Naast de Excel-bestanden kan de pipeline interactieve HTML-dashboards genereren onder `data/output/visualisaties/`. Per modus (`-d i`, `-d c`, `-d b`) wordt een apart dashboard aangemaakt met daarin:

--- a/notebooks/implementatie.ipynb
+++ b/notebooks/implementatie.ipynb
@@ -626,6 +626,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4fa0bd98",
+   "source": "## Stap 4b — Model evalueren en metrieken loggen (MLflow / Fabric)\n\nOm het model te **evalueren** vergelijk je de voorspellingen met de gerealiseerde instroom. Dat kan alleen voor een **afgerond** collegejaar (zoals `YEAR = 2023` hierboven): voor het lopende jaar bestaat de realisatie nog niet. De modellen trainen sowieso alleen op jaren vóór het voorspeljaar, dus dit is een lekvrije backtest.\n\n`evaluate_predictions` aggregeert de output tot scalaire metrieken per model (MAE, MAPE, WAPE, RMSE, bias, R²). Geef de peilweek mee (`week=WEEK`): in het cumulatieve spoor draagt alleen de peilweekrij de `SARIMA_cumulative`-voorspelling.\n\nZie [Output begrijpen → Het model evalueren](https://cedanl.github.io/studentprognose/output-begrijpen/#het-model-evalueren-evaluate_predictions).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "068f236e",
+   "source": "from studentprognose import evaluate_predictions, to_mlflow_metrics\n\n# Scalaire metrieken per model (alleen zinvol als de realisatie bekend is)\nmetrics = evaluate_predictions(result, week=WEEK)\nprint(metrics.to_string(index=False))\n\n# Naar MLflow loggen (ingebouwd in MS Fabric en Databricks).\n# In een Fabric-notebook hangt de run automatisch aan het gekoppelde experiment.\ntry:\n    import mlflow\n\n    with mlflow.start_run(run_name=f\"prognose_{YEAR}_wk{WEEK}\"):\n        mlflow.log_params({\"year\": YEAR, \"week\": WEEK, \"dataset\": \"cumulatief\"})\n        mlflow.log_metrics(to_mlflow_metrics(metrics))\n        mlflow.log_table(metrics, \"metrics.json\")  # volledige tabel als artifact\n    print(\"Metrieken gelogd naar MLflow.\")\nexcept ImportError:\n    print(\"mlflow niet beschikbaar (buiten Fabric/Databricks) — metrics-DataFrame staat hierboven.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c63118ff",
+   "source": "### Backtesten over meerdere jaren (`pivot_metrics`)\n\nEén afgerond jaar is **één datapunt**. Voor een eerlijk beeld backtest je meerdere afgeronde jaren op dezelfde peilweek, evalueer je per jaar met `group_by=\"Collegejaar\"`, en vat je dat samen tot een model × jaar-matrix met `pivot_metrics`. De `mean`-kolom is het gemiddelde over de jaren; `min`/`max` tonen de spreiding — ligt die in dezelfde orde als het verschil tussen modellen, trek dan geen harde conclusie uit één jaar.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "84e1d009",
+   "source": "from studentprognose import pivot_metrics\n\n# Backtest: voorspel meerdere AFGERONDE jaren op dezelfde peilweek en score ze samen.\nBACKTEST_JAREN = [2021, 2022, 2023]\n\nframes = []\nfor jaar in BACKTEST_JAREN:\n    res = run_pipeline_from_dataframes(\n        year=jaar, week=WEEK,\n        data_cumulative=df_cum, data_student_numbers=df_sc,\n        configuration=config, dataset=DataOption.CUMULATIVE, save_output=False,\n    )\n    frames.append(res.assign(Collegejaar=jaar))\n\n# Per jaar evalueren, dan tot een model x jaar-matrix draaien (WAPE).\nbacktest = evaluate_predictions(\n    pd.concat(frames, ignore_index=True), week=WEEK, group_by=\"Collegejaar\"\n)\nprint(pivot_metrics(backtest, value=\"wape\", over=\"Collegejaar\").round(3))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "e1f2a3b4",
    "metadata": {},
    "source": [

--- a/src/studentprognose/__init__.py
+++ b/src/studentprognose/__init__.py
@@ -2,6 +2,11 @@ from studentprognose.config import load_configuration, load_defaults_filtering, 
 from studentprognose.data.loader import load_data
 from studentprognose.main import run_pipeline_cli, run_pipeline_from_dataframes
 from studentprognose.cli import PipelineConfig
+from studentprognose.output.evaluation import (
+    evaluate_predictions,
+    pivot_metrics,
+    to_mlflow_metrics,
+)
 from studentprognose.utils.weeks import DataOption, StudentYearPrediction
 
 __all__ = [
@@ -11,6 +16,9 @@ __all__ = [
     "load_data",
     "run_pipeline_cli",
     "run_pipeline_from_dataframes",
+    "evaluate_predictions",
+    "pivot_metrics",
+    "to_mlflow_metrics",
     "PipelineConfig",
     "DataOption",
     "StudentYearPrediction",

--- a/src/studentprognose/output/evaluation.py
+++ b/src/studentprognose/output/evaluation.py
@@ -1,0 +1,395 @@
+"""Aggregeer pipeline-output tot scalaire evaluatiemetrieken.
+
+Vergelijkt de voorspelkolommen in de pipeline-output (zoals teruggegeven door
+:func:`studentprognose.run_pipeline_from_dataframes`) met de gerealiseerde
+``Aantal_studenten`` en vat dat samen tot scalaire metrieken per voorspelmethode.
+Bedoeld voor backtesting en monitoring: log de uitkomst naar MLflow
+(MS Fabric / Databricks) of een eigen monitoring-tabel.
+
+Belangrijk: evalueren kan alleen voor een (jaar, week) waarvoor de realisatie al
+bekend is. Voor het lopende, nog niet afgeronde collegejaar bestaat er geen
+``Aantal_studenten`` en is evaluatie per definitie niet mogelijk — kies dan een
+eerder collegejaar (backtest) en geef de bijbehorende realisatie mee als
+``data_student_numbers``.
+
+De metrieken zelf worden berekend met de canonieke primitieven uit
+:mod:`studentprognose.benchmark.metrics`, zodat ze identiek zijn aan wat de
+benchmark-CLI en de per-rij ``MAE_*``/``MAPE_*``-kolommen in de output gebruiken.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from studentprognose.benchmark.metrics import mae as _mae, mape as _mape, rmse as _rmse
+
+# Kandidaat-voorspelkolommen, van "samengesteld" naar "enkelvoudig model".
+# Exact dezelfde set die PostProcessor._create_error_columns van foutkolommen
+# voorziet, zodat evaluate_predictions dezelfde kolommen meet als de pipeline.
+# 'Baseline' (duplicaat van Prognose_ratio) en 'Voorspelde vooraanmelders'
+# (geen studentaantal-voorspelling) horen hier bewust niet bij.
+_CANDIDATE_PREDICTIONS = (
+    "Weighted_ensemble_prediction",
+    "Average_ensemble_prediction",
+    "Ensemble_prediction",
+    "Prognose_ratio",
+    "SARIMA_cumulative",
+    "SARIMA_individual",
+)
+
+# Volgorde van de metriekkolommen in het resultaat-DataFrame.
+_METRIC_COLS = ["n", "mae", "mape", "wape", "rmse", "bias", "r2"]
+
+# MLflow staat alleen [A-Za-z0-9_\-./ ] toe in metric-namen.
+_MLFLOW_KEY_INVALID = re.compile(r"[^A-Za-z0-9_\-./ ]")
+
+
+def _wape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Weighted Absolute Percentage Error: sum|fout| / sum|werkelijk|.
+
+    Robuuster dan MAPE bij kleine opleidingen: weegt elke voorspelling naar
+    omvang in plaats van elke (opleiding × herkomst) gelijk. Retourneert een
+    fractie (0.08 == 8%).
+    """
+    denom = float(np.sum(np.abs(y_true)))
+    if denom == 0:
+        return np.nan
+    return float(np.sum(np.abs(y_true - y_pred)) / denom)
+
+
+def _bias(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Gemiddelde signed fout (voorspeld - werkelijk). Positief = overschatting."""
+    if len(y_true) == 0:
+        return np.nan
+    return float(np.mean(y_pred - y_true))
+
+
+def _r2(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Determinatiecoëfficiënt R². NaN bij < 2 punten of nul-variantie."""
+    if len(y_true) < 2:
+        return np.nan
+    ss_tot = float(np.sum((y_true - np.mean(y_true)) ** 2))
+    if ss_tot == 0:
+        return np.nan
+    ss_res = float(np.sum((y_true - y_pred) ** 2))
+    return float(1.0 - ss_res / ss_tot)
+
+
+def _valid_mask(
+    frame: pd.DataFrame,
+    actual_column: str,
+    pred: str,
+    nf_set: set,
+    programme_column: str,
+) -> pd.Series:
+    """Bepaal welke rijen meetellen voor voorspelkolom ``pred``.
+
+    Gebruikt bij voorkeur de door de pipeline berekende ``MAE_<pred>``-kolom: die
+    codeert al zowel ``actual``- en ``pred``-notna als de numerus-fixus-uitsluiting,
+    zodat de aggregatie exact dezelfde populatie meet als de per-rij foutkolommen.
+    Valt terug op een eigen notna-masker (plus optionele NF-uitsluiting) wanneer die
+    foutkolom ontbreekt, bijvoorbeeld bij een zelf toegevoegde voorspelkolom.
+    """
+    mae_col = f"MAE_{pred}"
+    if mae_col in frame.columns:
+        return frame[mae_col].notna()
+
+    valid = frame[actual_column].notna() & frame[pred].notna()
+    if nf_set and programme_column in frame.columns:
+        valid &= ~frame[programme_column].isin(nf_set)
+    return valid
+
+
+def _metrics_for(
+    frame: pd.DataFrame,
+    actual_column: str,
+    pred: str,
+    nf_set: set,
+    programme_column: str,
+) -> dict | None:
+    """Bereken het scalaire metriekrijtje voor één voorspelkolom op één (sub)frame."""
+    valid = _valid_mask(frame, actual_column, pred, nf_set, programme_column)
+    sub = frame[valid]
+    if sub.empty:
+        return None
+
+    y_true = sub[actual_column].to_numpy(dtype="float64")
+    y_pred = sub[pred].to_numpy(dtype="float64")
+
+    return {
+        "n": int(len(sub)),
+        "mae": _mae(y_true, y_pred),
+        "mape": _mape(y_true, y_pred),
+        "wape": _wape(y_true, y_pred),
+        "rmse": _rmse(y_true, y_pred),
+        "bias": _bias(y_true, y_pred),
+        "r2": _r2(y_true, y_pred),
+    }
+
+
+def evaluate_predictions(
+    data: pd.DataFrame,
+    *,
+    actual_column: str = "Aantal_studenten",
+    prediction_columns: list[str] | None = None,
+    week: int | None = None,
+    group_by: str | list[str] | None = None,
+    numerus_fixus: list[str] | dict | None = None,
+    programme_column: str = "Croho groepeernaam",
+) -> pd.DataFrame:
+    """Vat de voorspel-output samen tot scalaire evaluatiemetrieken per model.
+
+    Vergelijkt elke voorspelkolom met ``actual_column`` (de gerealiseerde
+    studentaantallen) en geeft per voorspelmethode MAE, MAPE, WAPE, RMSE, bias en R²
+    terug. Rijen zonder realisatie of zonder voorspelling worden per voorspelkolom
+    overgeslagen; numerus-fixusopleidingen tellen niet mee (consistent met de
+    ``MAE_*``-kolommen die de pipeline al berekent).
+
+    Args:
+        data: Pipeline-output, zoals teruggegeven door
+            :func:`run_pipeline_from_dataframes`.
+        actual_column: Kolom met de gerealiseerde aantallen. Standaard
+            ``"Aantal_studenten"``.
+        prediction_columns: Welke voorspelkolommen te evalueren. Bij ``None`` worden
+            de standaard modelkolommen gebruikt die in ``data`` aanwezig zijn.
+        week: Beperk de evaluatie tot één peilweek (``Weeknummer``). Sterk aanbevolen
+            bij cumulatieve output: alleen de peilweekrij draagt de
+            ``SARIMA_cumulative``-voorspelling, terwijl latere weken enkel de
+            vooraanmeldcurve bevatten. Geef de gebruikte ``WEEK`` mee voor een
+            zuivere vergelijking tussen modellen.
+        group_by: Optionele kolom(men) om per segment te rapporteren (bijv.
+            ``"Examentype"`` of ``["Examentype", "Herkomst"]``).
+        numerus_fixus: NF-opleidingen om uit te sluiten in het terugvalpad (wanneer er
+            geen ``MAE_<pred>``-kolom is). Accepteert een lijst of een dict (sleutels).
+        programme_column: Kolom met de opleidingsnaam, gebruikt voor NF-uitsluiting.
+
+    Returns:
+        Een long-format DataFrame met één rij per (voorspelkolom × groep) en de
+        kolommen ``prediction``, eventuele ``group_by``-kolommen, en
+        ``n, mae, mape, wape, rmse, bias, r2``. MAPE en WAPE zijn fracties
+        (0.08 == 8%). Leeg DataFrame als niets evalueerbaar is.
+
+    Raises:
+        ValueError: Als ``data`` ``None`` is, of ``actual_column`` ontbreekt — dat
+            laatste betekent meestal dat je een nog niet afgerond collegejaar
+            probeert te evalueren (geef realisatiedata mee of kies een eerder jaar).
+
+    Example::
+
+        from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, DataOption
+
+        result = run_pipeline_from_dataframes(
+            year=2023, week=12,
+            data_cumulative=df_cum, data_student_numbers=df_sc,
+            dataset=DataOption.CUMULATIVE, save_output=False,
+        )
+        metrics = evaluate_predictions(result, week=12)
+        print(metrics)
+    """
+    if data is None:
+        raise ValueError("evaluate_predictions kreeg geen DataFrame (data is None).")
+
+    if actual_column not in data.columns:
+        raise ValueError(
+            f"Kolom {actual_column!r} ontbreekt in de output, dus er valt niets te "
+            "evalueren. Dit gebeurt als je een nog niet afgerond collegejaar voorspelt: "
+            "geef realisatiedata mee via data_student_numbers en evalueer een eerder "
+            "(afgerond) collegejaar."
+        )
+
+    group_cols: list[str] = (
+        [group_by] if isinstance(group_by, str) else list(group_by) if group_by else []
+    )
+
+    frame = data
+    if week is not None:
+        if "Weeknummer" not in frame.columns:
+            raise ValueError("week-filter gevraagd maar kolom 'Weeknummer' ontbreekt.")
+        frame = frame[frame["Weeknummer"] == week]
+        if frame.empty:
+            warnings.warn(
+                f"Geen rijen voor week {week}; resultaat is leeg.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    if prediction_columns is None:
+        prediction_columns = [c for c in _CANDIDATE_PREDICTIONS if c in frame.columns]
+    else:
+        missing = [c for c in prediction_columns if c not in frame.columns]
+        if missing:
+            raise ValueError(f"Voorspelkolommen ontbreken in data: {missing}")
+
+    if not prediction_columns:
+        warnings.warn(
+            "Geen evalueerbare voorspelkolommen gevonden in de output.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return pd.DataFrame(columns=["prediction"] + group_cols + _METRIC_COLS)
+
+    if isinstance(numerus_fixus, dict):
+        nf_set = set(numerus_fixus.keys())
+    elif numerus_fixus:
+        nf_set = set(numerus_fixus)
+    else:
+        nf_set = set()
+
+    rows: list[dict] = []
+    for pred in prediction_columns:
+        if group_cols:
+            for group_vals, sub in frame.groupby(group_cols, dropna=False):
+                metrics = _metrics_for(sub, actual_column, pred, nf_set, programme_column)
+                if metrics is None:
+                    continue
+                if not isinstance(group_vals, tuple):
+                    group_vals = (group_vals,)
+                row = {"prediction": pred}
+                row.update(dict(zip(group_cols, group_vals)))
+                row.update(metrics)
+                rows.append(row)
+        else:
+            metrics = _metrics_for(frame, actual_column, pred, nf_set, programme_column)
+            if metrics is None:
+                continue
+            row = {"prediction": pred}
+            row.update(metrics)
+            rows.append(row)
+
+    if not rows:
+        return pd.DataFrame(columns=["prediction"] + group_cols + _METRIC_COLS)
+
+    result = pd.DataFrame(rows, columns=["prediction"] + group_cols + _METRIC_COLS)
+    return result.sort_values(["prediction"] + group_cols, ignore_index=True)
+
+
+def pivot_metrics(
+    metrics: pd.DataFrame,
+    *,
+    value: str = "wape",
+    over: str = "Collegejaar",
+    summary: bool = True,
+) -> pd.DataFrame:
+    """Vat gegroepeerde metrieken samen tot een model × ``over``-matrix.
+
+    Bedoeld om een backtest over meerdere afgeronde jaren (of peilweken) in één oogopslag
+    te lezen: één rij per voorspelmodel, één kolom per groepswaarde van ``over`` (bijv. per
+    collegejaar), gevuld met de gekozen metriek ``value`` (standaard WAPE — robuust tegen
+    kleine opleidingen). Met ``summary=True`` komen er samenvattende kolommen bij — het
+    gemiddelde over de groepen plus de spreiding (``min``/``max``) — zodat je ziet of de
+    jaar-op-jaar variatie de verschillen tussen modellen overschaduwt.
+
+    Werkt op de output van :func:`evaluate_predictions`; voer eerst de evaluatie per groep
+    uit met ``group_by``. Pivoteer je op een grovere as dan waarop is gegroepeerd, dan worden
+    de fijnere groepen per cel gemiddeld (ongewogen).
+
+    Args:
+        metrics: Long-format resultaat van :func:`evaluate_predictions`, dat naast
+            ``prediction`` ook de groepskolom ``over`` bevat.
+        value: Welke metriek in de cellen komt; één van ``n, mae, mape, wape, rmse, bias, r2``.
+            Standaard ``"wape"`` (robuust tegen kleine opleidingen).
+        over: De groepskolom die de matrixkolommen vormt (bijv. ``"Collegejaar"`` of
+            ``"Weeknummer"``). Standaard ``"Collegejaar"``.
+        summary: Voeg ``mean``/``min``/``max`` over de groepen toe, plus ``n_groups``
+            (aantal groepen met een waarde). Standaard ``True``.
+
+    Returns:
+        Een wide-format DataFrame, geïndexeerd op ``prediction``, met één kolom per
+        groepswaarde en eventueel de samenvattingskolommen. Leeg DataFrame als ``metrics``
+        leeg is.
+
+    Raises:
+        ValueError: Als ``metrics`` geen ``prediction``-kolom heeft, of als ``value``/``over``
+            ontbreken — een ontbrekende ``over``-kolom betekent meestal dat je ``group_by``
+            in :func:`evaluate_predictions` bent vergeten.
+
+    Example::
+
+        # Backtest: voorspel meerdere afgeronde jaren op dezelfde peilweek en score ze samen.
+        frames = [
+            run_pipeline_from_dataframes(
+                year=jaar, week=WEEK, data_cumulative=df_cum,
+                data_student_numbers=df_sc, dataset=DataOption.CUMULATIVE, save_output=False,
+            )
+            for jaar in (2021, 2022, 2023)
+        ]
+        metrics = evaluate_predictions(pd.concat(frames, ignore_index=True),
+                                       week=WEEK, group_by="Collegejaar")
+        print(pivot_metrics(metrics, value="wape", over="Collegejaar").round(3))
+    """
+    if "prediction" not in metrics.columns:
+        raise ValueError(
+            "metrics mist de kolom 'prediction'; geef het resultaat van evaluate_predictions door."
+        )
+    if value not in metrics.columns:
+        raise ValueError(f"Onbekende metriek {value!r}; kies uit {_METRIC_COLS}.")
+    if over not in metrics.columns:
+        raise ValueError(
+            f"Groepskolom {over!r} ontbreekt in metrics. Gebruik group_by={over!r} in "
+            "evaluate_predictions zodat de metriek per groep wordt berekend."
+        )
+
+    if metrics.empty:
+        return pd.DataFrame(index=pd.Index([], name="prediction"))
+
+    table = metrics.pivot_table(index="prediction", columns=over, values=value, aggfunc="mean")
+    table = table.sort_index(axis=1)
+    table.columns.name = None
+    # Toon hele jaren/weken als int (2023) i.p.v. float (2023.0), net als dashboard.py.
+    if pd.api.types.is_float_dtype(table.columns):
+        table.columns = table.columns.astype("int64")
+
+    if summary:
+        period_cols = list(table.columns)
+        periods = table[period_cols]
+        table["mean"] = periods.mean(axis=1)
+        table["min"] = periods.min(axis=1)
+        table["max"] = periods.max(axis=1)
+        table["n_groups"] = periods.notna().sum(axis=1).astype(int)
+
+    return table
+
+
+def to_mlflow_metrics(
+    metrics: pd.DataFrame,
+    *,
+    prefix: str = "",
+) -> dict[str, float]:
+    """Vlak een :func:`evaluate_predictions`-resultaat af tot ``{naam: waarde}``.
+
+    Klaar voor ``mlflow.log_metrics(...)`` in een MS Fabric- of Databricks-notebook.
+    Sleutels zijn ``f"{prefix}{METRIC}_{prediction}"``; bij een gegroepeerd resultaat
+    worden de groepswaarden achteraan de sleutel toegevoegd. ``NaN``-waarden worden
+    overgeslagen (MLflow accepteert geen ``NaN``) en tekens die MLflow niet toestaat
+    in metric-namen worden vervangen door ``_``.
+
+    Args:
+        metrics: Resultaat van :func:`evaluate_predictions`.
+        prefix: Optioneel voorvoegsel voor elke sleutel (bijv. ``"cumulatief/"``).
+
+    Returns:
+        Platte dict van metricnaam naar float.
+
+    Example::
+
+        import mlflow
+        metrics = evaluate_predictions(result, week=12)
+        mlflow.log_metrics(to_mlflow_metrics(metrics))
+    """
+    group_cols = [c for c in metrics.columns if c not in (["prediction"] + _METRIC_COLS)]
+
+    out: dict[str, float] = {}
+    for _, row in metrics.iterrows():
+        suffix_parts = [str(row[g]) for g in group_cols]
+        for metric in _METRIC_COLS:
+            val = row[metric]
+            if pd.isna(val):
+                continue
+            key = prefix + "_".join([metric.upper(), str(row["prediction"])] + suffix_parts)
+            key = _MLFLOW_KEY_INVALID.sub("_", key)
+            out[key] = float(val)
+    return out

--- a/tests/studentprognose/test_evaluation.py
+++ b/tests/studentprognose/test_evaluation.py
@@ -1,0 +1,280 @@
+"""Tests voor studentprognose.output.evaluation (aggregatie van output naar metrieken)."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from studentprognose.output.evaluation import (
+    evaluate_predictions,
+    pivot_metrics,
+    to_mlflow_metrics,
+)
+
+
+def _sample_output():
+    """Mini-output die de structuur van een cumulatieve run nabootst.
+
+    - 'A' en 'B' zijn reguliere opleidingen; 'NF' is numerus fixus.
+    - SARIMA_cumulative staat (net als in productie) alleen op de peilweek (week 12);
+      latere weken (week 20) zijn NaN.
+    - Prognose_ratio is op meerdere weken gevuld.
+    - De MAE_*-kolommen zijn al door de pipeline berekend en zetten de NF-rij op NaN.
+    """
+    return pd.DataFrame(
+        {
+            "Croho groepeernaam": ["A", "A", "B", "B", "NF"],
+            "Herkomst": ["NL", "NL", "NL", "NL", "NL"],
+            "Examentype": ["Bachelor", "Bachelor", "Master", "Master", "Bachelor"],
+            "Collegejaar": [2023, 2023, 2023, 2023, 2023],
+            "Weeknummer": [12, 20, 12, 20, 12],
+            "SARIMA_cumulative": [100.0, np.nan, 200.0, np.nan, 50.0],
+            "Prognose_ratio": [110.0, 95.0, 190.0, 205.0, 55.0],
+            "Aantal_studenten": [120.0, 120.0, 180.0, 180.0, 60.0],
+            "MAE_SARIMA_cumulative": [20.0, np.nan, 20.0, np.nan, np.nan],
+            "MAE_Prognose_ratio": [10.0, 25.0, 10.0, 25.0, np.nan],
+            "MAPE_SARIMA_cumulative": [20 / 120, np.nan, 20 / 180, np.nan, np.nan],
+            "MAPE_Prognose_ratio": [10 / 120, 25 / 120, 10 / 180, 25 / 180, np.nan],
+        }
+    )
+
+
+def test_returns_row_per_prediction_column():
+    metrics = evaluate_predictions(_sample_output(), week=12)
+    assert set(metrics["prediction"]) == {"SARIMA_cumulative", "Prognose_ratio"}
+    assert list(metrics.columns) == [
+        "prediction",
+        "n",
+        "mae",
+        "mape",
+        "wape",
+        "rmse",
+        "bias",
+        "r2",
+    ]
+
+
+def test_week_filter_selects_peilweek_only():
+    metrics = evaluate_predictions(_sample_output(), week=12)
+    sarima = metrics[metrics["prediction"] == "SARIMA_cumulative"].iloc[0]
+    # Alleen A en B op week 12 tellen mee (NF uitgesloten via MAE-kolom).
+    assert sarima["n"] == 2
+    assert sarima["mae"] == pytest.approx(20.0)
+    # WAPE = (20 + 20) / (120 + 180)
+    assert sarima["wape"] == pytest.approx(40 / 300)
+    # bias = mean(100-120, 200-180) = 0
+    assert sarima["bias"] == pytest.approx(0.0)
+
+
+def test_numerus_fixus_excluded_via_existing_mae_column():
+    metrics = evaluate_predictions(_sample_output(), week=12)
+    # NF-rij heeft Aantal_studenten 60 en pred 50; als die meetelde zou n=3 zijn.
+    sarima = metrics[metrics["prediction"] == "SARIMA_cumulative"].iloc[0]
+    assert sarima["n"] == 2
+
+
+def test_nan_predictions_do_not_crash_and_are_skipped():
+    # Zonder week-filter: SARIMA_cumulative is NaN op week 20 → alleen week-12-rijen tellen.
+    metrics = evaluate_predictions(_sample_output())
+    sarima = metrics[metrics["prediction"] == "SARIMA_cumulative"].iloc[0]
+    assert sarima["n"] == 2
+    # Prognose_ratio is op week 12 én 20 gevuld → 4 rijen (NF uitgesloten).
+    ratio = metrics[metrics["prediction"] == "Prognose_ratio"].iloc[0]
+    assert ratio["n"] == 4
+    assert ratio["mae"] == pytest.approx((10 + 25 + 10 + 25) / 4)
+
+
+def test_group_by_segments():
+    metrics = evaluate_predictions(_sample_output(), week=12, group_by="Examentype")
+    assert "Examentype" in metrics.columns
+    sarima = metrics[metrics["prediction"] == "SARIMA_cumulative"]
+    assert set(sarima["Examentype"]) == {"Bachelor", "Master"}
+    bachelor = sarima[sarima["Examentype"] == "Bachelor"].iloc[0]
+    assert bachelor["n"] == 1
+    assert bachelor["mae"] == pytest.approx(20.0)
+
+
+def test_custom_prediction_column_with_numerus_fixus_list():
+    df = _sample_output().drop(columns=["MAE_SARIMA_cumulative", "MAE_Prognose_ratio"])
+    df["MijnVoorspelling"] = [100.0, np.nan, 200.0, np.nan, 50.0]
+    metrics = evaluate_predictions(
+        df,
+        week=12,
+        prediction_columns=["MijnVoorspelling"],
+        numerus_fixus=["NF"],
+    )
+    row = metrics.iloc[0]
+    assert row["prediction"] == "MijnVoorspelling"
+    assert row["n"] == 2  # NF uitgesloten via meegegeven lijst
+
+
+def test_missing_actual_column_raises():
+    df = _sample_output().drop(columns=["Aantal_studenten"])
+    with pytest.raises(ValueError, match="Aantal_studenten"):
+        evaluate_predictions(df, week=12)
+
+
+def test_none_data_raises():
+    with pytest.raises(ValueError, match="None"):
+        evaluate_predictions(None)
+
+
+def test_unknown_prediction_column_raises():
+    with pytest.raises(ValueError, match="ontbreken"):
+        evaluate_predictions(_sample_output(), prediction_columns=["Bestaat_niet"])
+
+
+def test_to_mlflow_metrics_flat_keys_and_no_nan():
+    metrics = evaluate_predictions(_sample_output(), week=12)
+    flat = to_mlflow_metrics(metrics)
+    assert flat["MAE_SARIMA_cumulative"] == pytest.approx(20.0)
+    assert "WAPE_SARIMA_cumulative" in flat
+    assert all(isinstance(v, float) for v in flat.values())
+    assert all(not math.isnan(v) for v in flat.values())
+
+
+def test_to_mlflow_metrics_grouped_keys_sanitized():
+    metrics = evaluate_predictions(_sample_output(), week=12, group_by="Examentype")
+    flat = to_mlflow_metrics(metrics, prefix="cumulatief/")
+    # Sleutel bevat het prefix, de metriek, het model en de groepswaarde.
+    assert "cumulatief/MAE_SARIMA_cumulative_Bachelor" in flat
+    # Geen ongeldige tekens in de sleutels.
+    import re
+
+    assert all(re.fullmatch(r"[A-Za-z0-9_\-./ ]+", k) for k in flat)
+
+
+def test_empty_after_week_filter_returns_empty_with_columns():
+    with pytest.warns(UserWarning):
+        metrics = evaluate_predictions(_sample_output(), week=99)
+    assert metrics.empty
+    assert "prediction" in metrics.columns
+
+
+# --- pivot_metrics (View 3: model × jaar matrix + spreiding) ---------------------
+
+
+def _sample_metrics():
+    """Long-format metrieken zoals evaluate_predictions(..., group_by='Collegejaar').
+
+    Twee modellen over drie backtest-jaren; 'Prognose_ratio' mist 2023 om de
+    gaten-afhandeling (n_groups / min / max) te testen.
+    """
+    return pd.DataFrame(
+        {
+            "prediction": [
+                "SARIMA_cumulative",
+                "SARIMA_cumulative",
+                "SARIMA_cumulative",
+                "Prognose_ratio",
+                "Prognose_ratio",
+            ],
+            "Collegejaar": [2021, 2022, 2023, 2021, 2022],
+            "n": [10, 11, 12, 10, 11],
+            "mae": [8.0, 7.0, 6.0, 9.0, 8.0],
+            "mape": [0.10, 0.09, 0.08, 0.12, 0.11],
+            "wape": [0.06, 0.05, 0.04, 0.08, 0.07],
+            "rmse": [12.0, 11.0, 10.0, 14.0, 13.0],
+            "bias": [1.0, -1.0, 0.5, -2.0, 1.0],
+            "r2": [0.97, 0.98, 0.99, 0.95, 0.96],
+        }
+    )
+
+
+def test_pivot_shape_index_and_columns():
+    table = pivot_metrics(_sample_metrics(), value="wape", over="Collegejaar")
+    assert table.index.name == "prediction"
+    assert set(table.index) == {"SARIMA_cumulative", "Prognose_ratio"}
+    assert [c for c in (2021, 2022, 2023)] == [c for c in table.columns if isinstance(c, int)]
+    assert ["mean", "min", "max", "n_groups"] == list(table.columns)[-4:]
+
+
+def test_pivot_cell_values_are_the_chosen_metric():
+    table = pivot_metrics(_sample_metrics(), value="wape", over="Collegejaar")
+    assert table.loc["SARIMA_cumulative", 2022] == pytest.approx(0.05)
+    assert table.loc["Prognose_ratio", 2021] == pytest.approx(0.08)
+
+
+def test_pivot_summary_mean_min_max_and_n_groups():
+    table = pivot_metrics(_sample_metrics(), value="wape", over="Collegejaar")
+    sarima = table.loc["SARIMA_cumulative"]
+    assert sarima["mean"] == pytest.approx((0.06 + 0.05 + 0.04) / 3)
+    assert sarima["min"] == pytest.approx(0.04)
+    assert sarima["max"] == pytest.approx(0.06)
+    assert sarima["n_groups"] == 3
+    # Prognose_ratio mist 2023 → die cel is NaN en telt niet mee in summary.
+    ratio = table.loc["Prognose_ratio"]
+    assert math.isnan(ratio[2023])
+    assert ratio["n_groups"] == 2
+    assert ratio["mean"] == pytest.approx((0.08 + 0.07) / 2)
+
+
+def test_pivot_value_selects_other_metric():
+    table = pivot_metrics(_sample_metrics(), value="mae", over="Collegejaar")
+    assert table.loc["SARIMA_cumulative", 2021] == pytest.approx(8.0)
+
+
+def test_pivot_summary_false_only_group_columns():
+    table = pivot_metrics(_sample_metrics(), value="wape", over="Collegejaar", summary=False)
+    assert list(table.columns) == [2021, 2022, 2023]
+
+
+def test_pivot_unknown_metric_raises():
+    with pytest.raises(ValueError, match="Onbekende metriek"):
+        pivot_metrics(_sample_metrics(), value="bestaat_niet", over="Collegejaar")
+
+
+def test_pivot_missing_over_column_hints_group_by():
+    with pytest.raises(ValueError, match="group_by"):
+        pivot_metrics(_sample_metrics(), value="wape", over="Weeknummer")
+
+
+def test_pivot_missing_prediction_column_raises():
+    df = _sample_metrics().drop(columns=["prediction"])
+    with pytest.raises(ValueError, match="prediction"):
+        pivot_metrics(df, value="wape", over="Collegejaar")
+
+
+def test_pivot_empty_metrics_returns_empty():
+    empty = _sample_metrics().iloc[0:0]
+    table = pivot_metrics(empty, value="wape", over="Collegejaar")
+    assert table.empty
+
+
+def test_pivot_end_to_end_from_pipeline_output():
+    # Twee jaren output samenvoegen, per jaar evalueren, dan pivoteren.
+    out_2022 = _sample_output().assign(Collegejaar=2022)
+    out_2023 = _sample_output()  # heeft al Collegejaar 2023
+    combined = pd.concat([out_2022, out_2023], ignore_index=True)
+    metrics = evaluate_predictions(combined, week=12, group_by="Collegejaar")
+    table = pivot_metrics(metrics, value="mae", over="Collegejaar")
+    assert set(table.index) == {"SARIMA_cumulative", "Prognose_ratio"}
+    assert {2022, 2023}.issubset(set(table.columns))
+    # Identieke input per jaar → identieke MAE en dus nul spreiding.
+    assert table.loc["SARIMA_cumulative", "min"] == pytest.approx(
+        table.loc["SARIMA_cumulative", "max"]
+    )
+
+
+def test_pivot_casts_float_period_labels_to_int():
+    # Collegejaar kan als float binnenkomen → kolomlabels moeten 2021 zijn, niet 2021.0.
+    metrics = _sample_metrics().astype({"Collegejaar": "float64"})
+    table = pivot_metrics(metrics, value="wape", over="Collegejaar", summary=False)
+    assert list(table.columns) == [2021, 2022, 2023]
+    assert table.columns.dtype == np.dtype("int64")
+
+
+def test_pivot_single_group_has_zero_spread():
+    metrics = _sample_metrics()
+    one_year = metrics[metrics["Collegejaar"] == 2021]
+    table = pivot_metrics(one_year, value="wape", over="Collegejaar")
+    sarima = table.loc["SARIMA_cumulative"]
+    assert sarima["n_groups"] == 1
+    assert sarima["mean"] == sarima["min"] == sarima["max"]
+
+
+def test_pivot_value_n_returns_counts_not_averaged():
+    # Eén rij per (prediction, jaar) → aggfunc='mean' geeft de count ongewijzigd terug.
+    table = pivot_metrics(_sample_metrics(), value="n", over="Collegejaar", summary=False)
+    assert table.loc["SARIMA_cumulative", 2022] == 11


### PR DESCRIPTION
## Wat & waarom

Implementeert #242: een lichte evaluatie-helper die de pipeline-output samenvat tot scalaire metrieken per voorspelmodel — geen MLflow/zware tooling, geen extra dependencies.

## Wijzigingen

- **`evaluate_predictions(result, week=...)`** (View 1) — MAE, MAPE, WAPE, RMSE, bias, R² per voorspelkolom (`SARIMA_cumulative` = XGBoost, `Prognose_ratio`, `SARIMA_individual`, ensembles). Filtert op de peilweek, sluit numerus-fixus en rijen zonder realisatie/voorspelling uit (consistent met de bestaande `MAE_*`-kolommen), en geeft een duidelijke, niet-stille foutmelding wanneer er geen realisatie is (lopend jaar → backtest een afgerond jaar). Optioneel `group_by` voor segmentatie.
- **`pivot_metrics(metrics, value="wape", over="Collegejaar")`** (View 3) — vat een backtest over meerdere jaren/weken samen tot een model × jaar-matrix met `mean`/`min`/`max`/`n_groups`, zodat de jaar-op-jaar spreiding zichtbaar wordt naast het verschil tussen modellen.
- **`to_mlflow_metrics`** — vlakt metrieken af tot een dict, klaar voor MLflow in MS Fabric/Databricks (zonder mlflow-dependency).
- Tests (25), docs (`output-begrijpen.md`, `aan-de-slag.md`) en een notebook-voorbeeld.

## Acceptatiecriteria #242

- [x] Lichte functie, geen extra deps, ≥ MAE + MAPE (+ WAPE/RMSE/bias/R²)
- [x] Scoort `SARIMA_cumulative`, `Prognose_ratio`, + `SARIMA_individual`/ensembles waar aanwezig
- [x] Filtert op de peilweek
- [x] Slaat numerus-fixus en rijen zonder realisatie/voorspelling over
- [x] Niet-stille afhandeling wanneer realisatie ontbreekt
- [x] Print-vriendelijke output (klein DataFrame)
- [x] Korte test + voorbeeld in docstring/README/docs

## Tests & kwaliteit

- `423 passed` (volledige suite; waarvan 25 evaluation-tests)
- black (line-length 99) clean, ruff `E,F,N,W,UP` clean
- End-to-end geverifieerd met een backtest 2021–2023 op de demodata

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
