### PR TITLE
Dashboards genereren vanuit in-memory DataFrames (Python-API)

### DIFF
--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -215,6 +215,7 @@ from studentprognose import (
     load_data,                     # laad data vanaf schijf als DataFrames
     run_pipeline_cli,              # volledige CLI-pipeline (accepteert argv-lijst)
     run_pipeline_from_dataframes,  # pipeline met DataFrames in-memory
+    build_dashboard_from_dataframes,  # interactieve HTML-dashboards uit DataFrames
     evaluate_predictions,          # output → scalaire evaluatiemetrieken per model
     pivot_metrics,                 # metrieken → model × jaar/week-matrix (backtest)
     to_mlflow_metrics,             # metrieken afvlakken voor mlflow.log_metrics (Fabric)
@@ -309,6 +310,37 @@ result = run_pipeline_from_dataframes(
     ```
 
     Pas `year`/`week` aan binnen de range, of voeg aanvullende trainingsdata toe.
+
+### Dashboards genereren vanuit DataFrames
+
+De interactieve Plotly-dashboards (die de CLI met `--dashboard` maakt) kun je vanuit een
+notebook of cloud-run genereren met `build_dashboard_from_dataframes`. Dit is een
+**aparte functie** die je ná (of in plaats van) `run_pipeline_from_dataframes` aanroept,
+met dezelfde in-memory DataFrames. Ze draait de pipeline (zonder iets naar schijf te
+schrijven) en schrijft daarna de dashboards weg naar `<cwd>/data/output/visualisations/`.
+
+```python
+from studentprognose import build_dashboard_from_dataframes, DataOption
+
+output_dir = build_dashboard_from_dataframes(
+    year=2025,
+    week=10,
+    data_cumulative=df_cum,
+    data_student_numbers=sc,   # nodig voor de realisatie-/conversiegrafieken
+    dataset=DataOption.CUMULATIVE,
+    configuration=config,
+)
+print(f"Dashboards geschreven naar {output_dir}")
+# -> <cwd>/data/output/visualisations/{individual,cumulative,final}/dashboard.html
+```
+
+!!! tip "Losse functie, geen extra parameter"
+    Het dashboard is bewust een aparte functie en géén parameter op
+    `run_pipeline_from_dataframes`: zo blijft de voorspelfunctie ongewijzigd en is de
+    dashboard-stap los te draaien en te testen. Gebruik `cwd` om de uitvoermap te sturen.
+    De `year`/`week`-rangecontrole is identiek aan die van `run_pipeline_from_dataframes`;
+    komt geen enkele rij door de filters, dan krijg je een heldere `ValueError` in plaats
+    van een leeg dashboard.
 
 ## Bekende valkuil: stille modus-downgrade
 

--- a/src/studentprognose/__init__.py
+++ b/src/studentprognose/__init__.py
@@ -1,6 +1,10 @@
 from studentprognose.config import load_configuration, load_defaults_filtering, load_filtering
 from studentprognose.data.loader import load_data
-from studentprognose.main import run_pipeline_cli, run_pipeline_from_dataframes
+from studentprognose.main import (
+    build_dashboard_from_dataframes,
+    run_pipeline_cli,
+    run_pipeline_from_dataframes,
+)
 from studentprognose.cli import PipelineConfig
 from studentprognose.output.evaluation import (
     evaluate_predictions,
@@ -16,6 +20,7 @@ __all__ = [
     "load_data",
     "run_pipeline_cli",
     "run_pipeline_from_dataframes",
+    "build_dashboard_from_dataframes",
     "evaluate_predictions",
     "pivot_metrics",
     "to_mlflow_metrics",

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -180,6 +180,162 @@ def run_pipeline_from_dataframes(
             save_output=False,
         )
     """
+    cfg, datasets, configuration, filtering, cwd = _prepare_in_memory_run(
+        year,
+        week,
+        data_cumulative=data_cumulative,
+        data_individual=data_individual,
+        data_student_numbers=data_student_numbers,
+        data_latest=data_latest,
+        data_weighted_ensemble=data_weighted_ensemble,
+        configuration=configuration,
+        filtering=filtering,
+        cwd=cwd,
+        dataset=dataset,
+        student_year_prediction=student_year_prediction,
+        skip_years=skip_years,
+    )
+
+    return _run_pipeline_core(cfg, datasets, configuration, filtering, cwd, save_output=save_output)
+
+
+def build_dashboard_from_dataframes(
+    year: int,
+    week: int,
+    data_cumulative: Optional[pd.DataFrame] = None,
+    data_individual: Optional[pd.DataFrame] = None,
+    configuration: Optional[dict] = None,
+    data_student_numbers: Optional[pd.DataFrame] = None,
+    data_latest: Optional[pd.DataFrame] = None,
+    data_weighted_ensemble: Optional[pd.DataFrame] = None,
+    dataset: DataOption = DataOption.BOTH_DATASETS,
+    student_year_prediction: StudentYearPrediction = StudentYearPrediction.FIRST_YEARS,
+    skip_years: int = 0,
+    filtering: Optional[dict] = None,
+    cwd: Optional[str] = None,
+) -> str:
+    """Genereer de interactieve Plotly-dashboards vanuit in-memory DataFrames.
+
+    Zelfstandige tegenhanger van :func:`run_pipeline_from_dataframes` voor cloud- en
+    notebook-gebruikers (bijv. Microsoft Fabric) die hun data al als DataFrame in het
+    geheugen hebben. Draait de voorspelpipeline (zonder iets naar schijf te schrijven)
+    en schrijft daarna de HTML-dashboards naar ``<cwd>/data/output/visualisations/``.
+
+    De data-parameters zijn identiek aan die van :func:`run_pipeline_from_dataframes`;
+    roep deze functie ná (of in plaats van) die functie aan met dezelfde argumenten.
+
+    Args:
+        year: Academisch jaar om te voorspellen (bijv. ``2025``).
+        week: ISO-weeknummer waarvandaan voorspeld wordt (bijv. ``10``).
+        data_cumulative: Cumulatief vooraanmeld-DataFrame. Vereist wanneer ``dataset``
+            ``CUMULATIVE`` of ``BOTH_DATASETS`` is.
+        data_individual: Individueel aanmeld-DataFrame. Vereist wanneer ``dataset``
+            ``INDIVIDUAL`` of ``BOTH_DATASETS`` is.
+        configuration: Configuratiedict (zelfde structuur als ``configuration.json``).
+            Bij ``None`` worden de gebundelde package-defaults gebruikt.
+        data_student_numbers: Studentaantallen eerstejaars DataFrame (optioneel, maar
+            nodig voor de realisatie-/conversiegrafieken in het dashboard).
+        data_latest: Laatste output Excel DataFrame voor hogerejaarsvoorspellingen (optioneel).
+        data_weighted_ensemble: Ensemble-gewichten DataFrame (optioneel).
+        dataset: Welke dataset(s) te gebruiken. Standaard ``BOTH_DATASETS``.
+        student_year_prediction: Welke studentcohort te voorspellen. Standaard ``FIRST_YEARS``.
+        skip_years: Aantal meest recente jaren om uit training te sluiten (backtesting).
+        filtering: Filteringdict (zelfde structuur als een filtering-JSON-bestand).
+            Bij ``None`` wordt de gebundelde ``base.json`` gebruikt (geen filters).
+        cwd: Werkmap voor de uitvoer. De dashboards komen in
+            ``<cwd>/data/output/visualisations/``. Standaard ``os.getcwd()``.
+
+    Returns:
+        Het pad naar de map waarin de dashboards zijn geschreven
+        (``<cwd>/data/output/visualisations/``).
+
+    Raises:
+        ValueError: Als ``week`` de laatste academische week is, als ``year``/``week``
+            buiten de range van de meegegeven data valt, of als geen enkele rij
+            overeenkwam met de filters/voorspellingscriteria (dan valt er niets te
+            visualiseren).
+
+    Example::
+
+        from studentprognose import build_dashboard_from_dataframes, DataOption
+
+        output_dir = build_dashboard_from_dataframes(
+            year=2025,
+            week=10,
+            data_cumulative=df_cum,
+            data_student_numbers=sc,
+            dataset=DataOption.CUMULATIVE,
+            configuration=config,
+        )
+        print(f"Dashboards geschreven naar {output_dir}")
+    """
+    cfg, datasets, configuration, filtering, cwd = _prepare_in_memory_run(
+        year,
+        week,
+        data_cumulative=data_cumulative,
+        data_individual=data_individual,
+        data_student_numbers=data_student_numbers,
+        data_latest=data_latest,
+        data_weighted_ensemble=data_weighted_ensemble,
+        configuration=configuration,
+        filtering=filtering,
+        cwd=cwd,
+        dataset=dataset,
+        student_year_prediction=student_year_prediction,
+        skip_years=skip_years,
+    )
+
+    # Draai de pipeline zonder schijf-output; we willen alleen de uitgevoerde
+    # strategy (met voorspellingen én dashboard-data) om er de dashboards uit te bouwen.
+    strategy = _run_pipeline_strategy(
+        cfg, datasets, configuration, filtering, cwd, save_output=False
+    )
+
+    # Zowel None (geen voorspelling) als een lege DataFrame (alle rijen weggefilterd)
+    # afvangen: DashboardBuilder doet o.a. int(data["Collegejaar"].max()) en zou op
+    # leeg met een cryptische int(NaN)-fout crashen i.p.v. deze heldere melding.
+    data = strategy.postprocessor.data
+    if data is None or data.empty:
+        raise ValueError(
+            "Geen data om een dashboard van te bouwen: geen enkele rij kwam overeen met "
+            "de filters of voorspellingscriteria. Controleer year/week, dataset en filtering."
+        )
+
+    # Anders dan de CLI-route (_try_build_dashboard) laten we fouten hier wél
+    # propageren: dit is een expliciete, op zichzelf staande dashboard-actie, dus
+    # stil falen zou de gebruiker misleiden.
+    builder = _make_dashboard_builder(strategy, cfg, cwd)
+    builder.build_and_save()
+    return builder.base_dir
+
+
+def _prepare_in_memory_run(
+    year: int,
+    week: int,
+    *,
+    data_cumulative: Optional[pd.DataFrame],
+    data_individual: Optional[pd.DataFrame],
+    data_student_numbers: Optional[pd.DataFrame],
+    data_latest: Optional[pd.DataFrame],
+    data_weighted_ensemble: Optional[pd.DataFrame],
+    configuration: Optional[dict],
+    filtering: Optional[dict],
+    cwd: Optional[str],
+    dataset: DataOption,
+    student_year_prediction: StudentYearPrediction,
+    skip_years: int,
+) -> tuple:
+    """Gedeelde setup voor de in-memory routes.
+
+    Zowel :func:`run_pipeline_from_dataframes` als
+    :func:`build_dashboard_from_dataframes` gebruiken dit: rangecontrole,
+    config-/filtering-defaults, runtime-validatie, programmesleutel-normalisatie en
+    het opbouwen van de :class:`PipelineConfig`.
+
+    Returns:
+        Een tuple ``(cfg, datasets, configuration, filtering, cwd)`` klaar voor de
+        pipeline-kern.
+    """
     from studentprognose.config import load_defaults, _validate_runtime
 
     # Zelfde vangnet als de CLI: faal direct met een heldere melding wanneer year/week
@@ -249,14 +405,27 @@ def run_pipeline_from_dataframes(
         data_weighted_ensemble,
     )
 
-    return _run_pipeline_core(cfg, datasets, configuration, filtering, cwd, save_output=save_output)
+    return cfg, datasets, configuration, filtering, cwd
 
 
 def _run_pipeline_core(cfg, datasets, configuration, filtering, cwd, save_output: bool = True):
     """Gemeenschappelijke pipeline-kern: strategy, preprocessing, predict, opslaan.
 
     Zowel ``main()`` (CLI) als ``run_pipeline_from_dataframes()`` (Python API)
-    delegeren hiernaartoe na hun eigen setup-stappen.
+    delegeren hiernaartoe na hun eigen setup-stappen. Geeft het gepostprocessde
+    voorspellings-DataFrame terug (of ``None``).
+    """
+    strategy = _run_pipeline_strategy(cfg, datasets, configuration, filtering, cwd, save_output)
+    return strategy.postprocessor.data
+
+
+def _run_pipeline_strategy(cfg, datasets, configuration, filtering, cwd, save_output: bool = True):
+    """Draai de pipeline-kern en geef de uitgevoerde strategy terug.
+
+    Gescheiden van :func:`_run_pipeline_core` zodat aanroepers die het
+    strategy-object zelf nodig hebben (bijv. :func:`build_dashboard_from_dataframes`
+    voor de dashboard-data) er niet de omweg via ``postprocessor.data`` voor hoeven te
+    maken.
     """
     # Step 2: Initialize strategy (Individual / Cumulative / Combined)
     strategy = create_strategy(cfg, datasets, configuration, cwd)
@@ -303,7 +472,7 @@ def _run_pipeline_core(cfg, datasets, configuration, filtering, cwd, save_output
     if save_output:
         _save_results(strategy, cfg)
 
-    return strategy.postprocessor.data
+    return strategy
 
 
 def _apply_auto_defaults(datasets, cfg, configuration):
@@ -486,6 +655,30 @@ def _save_results(strategy, cfg):
             print("No data to save. Saving output skipped.")
 
 
+def _make_dashboard_builder(strategy, cfg, cwd: str) -> DashboardBuilder:
+    """Bouw een :class:`DashboardBuilder` uit een uitgevoerde strategy en config.
+
+    Gedeeld door de CLI-route (:func:`_try_build_dashboard`) en de Python-API
+    (:func:`build_dashboard_from_dataframes`) zodat de constructie op één plek staat.
+    """
+    dd = strategy.get_dashboard_data()
+    return DashboardBuilder(
+        data=strategy.postprocessor.data,
+        data_option=cfg.data_option,
+        numerus_fixus_list=strategy.postprocessor.numerus_fixus_list,
+        student_year_prediction=cfg.student_year_prediction,
+        ci_test_n=cfg.ci_test_n,
+        cwd=cwd,
+        predict_week=cfg.weeks[-1] if cfg.weeks else None,
+        data_cumulative=dd["data_cumulative"],
+        data_studentcount=strategy.postprocessor.data_studentcount,
+        data_xgboost_curve=dd["xgboost_curve"],
+        xgb_classifier_importance=dd["xgb_classifier_importance"],
+        xgb_regressor_importance=dd["xgb_regressor_importance"],
+        final_academic_week=strategy.final_academic_week,
+    )
+
+
 def _try_build_dashboard(strategy, cfg):
     """Build the Plotly dashboard. A failure here is logged but never crashes the pipeline."""
     if len(cfg.weeks) > 1:
@@ -494,23 +687,7 @@ def _try_build_dashboard(strategy, cfg):
         )
 
     try:
-        dd = strategy.get_dashboard_data()
-        dashboard = DashboardBuilder(
-            data=strategy.postprocessor.data,
-            data_option=cfg.data_option,
-            numerus_fixus_list=strategy.postprocessor.numerus_fixus_list,
-            student_year_prediction=cfg.student_year_prediction,
-            ci_test_n=cfg.ci_test_n,
-            cwd=os.getcwd(),
-            predict_week=cfg.weeks[-1] if cfg.weeks else None,
-            data_cumulative=dd["data_cumulative"],
-            data_studentcount=strategy.postprocessor.data_studentcount,
-            data_xgboost_curve=dd["xgboost_curve"],
-            xgb_classifier_importance=dd["xgb_classifier_importance"],
-            xgb_regressor_importance=dd["xgb_regressor_importance"],
-            final_academic_week=strategy.final_academic_week,
-        )
-        dashboard.build_and_save()
+        _make_dashboard_builder(strategy, cfg, os.getcwd()).build_and_save()
     except Exception:
         log_path = os.path.join(os.getcwd(), "data", "output", "dashboard_error.log")
         os.makedirs(os.path.dirname(log_path), exist_ok=True)

--- a/tests/studentprognose/test_dashboard.py
+++ b/tests/studentprognose/test_dashboard.py
@@ -117,3 +117,120 @@ def test_save_results_runs_dashboard_when_enabled(monkeypatch):
     main_module._save_results(strategy, cfg)
 
     assert called["n"] == 1, "dashboard moet draaien met --dashboard"
+
+
+# ── build_dashboard_from_dataframes (issue #253) ─────────────────────
+
+
+def _install_dashboard_fake_strategy(monkeypatch, *, result="frame"):
+    """Vervang create_strategy door een lichtgewicht fake met echte PostProcessor.
+
+    Zo testen we de wiring van ``build_dashboard_from_dataframes`` (setup -> strategy
+    -> DashboardBuilder -> HTML) end-to-end, zónder de zware SARIMA/XGBoost-compute
+    (conform de projectconventie dat unit tests de volledige pipeline niet draaien).
+    """
+    import studentprognose.main as main_mod
+    from studentprognose.config import load_defaults
+    from studentprognose.output.postprocessor import PostProcessor
+    from studentprognose.utils.constants import FINAL_ACADEMIC_WEEK
+
+    def _frame():
+        return pd.DataFrame({
+            "Croho groepeernaam": ["B Foo"],
+            "Faculteit": ["FdM"],
+            "Examentype": ["Bachelor"],
+            "Collegejaar": [2025],
+            "Herkomst": ["NL"],
+            "Weeknummer": [10],
+            "SARIMA_cumulative": [100.0],
+            "SARIMA_individual": [110.0],
+            "Voorspelde vooraanmelders": [120.0],
+        })
+
+    class _FakeStrategy:
+        def __init__(self, cwd, opt):
+            configuration = load_defaults()
+            self.postprocessor = PostProcessor(
+                configuration=configuration, data_latest=None, ensemble_weights=None,
+                data_studentcount=None, cwd=cwd, data_option=opt, ci_test_n=None,
+            )
+            self.numerus_fixus_list = configuration["numerus_fixus"]
+            self.final_academic_week = configuration.get("model_config", {}).get(
+                "final_academic_week", FINAL_ACADEMIC_WEEK
+            )
+            self.programme_filtering = []
+
+        def preprocess(self):
+            return None
+
+        def set_filtering(self, *args, **kwargs):
+            pass
+
+        def predict_nr_of_students(self, year, week, skip_years=0):
+            if result == "none":
+                return None
+            if result == "empty":
+                return _frame().iloc[0:0]  # zelfde kolommen, geen rijen
+            return _frame()
+
+        def get_dashboard_data(self):
+            return {
+                "data_cumulative": None, "xgboost_curve": None,
+                "xgb_classifier_importance": None, "xgb_regressor_importance": None,
+            }
+
+    monkeypatch.setattr(
+        main_mod, "create_strategy",
+        lambda cfg, datasets, configuration, cwd: _FakeStrategy(cwd, cfg.data_option),
+    )
+
+
+def test_build_dashboard_from_dataframes_importable():
+    from studentprognose import build_dashboard_from_dataframes
+
+    assert callable(build_dashboard_from_dataframes)
+
+
+def test_build_dashboard_from_dataframes_rejects_final_week():
+    """De gedeelde year/week-validatie geldt ook voor de dashboard-route."""
+    from studentprognose import build_dashboard_from_dataframes
+    from studentprognose.utils.constants import FINAL_ACADEMIC_WEEK
+
+    with pytest.raises(ValueError, match=str(FINAL_ACADEMIC_WEEK)):
+        build_dashboard_from_dataframes(year=2025, week=FINAL_ACADEMIC_WEEK)
+
+
+def test_build_dashboard_from_dataframes_writes_html(tmp_path, monkeypatch):
+    from studentprognose import DataOption, build_dashboard_from_dataframes
+
+    _install_dashboard_fake_strategy(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    data_individual = pd.DataFrame({"Collegejaar": [2025], "Croho groepeernaam": ["B Foo"]})
+
+    out = build_dashboard_from_dataframes(
+        year=2025, week=10, data_individual=data_individual, dataset=DataOption.INDIVIDUAL,
+    )
+
+    vis = tmp_path / "data" / "output" / "visualisations"
+    assert out == str(vis), "moet de visualisatiemap teruggeven"
+    assert (vis / "final" / "dashboard.html").exists()
+    # save_output wordt intern op False gezet: geen excel-/csv-uitvoer.
+    assert not list((tmp_path / "data" / "output").glob("*.xlsx"))
+
+
+@pytest.mark.parametrize("result", ["none", "empty"])
+def test_build_dashboard_from_dataframes_raises_without_data(tmp_path, monkeypatch, result):
+    """Geen voorspelrijen (None óf lege DataFrame) -> heldere ValueError i.p.v. een
+    leeg/stil dashboard of een cryptische int(NaN)-crash in DashboardBuilder."""
+    from studentprognose import DataOption, build_dashboard_from_dataframes
+
+    _install_dashboard_fake_strategy(monkeypatch, result=result)
+    monkeypatch.chdir(tmp_path)
+
+    data_individual = pd.DataFrame({"Collegejaar": [2025], "Croho groepeernaam": ["B Foo"]})
+
+    with pytest.raises(ValueError, match="Geen data om een dashboard"):
+        build_dashboard_from_dataframes(
+            year=2025, week=10, data_individual=data_individual, dataset=DataOption.INDIVIDUAL,
+        )


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description of Changes

Voegt `build_dashboard_from_dataframes(...)` toe: een aparte, publieke functie waarmee cloud-/notebook-gebruikers (bijv. Microsoft Fabric) de interactieve Plotly-dashboards vanuit **in-memory DataFrames** naar HTML schrijven — zonder de CLI en zonder `save_output=True`.

```python
from studentprognose import build_dashboard_from_dataframes, DataOption

output_dir = build_dashboard_from_dataframes(
    year=2025, week=10,
    data_cumulative=df_cum, data_student_numbers=sc,
    dataset=DataOption.CUMULATIVE, configuration=config,
)
# -> <cwd>/data/output/visualisations/{individual,cumulative,final}/dashboard.html
```

Bewust een **losstaande functie** (geen extra parameter op `run_pipeline_from_dataframes`): decoupled, los te testen, en de bestaande voorspelfunctie blijft ongewijzigd.

**Implementatie (DRY, hergebruik):**
- `_prepare_in_memory_run(...)` — gedeelde setup (rangecontrole, config/filtering-defaults, runtime-validatie, programmesleutel-normalisatie, `PipelineConfig`), gebruikt door zowel `run_pipeline_from_dataframes` als de nieuwe functie.
- `_run_pipeline_strategy(...)` — draait de pipeline-kern en geeft de uitgevoerde strategy terug; `_run_pipeline_core` blijft een dunne wrapper met exact dezelfde publieke return (`postprocessor.data`), dus de CLI en bestaande API zijn onveranderd.
- `_make_dashboard_builder(...)` — centraliseert de `DashboardBuilder`-constructie; ook de CLI-route (`_try_build_dashboard`) gebruikt 'm nu (verwijdert ~14 regels copy-paste).

**Robuustheid:**
- Heldere `ValueError` bij geen (`None`) én lege (`.empty`) voorspeldata, i.p.v. een cryptische `int(NaN)`-crash in de dashboardbouwer.
- Identieke `year`/`week`-rangecontrole als `run_pipeline_from_dataframes`.
- Anders dan de CLI-route laat deze functie dashboardfouten bewust propageren (expliciete, op zichzelf staande actie — stil falen zou misleiden).

## Related Issues
Closes #253

## Before / After

### Before:
Dashboards waren alleen te genereren via de CLI-vlag `--dashboard`, en alleen bij `save_output=True` met lokale bronbestanden. In-memory/cloud-gebruikers hadden geen route.

### After:
`build_dashboard_from_dataframes(...)` schrijft de dashboards vanuit DataFrames en geeft de outputmap terug.

## Checklist
- [x] I have tested these changes locally (`uv run pytest` — 435 passed)
- [x] My code follows the project's coding standards (`uvx ruff check` clean; docs bijgewerkt per CLAUDE.md docs-regel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)