### PR TITLE
feat: guard tegen stil all-NaN wanneer cumulatieve data geen historie bevat (#244)

### DIFF
--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -185,6 +185,11 @@ studentprognose --noetl -d cumulative -w 12 -y 2025
 
 Zorg ervoor dat de vereiste bestanden in `data/input/` staan voordat je de tool draait. Welke bestanden je nodig hebt hangt af van de gekozen datamodus (`-d`). Zie de tabel hieronder.
 
+!!! warning "De cumulatieve data heeft historische collegejaren nodig"
+    Het cumulatieve spoor traint op data van vóór het voorspeljaar: het XGBoost-instroommodel (`SARIMA_cumulative`) en het ratio-model (`Prognose_ratio`) leiden beide hun voorspelling af uit eerdere collegejaren. Bevat je cumulatieve data (`vooraanmeldingen_cumulatief.csv`, of `df_cum` bij in-memory gebruik via [`run_pipeline_from_dataframes`](api/index.md)) **alleen het voorspeljaar**, dan blijven beide kolommen voor elke opleiding `NaN` — terwijl `Voorspelde vooraanmelders` zich wél vult en de output dus compleet *oogt*.
+
+    Lever daarom altijd minstens één, idealiter de drie, collegejaren vóór het voorspeljaar mee. De [trainingshistorie-check](validatie.md#trainingshistorie-waarom-deze-check-bestaat) stopt de pipeline (of waarschuwt, op het in-memory pad) wanneer die historie ontbreekt. Snelle controle: `sorted(df_cum["Collegejaar"].unique())`.
+
 ## Verwerkte inputbestanden (`data/input/`)
 
 Dit zijn de bestanden die het model direct inleest. Ze worden aangemaakt door de ETL, of je plaatst ze zelf in `data/input/` als je `--noetl` gebruikt.

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -74,7 +74,7 @@ Telbestand met studentaantallen, door de instelling zelf aangeleverd — zie [Je
 
 ## Pre-prediction checks
 
-Vóór elke modelrun voert de pipeline drie aanvullende checks uit op de **cumulatieve vooraanmelddata**. Ze draaien per `(jaar, week)`-combinatie, na ETL maar vóór de modellen.
+Vóór elke modelrun voert de pipeline vier aanvullende checks uit op de **cumulatieve vooraanmelddata**. Ze draaien per `(jaar, week)`-combinatie, na ETL maar vóór de modellen.
 
 !!! note "Alleen actief als cumulatieve data beschikbaar is"
     De pre-prediction checks worden overgeslagen als de pipeline zonder cumulatieve data draait (individueel-enkel modus, `-d i`). In dat geval is er geen `Gewogen vooraanmelders`-kolom om te valideren.
@@ -83,7 +83,28 @@ Vóór elke modelrun voert de pipeline drie aanvullende checks uit op de **cumul
 |-------|------|-------------------|
 | Decimaalintegriteit | Hard stop | `Gewogen vooraanmelders` bevat strings met komma's of niet-numerieke waarden |
 | Lege dataset | Hard stop | Geen rijen aanwezig voor het gevraagde jaar+week |
+| Trainingshistorie | Hard stop / waarschuwing | Geen historische collegejaren (`Collegejaar < voorspeljaar`) aanwezig om op te trainen |
 | Historisch realisme | Hard stop / waarschuwing | Afwijking t.o.v. dezelfde week vorig jaar per opleiding/herkomst/examentype |
+
+### Trainingshistorie — waarom deze check bestaat
+
+Het cumulatieve spoor leidt twee voorspellingen af uit **historische** collegejaren:
+
+- het XGBoost-instroommodel (kolom `SARIMA_cumulative`) traint op `Collegejaar < voorspeljaar`;
+- het ratio-model (kolom `Prognose_ratio`) middelt de aanmelder/student-ratio over de drie jaren vóór het voorspeljaar.
+
+Bevat de cumulatieve data **alleen het voorspeljaar** (bijv. een `df_cum` die per ongeluk op het huidige jaar is gefilterd), dan hebben beide modellen geen trainingsdata en geven ze voor élke opleiding `NaN` terug. De SARIMA-vooraanmeldforecast (`Voorspelde vooraanmelders`) heeft géén historie nodig en vult zich wél — daardoor *oogt* de output compleet terwijl er geen bruikbare instroomvoorspelling in zit. Dit faalde vroeger stil; de check maakt het nu expliciet.
+
+| Situatie | Gedrag |
+|----------|--------|
+| Geen enkel jaar `< voorspeljaar` aanwezig | Hard stop — pipeline stopt (te omzeilen met `--yes`) |
+| Minstens één historisch jaar aanwezig | Check slaagt stilzwijgend |
+
+!!! tip "Oplossing"
+    Voeg historische collegejaren toe aan de cumulatieve data (idealiter de drie jaren vóór het voorspeljaar) en verwerk opnieuw. Controleer bij in-memory gebruik dat `df_cum` niet op één jaar gefilterd is: `sorted(df_cum["Collegejaar"].unique())`.
+
+!!! note "In-memory API-pad waarschuwt in plaats van te stoppen"
+    [`run_pipeline_from_dataframes`](api/index.md) draait altijd met `--yes` zodat een bibliotheekaanroep de aanroepende toepassing niet afbreekt: bij ontbrekende historie verschijnt daar een waarschuwing in plaats van een hard stop. De cumulatieve kolommen blijven dan `NaN`.
 
 ### Historisch realisme — drempelwaarden
 
@@ -102,7 +123,7 @@ Als er geen vorig-jaar-data beschikbaar is (nieuwe opleiding), wordt de check st
 
 ### Hard stop omzeilen met `--yes`
 
-De decimaalcheck en lege-dataset-check zijn nooit te omzeilen: corrupte of afwezige data heeft geen veilige fallback. De historisch-realismecheck wél — gebruik `--yes` om een extreme afwijking te accepteren en door te gaan:
+De decimaalcheck en lege-dataset-check zijn nooit te omzeilen: corrupte of afwezige data heeft geen veilige fallback. De trainingshistorie- en historisch-realismecheck wél — gebruik `--yes` om een ontbrekende historie of extreme afwijking te accepteren en door te gaan:
 
 ```bash
 uv run studentprognose --yes -y 2024 -w 10

--- a/src/studentprognose/data/prediction_validator.py
+++ b/src/studentprognose/data/prediction_validator.py
@@ -1,10 +1,13 @@
 """Pre-prediction datakwaliteitschecks.
 
-Drie checks worden uitgevoerd op de cumulatieve data vóór de modellen draaien:
+Vier checks worden uitgevoerd op de cumulatieve data vóór de modellen draaien:
 
   decimaalintegriteit – hard stop als 'Gewogen vooraanmelders' strings met
                         komma's of niet-numerieke waarden bevat.
   lege dataset        – hard stop als er geen data is voor de gevraagde week.
+  trainingshistorie   – hard stop als er geen historische collegejaren
+                        (< voorspeljaar) zijn; zonder historie blijven het
+                        XGBoost-instroommodel en het ratio-model stil all-NaN.
   historisch realisme – vergelijkt de huidige week met dezelfde week een jaar
                         eerder. Hard stop bij extreme afwijking, warning bij
                         matige afwijking. NF-opleidingen worden overgeslagen.
@@ -18,6 +21,8 @@ import sys
 import warnings
 
 import pandas as pd
+
+from studentprognose.utils.constants import LOOKBACK_YEARS
 
 
 def run_pre_prediction_checks(
@@ -39,10 +44,12 @@ def run_pre_prediction_checks(
 
     # Decimal and empty checks are unconditional hard stops: corrupted or missing
     # data means the model cannot run at all — there is no safe value to fall back on.
-    # Historical realism is a domain judgment (e.g. COVID years legitimately differ)
-    # so --yes can demote it to a warning.
+    # Training-history and historical-realism are domain judgments (a brand-new
+    # institution may legitimately have only the current year; COVID years legitimately
+    # differ) so --yes can demote them to a warning.
     _check_decimal_integrity(current, predict_year, predict_week)
     _check_empty_data(current, predict_year, predict_week)
+    _check_training_history(data_cumulative, predict_year, yes)
     _check_historical_realism(current, last_year, numerus_fixus_list, predict_year, predict_week, yes)
 
 
@@ -86,6 +93,51 @@ def _check_empty_data(
             f"Voeg de ontbrekende telbestanden toe via data/input_raw/ en verwerk opnieuw."
         )
         sys.exit(1)
+
+
+def _check_training_history(
+    data_cumulative: pd.DataFrame, predict_year: int, yes: bool = False
+) -> None:
+    """Guard tegen stil falen wanneer historische collegejaren ontbreken.
+
+    Het cumulatieve spoor traint twee modellen op data van vóór het voorspeljaar:
+
+      * de XGBoost-instroomvoorspelling (kolom ``SARIMA_cumulative``) traint op
+        ``Collegejaar < predict_year``;
+      * het ratio-model (kolom ``Prognose_ratio``) middelt de aanmelder/student-ratio
+        over ``Collegejaar`` in ``[predict_year - LOOKBACK_YEARS, predict_year - 1]``.
+
+    Ontbreken die jaren volledig, dan geven beide modellen voor élke opleiding
+    ``NaN`` terug — zonder foutmelding. De SARIMA-vooraanmeldforecast
+    (``Voorspelde vooraanmelders``) heeft geen historie nodig en vult zich wél,
+    waardoor de output compleet *oogt* terwijl er geen bruikbare instroomvoorspelling
+    in zit. Deze check maakt dat expliciet: hard stop, met ``--yes`` gedemoveerd tot
+    waarschuwing (zodat het puur in-memory API-pad, dat ``yes=True`` zet, niet de
+    aanroepende toepassing afbreekt).
+    """
+    if "Collegejaar" not in data_cumulative.columns or data_cumulative.empty:
+        return
+
+    years = pd.to_numeric(data_cumulative["Collegejaar"], errors="coerce").dropna()
+    if (years < predict_year).any():
+        return
+
+    available = sorted({int(y) for y in years.unique()})
+    msg = (
+        f"Geen historische collegejaren (< {predict_year}) in de cumulatieve data "
+        f"(beschikbaar: {available}). Zonder historie kunnen het XGBoost-instroommodel "
+        f"('SARIMA_cumulative') en het ratio-model ('Prognose_ratio') niet trainen: "
+        f"beide blijven voor elke opleiding NaN. 'Voorspelde vooraanmelders' vult zich "
+        f"wél, dus de output oogt compleet maar bevat geen instroomvoorspelling. "
+        f"Voeg historische collegejaren toe aan de cumulatieve data "
+        f"(idealiter de {LOOKBACK_YEARS} jaren vóór {predict_year}) en verwerk opnieuw."
+    )
+
+    if yes:
+        warnings.warn(f"[--yes] {msg}", UserWarning, stacklevel=2)
+        return
+    print(f"\n[HARD STOP] {msg} Gebruik --yes om door te gaan.")
+    sys.exit(1)
 
 
 def _check_historical_realism(

--- a/src/studentprognose/strategies/cumulative.py
+++ b/src/studentprognose/strategies/cumulative.py
@@ -366,6 +366,26 @@ class CumulativeStrategy(PredictionStrategy):
 
         return data_to_predict
 
+    def _warn_no_xgboost_training_data(self):
+        """Waarschuw als het XGBoost-instroommodel geen trainingsdata heeft.
+
+        Vervangt het vroegere stille ``print``: gaat nu via de warning-machinery
+        (zichtbaar in pipeline-/Fabric-runs, filterbaar) en benoemt de echte oorzaak.
+        De upfront-guard ``_check_training_history`` vangt het volledige
+        "geen historie"-geval al af; deze waarschuwing dekt de resterende per-groep
+        gevallen (bijv. een te kleine ``--ci test``-subset of backtesting met
+        ``--skipyears``).
+        """
+        warnings.warn(
+            f"XGBoost-instroomvoorspelling overgeslagen: geen trainingsdata met "
+            f"Collegejaar < {self.predict_year}. Oorzaak: de cumulatieve data bevat "
+            f"geen (voldoende) historische collegejaren — voeg ze toe aan df_cum — of, "
+            f"in --ci test-modus, is de subset te klein (verhoog N). 'SARIMA_cumulative' "
+            f"blijft NaN voor deze groep.",
+            UserWarning,
+            stacklevel=3,
+        )
+
     def _predict_with_xgboost_extra_year(self, train, test, data_to_predict, replace_mask):
         columns_to_match = [
             "Collegejaar", "Faculteit", "Examentype", "Herkomst", "Croho groepeernaam",
@@ -382,10 +402,7 @@ class CumulativeStrategy(PredictionStrategy):
             ][columns_to_match].merge(test2, on=columns_to_match)
             if not test2_merged.empty:
                 if train2.empty:
-                    print(
-                        "WARNING: Skipping XGBoost prediction: no training data "
-                        "available (try increasing --ci test N)."
-                    )
+                    self._warn_no_xgboost_training_data()
                     return data_to_predict
                 test2["Collegejaar"] = test2["Collegejaar"] - self.skip_years
                 ahead_predictions, imp = predict_with_xgboost(train2, test2_merged, self.data_studentcount, ENGINEERED_FEATURE_COLS, regressor=self._regressor, config=self.configuration)
@@ -412,10 +429,7 @@ class CumulativeStrategy(PredictionStrategy):
 
             if not test_merged.empty:
                 if train.empty:
-                    print(
-                        "WARNING: Skipping XGBoost prediction: no training data "
-                        "available (try increasing --ci test N)."
-                    )
+                    self._warn_no_xgboost_training_data()
                     return data_to_predict
                 predictions, imp = predict_with_xgboost(train, test_merged, self.data_studentcount, ENGINEERED_FEATURE_COLS, regressor=self._regressor, config=self.configuration)
                 if imp is not None:

--- a/tests/studentprognose/test_prediction_validators.py
+++ b/tests/studentprognose/test_prediction_validators.py
@@ -9,6 +9,7 @@ from studentprognose.data.prediction_validator import (
     run_pre_prediction_checks,
     _check_decimal_integrity,
     _check_empty_data,
+    _check_training_history,
     _check_historical_realism,
 )
 from studentprognose.output.validator import (
@@ -89,6 +90,66 @@ class TestCheckEmptyData:
         df = pd.DataFrame()
         with pytest.raises(SystemExit):
             _check_empty_data(df, 2024, 10)
+
+
+# ---------------------------------------------------------------------------
+# _check_training_history
+# ---------------------------------------------------------------------------
+
+class TestCheckTrainingHistory:
+    def test_with_history_passes_silently(self):
+        data = pd.concat([
+            _make_cumulative(2023, 10),
+            _make_cumulative(2024, 10),
+        ])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _check_training_history(data, 2024)  # no exception
+        assert not w
+
+    def test_only_predict_year_hard_stops(self):
+        data = _make_cumulative(2024, 10)  # alleen het voorspeljaar
+        with pytest.raises(SystemExit) as exc:
+            _check_training_history(data, 2024)
+        assert exc.value.code == 1
+
+    def test_only_future_years_hard_stops(self):
+        # Geen enkel jaar < voorspeljaar (alle data ligt op of na het voorspeljaar).
+        data = pd.concat([
+            _make_cumulative(2024, 10),
+            _make_cumulative(2025, 10),
+        ])
+        with pytest.raises(SystemExit) as exc:
+            _check_training_history(data, 2024)
+        assert exc.value.code == 1
+
+    def test_only_predict_year_with_yes_warns_instead(self):
+        data = _make_cumulative(2024, 10)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _check_training_history(data, 2024, yes=True)
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        message = str(w[0].message)
+        # Boodschap noemt beide getroffen modellen + de oplossing.
+        assert "SARIMA_cumulative" in message
+        assert "Prognose_ratio" in message
+        assert "[--yes]" in message
+
+    def test_missing_collegejaar_column_is_skipped(self):
+        data = pd.DataFrame({"Weeknummer": [10]})
+        _check_training_history(data, 2024)  # no exception
+
+    def test_empty_dataframe_is_skipped(self):
+        # Lege data wordt al door _check_empty_data afgevangen; deze check blijft stil.
+        _check_training_history(pd.DataFrame(), 2024)  # no exception
+
+    def test_propagates_through_run_pre_prediction_checks(self):
+        # Alleen het voorspeljaar aanwezig: hard stop via de orchestrator.
+        data = _make_cumulative(2024, 10)
+        with pytest.raises(SystemExit) as exc:
+            run_pre_prediction_checks(data, 2024, 10, {})
+        assert exc.value.code == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #244.

## Probleem

Wanneer `df_cum` alleen het voorspeljaar bevat (geen historische collegejaren), kunnen het XGBoost-instroommodel (`SARIMA_cumulative`) en het ratio-model (`Prognose_ratio`) niet trainen en geven ze voor élke opleiding `NaN` terug. De SARIMA-vooraanmeldforecast (`Voorspelde vooraanmelders`) heeft geen historie nodig en vult zich wél — de output *oogt* dus compleet terwijl er geen instroomvoorspelling in zit. Dit faalde **stil**; de enige hint was een misleidende `print` ("try increasing --ci test N").

Empirisch bevestigd via `run_pipeline_from_dataframes(year=2026, dataset=CUMULATIVE)` met `df_cum` op één jaar: beide instroomkolommen 100% NaN, geen exception.

## Oplossing

- **`prediction_validator.py`** — nieuwe pre-prediction check `_check_training_history`, analoog aan `_check_empty_data`. Hard stop wanneer er geen jaar `< voorspeljaar` is; met `--yes` gedemoveerd tot `warnings.warn`. Het in-memory API-pad (`run_pipeline_from_dataframes`, dat `yes=True` zet) waarschuwt zo i.p.v. de aanroepende toepassing af te breken. De boodschap noemt beide getroffen modellen én de oplossing.
- **`cumulative.py`** — de misleidende `print` (beide branches) vervangen door een accurate `warnings.warn`-helper die de echte oorzaak benoemt.

## Tests

7 nieuwe tests in `test_prediction_validators.py`: hard stop, `--yes`-demotie, historie-aanwezig (stil), propagatie via `run_pre_prediction_checks`, en edge cases. Volledige suite groen (430 passed), ruff clean, `mkdocs build --strict` exit 0.

## Acceptatiecriteria

- [x] Bij ontbrekende historie: duidelijke melding met uitleg + oplossing i.p.v. stil all-NaN
- [x] Hard stop analoog aan `_check_empty_data`, met `--yes`-override
- [x] `Voorspelde vooraanmelders` (SARIMA-forecast) blijft werken — guard blokkeert dat spoor niet
- [x] Test: `df_cum` met alleen het voorspeljaar → nette afhandeling

## Docs (verplicht per CLAUDE.md)

- `docs/validatie.md` — nieuwe check + tabelrij + `--yes`-sectie
- `docs/je-data-voorbereiden.md` — historie-eis voor het cumulatieve spoor

🤖 Generated with [Claude Code](https://claude.com/claude-code)