### PR TITLE
fix: guard tegen stille numerus_fixus-sleutelmismatch (#258)

### DIFF
--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -50,9 +50,7 @@
         "cumulative_regressor": "xgboost",
         "final_academic_week": 36
     },
-    "numerus_fixus": {
-        "B Opleiding": 0
-    },
+    "numerus_fixus": {},
     "excluded_data_points": [],
     "ensemble_override_cumulative": [
         "B Geneeskunde",

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -248,18 +248,32 @@ De canonieke output is altijd `;`-gescheiden, ongeacht de input-separator.
 
 ## `numerus_fixus`
 
-Een object met opleidingsnamen als sleutels en het maximale inschrijvingsaantal als waarde:
+Een object met **programmasleutels** als keys en het maximale inschrijvingsaantal (de NF-capaciteit) als waarde. Numerus-fixus-opleidingen krijgen een aparte behandeling: een eigen regressor (los van de gedeelde pool), een capaciteitsplafond op de voorspelling, en aparte foutrapportage.
 
 ```json
 {
     "numerus_fixus": {
-        "B Geneeskunde": 340,
-        "B Tandheelkunde": 50
+        "56604": 350,
+        "50033": 260
     }
 }
 ```
 
 Als de gesommeerde voorspelling over herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Opleidingen die hier niet staan worden niet gecapped.
+
+!!! danger "De sleutel moet exact matchen met de programmakolom (`Croho groepeernaam`)"
+    De NF-behandeling grijpt **alleen** aan als de sleutel exact overeenkomt met een waarde in de programmakolom van je data. Welk formaat dat is, hangt af van je instelling:
+
+    - **Cumulatief spoor** — de programmakolom bevat sinds de Isatcode-migratie de numerieke **Isatcode** (CROHO-code, bijv. `56604`). Gebruik dan de Isatcode als sleutel.
+    - **Individueel spoor / legacy** — de programmakolom bevat de **leesbare opleidingsnaam** (bijv. `"B Geneeskunde"`). Gebruik dan de naam als sleutel.
+
+    Het dtype maakt niet uit: een numerieke sleutel wordt automatisch als getal geïnterpreteerd (`"56604"` en `56604` zijn equivalent). JSON kent geen inline-commentaar, dus noteer de leesbare naam bij voorkeur in je eigen documentatie of changelog naast de Isatcode.
+
+!!! warning "Sleutelruimtes van de twee sporen overlappen niet (#238)"
+    Het cumulatieve spoor keyt op Isatcodes, het individuele spoor op namen. Eén sleutel kan daardoor maar één van beide sporen matchen. Draai je `-d both`, dan grijpt een Isatcode-sleutel wél aan in het cumulatieve spoor maar niet in het individuele — je krijgt hierover een **waarschuwing**. Tot #238 is opgelost is er geen sleutel die beide sporen tegelijk bedient.
+
+!!! info "Guard tegen stille misconfiguratie (#258)"
+    Vóór de voorspelling controleert de pipeline of elke `numerus_fixus`-sleutel voorkomt in de programmakolom. Matcht een sleutel **geen enkel** geladen spoor (typefout of verkeerd formaat), dan **stopt de pipeline met een harde fout** — een niet-matchende sleutel wordt nooit meer stil genegeerd. Zie [validatie](validatie.md#numerus-fixus-sleutels).
 
 ## `excluded_data_points` — anomaliejaren uitsluiten van trainingsdata
 

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -131,6 +131,21 @@ uv run studentprognose --yes -y 2024 -w 10
 
 Met `--yes` verschijnt een waarschuwing in de console maar stopt de pipeline niet. Gebruik dit bewust: een extreme afwijking kan duiden op een Studielink-probleem dat je niet wilt meenemen in de modeltraining.
 
+### Numerus-fixus-sleutels
+
+Direct na het preprocessen — vóór de voorspelling — controleert de pipeline of elke sleutel in [`numerus_fixus`](configuratie.md#numerus_fixus) daadwerkelijk voorkomt in de programmakolom (`Croho groepeernaam`) van de geladen data. Dit voorkomt de stille misconfiguratie uit issue #258: een sleutel die niet matcht, levert bij `.isin`/`==` simpelweg `False` op, zonder foutmelding, waardoor de numerus-fixus-behandeling (aparte regressor, capaciteitsplafond, aparte foutrapportage) ongemerkt niet aangrijpt.
+
+De check draait op de genormaliseerde, gepreprocesste data, zodat het exacte dtype van de kolom wordt gezien.
+
+| Situatie | Gedrag |
+|----------|--------|
+| Sleutel matcht **geen enkel** geladen spoor | Hard stop — pipeline stopt (typefout of verkeerd formaat) |
+| Sleutel matcht wel het ene, maar niet het andere geladen spoor | Waarschuwing — bekende namen-vs-Isatcodes-mismatch (#238) |
+| Elke sleutel matcht alle geladen sporen | Check slaagt stilzwijgend |
+
+!!! tip "Oplossing"
+    Gebruik voor het cumulatieve spoor de numerieke **Isatcode** als sleutel, voor het individuele spoor de leesbare **opleidingsnaam** — precies de waarde zoals die in de programmakolom van dat spoor staat. Zie [`numerus_fixus`](configuratie.md#numerus_fixus).
+
 ## Post-prediction checks
 
 Nadat het ensemble zijn voorspellingen heeft opgeleverd, voert de pipeline twee informatieve checks uit. Ze stoppen de pipeline **nooit** — ze printen alleen waarschuwingen in de console.

--- a/src/studentprognose/data/nf_validation.py
+++ b/src/studentprognose/data/nf_validation.py
@@ -1,0 +1,131 @@
+"""Guard op de ``numerus_fixus``-sleutels (issue #258).
+
+De numerus-fixus-behandeling (aparte regressor, ratio-cap, aparte
+WAPE-rapportage) grijpt alleen aan als een geconfigureerde ``numerus_fixus``-key
+*exact* matcht met een waarde in de programmakolom (``Croho groepeernaam``).
+Een niet-matchende key faalt **stil**: ``.isin``/``==`` levert simpelweg
+``False`` op — geen error, geen waarschuwing. De opleiding wordt dan als een
+gewone opleiding behandeld, belandt in de gedeelde regressor-pool en wordt niet
+afgetopt.
+
+De sleutelruimtes van de twee sporen overlappen bovendien niet: het cumulatieve
+spoor keyt op numerieke Isatcodes, het individuele spoor op leesbare namen
+(#238). Eén key kan daardoor per definitie maar één spoor matchen.
+
+Deze module dwingt daarom af:
+
+- **hard error** — een key matcht *geen enkel* geladen spoor (typefout of
+  verkeerd dtype/formaat). De pipeline stopt.
+- **waarschuwing** — een key matcht *wel* een spoor maar niet een ander geladen
+  spoor (de bekende namen-vs-Isatcodes-mismatch, #238). De NF-behandeling grijpt
+  dan niet aan in dat spoor; de gebruiker wordt gewaarschuwd i.p.v. stil
+  genegeerd.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from studentprognose.data.validation import ValidationResult
+
+
+class NumerusFixusConfigError(ValueError):
+    """Een numerus_fixus-sleutel matcht geen enkele geladen programmakolom.
+
+    Subklasse van ``ValueError`` zodat het in-memory API-pad (dat excepties
+    doorgeeft i.p.v. ``sys.exit``) de fout normaal kan afvangen, terwijl de CLI
+    hem opvangt en netjes met exitcode 1 afsluit.
+    """
+
+
+def validate_numerus_fixus_keys(
+    numerus_fixus_list: dict | None,
+    programme_series_by_track: dict[str, pd.Series | None] | None,
+    result: ValidationResult | None = None,
+) -> ValidationResult:
+    """Controleer of elke ``numerus_fixus``-key een programmakolom matcht.
+
+    Args:
+        numerus_fixus_list: De (reeds dtype-genormaliseerde) numerus-fixus-dict
+            ``{sleutel: cap}``. Leeg of ``None`` → no-op.
+        programme_series_by_track: Mapping van spoornaam
+            (bijv. ``"cumulatief"``, ``"individueel"``) naar de programmakolom
+            van dat spoor. Alleen de daadwerkelijk geladen sporen hoeven erin te
+            zitten (afhankelijk van ``-d``).
+        result: Optioneel bestaand :class:`ValidationResult` om aan toe te
+            voegen; anders wordt een nieuwe aangemaakt.
+
+    Returns:
+        Het :class:`ValidationResult` met eventuele ``hard_errors`` (key matcht
+        nergens) en ``warnings`` (key matcht niet elk geladen spoor).
+    """
+    result = result or ValidationResult()
+
+    if not isinstance(numerus_fixus_list, dict) or not numerus_fixus_list:
+        return result
+    if not programme_series_by_track:
+        return result
+
+    # Bouw per spoor een set van unieke programmawaarden. .dropna() haalt
+    # pandas-NA weg; .tolist() geeft native Python-typen zodat een int-key
+    # (Isatcode) een Int64-kolom matcht en een str-key een namen-kolom.
+    track_values: dict[str, set] = {}
+    for track, series in programme_series_by_track.items():
+        if series is None:
+            continue
+        track_values[track] = set(pd.Series(series).dropna().tolist())
+
+    if not track_values:
+        return result
+
+    for key in numerus_fixus_list:
+        matched = [track for track, values in track_values.items() if key in values]
+
+        if not matched:
+            result.hard_errors.append(
+                f"numerus_fixus-sleutel {key!r} komt in geen enkele geladen "
+                f"programmakolom voor (gecontroleerde sporen: "
+                f"{', '.join(sorted(track_values))}). Gebruik de exacte waarde en "
+                f"het exacte dtype uit de programmakolom — voor het cumulatieve "
+                f"spoor de numerieke Isatcode, voor het individuele spoor de "
+                f"leesbare opleidingsnaam (zie #258/#238)."
+            )
+            continue
+
+        for track in sorted(track_values):
+            if track not in matched:
+                result.warnings.append(
+                    f"numerus_fixus-sleutel {key!r} matcht wel het spoor "
+                    f"'{matched[0]}' maar niet '{track}'. De numerus-fixus-"
+                    f"behandeling grijpt daardoor niet aan in '{track}' (bekende "
+                    f"sleutel-mismatch tussen namen en Isatcodes, #238)."
+                )
+
+    return result
+
+
+def enforce_numerus_fixus_keys(
+    numerus_fixus_list: dict | None,
+    programme_series_by_track: dict[str, pd.Series | None] | None,
+) -> None:
+    """Draai de guard en handel de bevindingen af.
+
+    Waarschuwingen worden geprint (pipeline loopt door); een niet-matchende
+    sleutel gooit :class:`NumerusFixusConfigError`. Deze exception werkt in beide
+    routes: het API-pad geeft hem door aan de aanroeper, de CLI vangt hem en sluit
+    af met exitcode 1.
+
+    Raises:
+        NumerusFixusConfigError: Als minstens één sleutel geen enkel geladen
+            spoor matcht.
+    """
+    result = validate_numerus_fixus_keys(numerus_fixus_list, programme_series_by_track)
+
+    for warning in result.warnings:
+        print(f"  [WAARSCHUWING] {warning}")
+
+    if result.hard_errors:
+        raise NumerusFixusConfigError(
+            "Ongeldige numerus_fixus-configuratie:\n"
+            + "\n".join(f"  - {e}" for e in result.hard_errors)
+        )

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -10,6 +10,10 @@ from studentprognose.config import (
     load_configuration, load_defaults_filtering, load_filtering, get_final_academic_week,
 )
 from studentprognose.data.loader import load_data, _normalize_programme_code
+from studentprognose.data.nf_validation import (
+    NumerusFixusConfigError,
+    enforce_numerus_fixus_keys,
+)
 from studentprognose.data.prediction_validator import run_pre_prediction_checks
 from studentprognose.data.range_check import (
     detect_data_range_mismatch,
@@ -143,7 +147,17 @@ def main(argv):
 
     # Steps 2-7: gemeenschappelijke pipeline-kern
     cwd = os.getcwd()
-    _run_pipeline_core(cfg, datasets, configuration, filtering, cwd)
+    try:
+        _run_pipeline_core(cfg, datasets, configuration, filtering, cwd)
+    except NumerusFixusConfigError as exc:
+        # Config-fout: netjes afsluiten met exitcode 1 i.p.v. een traceback.
+        # (Het in-memory API-pad vangt dezelfde exception zelf af.)
+        print(f"\nValidatie mislukt — de pipeline kan niet worden gestart:\n{exc}")
+        print(
+            "\nLos de numerus_fixus-configuratie op (gebruik de exacte "
+            "programmasleutel uit je data) en probeer opnieuw."
+        )
+        sys.exit(1)
 
 
 def cli():
@@ -539,6 +553,21 @@ def _run_pipeline_strategy(cfg, datasets, configuration, filtering, cwd, save_ou
 
     # Step 3: Preprocess (feature engineering)
     data_cumulative = _preprocess(strategy, cfg.student_year_prediction)
+
+    # Step 3b: Guard op de numerus_fixus-sleutels (#258). Voorkomt dat een
+    # NF-sleutel die niet exact matcht met de programmakolom stil wordt
+    # genegeerd (geen aparte regressor, geen ratio-cap). Draait op de
+    # genormaliseerde, gepreprocesste data zodat de check het echte dtype ziet.
+    if cfg.student_year_prediction in (
+        StudentYearPrediction.FIRST_YEARS,
+        StudentYearPrediction.VOLUME,
+    ):
+        get_tracks = getattr(strategy, "get_programme_columns_by_track", None)
+        if callable(get_tracks):
+            enforce_numerus_fixus_keys(
+                getattr(strategy, "numerus_fixus_list", None),
+                get_tracks(),
+            )
 
     # Step 4: Apply filtering
     strategy.set_filtering(

--- a/src/studentprognose/strategies/base.py
+++ b/src/studentprognose/strategies/base.py
@@ -63,6 +63,21 @@ class PredictionStrategy(ABC):
             "xgb_regressor_importance": None,
         }
 
+    def _programme_column_name(self) -> str:
+        """Naam van de programmakolom (config-driven, valt terug op default)."""
+        return self.configuration.get("column_roles", {}).get(
+            "programme", "Croho groepeernaam"
+        )
+
+    def get_programme_columns_by_track(self) -> dict:
+        """Programmakolom per geladen spoor, voor de numerus_fixus-guard (#258).
+
+        Retourneert een mapping ``{spoornaam: Series}`` met alleen de sporen die
+        na preprocessing daadwerkelijk data hebben. De basisimplementatie levert
+        niets op; elke strategie vult haar eigen spoor/sporen in.
+        """
+        return {}
+
     def get_data_to_predict(
         self, data, programme_filtering=None, herkomst_filtering=None, examentype_filtering=None
     ):

--- a/src/studentprognose/strategies/combined.py
+++ b/src/studentprognose/strategies/combined.py
@@ -50,6 +50,12 @@ class CombinedStrategy(PredictionStrategy):
             "xgb_regressor_importance": self.cumulative.xgboost_importance,
         }
 
+    def get_programme_columns_by_track(self) -> dict:
+        tracks = {}
+        tracks.update(self.individual.get_programme_columns_by_track())
+        tracks.update(self.cumulative.get_programme_columns_by_track())
+        return tracks
+
     def preprocess(self):
         print("Preprocessing individual data...")
         self.individual.preprocess()

--- a/src/studentprognose/strategies/cumulative.py
+++ b/src/studentprognose/strategies/cumulative.py
@@ -153,6 +153,12 @@ class CumulativeStrategy(PredictionStrategy):
             "xgb_regressor_importance": self.xgboost_importance,
         }
 
+    def get_programme_columns_by_track(self) -> dict:
+        col = self._programme_column_name()
+        if self.data_cumulative is None or col not in self.data_cumulative.columns:
+            return {}
+        return {"cumulatief": self.data_cumulative[col]}
+
     def preprocess(self):
         data = self.data_cumulative
 

--- a/src/studentprognose/strategies/individual.py
+++ b/src/studentprognose/strategies/individual.py
@@ -140,6 +140,12 @@ class IndividualStrategy(PredictionStrategy):
             "xgb_regressor_importance": None,
         }
 
+    def get_programme_columns_by_track(self) -> dict:
+        col = self._programme_column_name()
+        if self.data_individual is None or col not in self.data_individual.columns:
+            return {}
+        return {"individueel": self.data_individual[col]}
+
     def set_xgboost_importance(self, importance):
         self.xgboost_importance = importance
 

--- a/tests/studentprognose/test_nf_validation.py
+++ b/tests/studentprognose/test_nf_validation.py
@@ -1,0 +1,132 @@
+"""Tests voor de numerus_fixus-sleutelguard (#258).
+
+Bewaakt dat een NF-sleutel die niet matcht met de programmakolom niet stil wordt
+genegeerd: geen match → harde fout; match in één spoor maar niet het andere →
+waarschuwing; geldige match → schoon resultaat.
+"""
+
+import pandas as pd
+import pytest
+
+from studentprognose.data.nf_validation import (
+    NumerusFixusConfigError,
+    enforce_numerus_fixus_keys,
+    validate_numerus_fixus_keys,
+)
+
+
+class TestValidateNumerusFixusKeys:
+    def test_empty_nf_list_is_noop(self):
+        result = validate_numerus_fixus_keys(
+            {}, {"cumulatief": pd.Series([56604, 56605], dtype="Int64")}
+        )
+        assert result.hard_errors == []
+        assert result.warnings == []
+
+    def test_none_nf_list_is_noop(self):
+        result = validate_numerus_fixus_keys(
+            None, {"cumulatief": pd.Series([56604], dtype="Int64")}
+        )
+        assert result.hard_errors == []
+        assert result.warnings == []
+
+    def test_no_tracks_is_noop(self):
+        result = validate_numerus_fixus_keys({56604: 350}, {})
+        assert result.hard_errors == []
+        assert result.warnings == []
+
+    def test_matching_isatcode_produces_no_findings(self):
+        result = validate_numerus_fixus_keys(
+            {56604: 350},
+            {"cumulatief": pd.Series([56604, 56605], dtype="Int64")},
+        )
+        assert result.hard_errors == []
+        assert result.warnings == []
+
+    def test_nonmatching_key_is_hard_error(self):
+        # Naam-key tegen een numerieke Isatcode-kolom → matcht nooit → harde fout
+        # (dit is exact het silent-no-match-scenario uit #258).
+        result = validate_numerus_fixus_keys(
+            {"B Geneeskunde": 350},
+            {"cumulatief": pd.Series([56604, 56605], dtype="Int64")},
+        )
+        assert len(result.hard_errors) == 1
+        assert "B Geneeskunde" in result.hard_errors[0]
+        assert result.warnings == []
+
+    def test_wrong_dtype_string_isatcode_is_hard_error(self):
+        # Str "56604" != Int64 56604 → geen match → harde fout (dtype-mismatch).
+        result = validate_numerus_fixus_keys(
+            {"56604": 350},
+            {"cumulatief": pd.Series([56604], dtype="Int64")},
+        )
+        assert len(result.hard_errors) == 1
+        assert result.warnings == []
+
+    def test_track_mismatch_produces_warning_not_error(self):
+        # Isatcode-key matcht cumulatief (Int64) maar niet individueel (namen).
+        # Geen harde fout — de key is geldig voor minstens één spoor — wél een
+        # waarschuwing dat NF niet aangrijpt in het individuele spoor (#238).
+        result = validate_numerus_fixus_keys(
+            {56604: 350},
+            {
+                "cumulatief": pd.Series([56604, 56605], dtype="Int64"),
+                "individueel": pd.Series(["B Geneeskunde", "B Psychologie"]),
+            },
+        )
+        assert result.hard_errors == []
+        assert len(result.warnings) == 1
+        assert "individueel" in result.warnings[0]
+
+    def test_multiple_keys_mixed_outcomes(self):
+        result = validate_numerus_fixus_keys(
+            {56604: 350, 99999: 100},
+            {"cumulatief": pd.Series([56604, 56605], dtype="Int64")},
+        )
+        # 56604 matcht, 99999 niet → precies één harde fout.
+        assert len(result.hard_errors) == 1
+        assert "99999" in result.hard_errors[0]
+
+    def test_none_series_track_is_ignored(self):
+        result = validate_numerus_fixus_keys(
+            {56604: 350},
+            {
+                "cumulatief": pd.Series([56604], dtype="Int64"),
+                "individueel": None,
+            },
+        )
+        # Individueel spoor niet geladen → geen waarschuwing daarover.
+        assert result.hard_errors == []
+        assert result.warnings == []
+
+
+class TestEnforceNumerusFixusKeys:
+    def test_hard_error_raises(self):
+        with pytest.raises(NumerusFixusConfigError) as exc:
+            enforce_numerus_fixus_keys(
+                {"B Geneeskunde": 350},
+                {"cumulatief": pd.Series([56604], dtype="Int64")},
+            )
+        assert "B Geneeskunde" in str(exc.value)
+
+    def test_hard_error_is_valueerror_subclass(self):
+        # Het API-pad vangt ValueError; de exception moet daaronder vallen.
+        assert issubclass(NumerusFixusConfigError, ValueError)
+
+    def test_valid_key_does_not_raise(self):
+        enforce_numerus_fixus_keys(
+            {56604: 350},
+            {"cumulatief": pd.Series([56604], dtype="Int64")},
+        )
+
+    def test_track_mismatch_warns_but_does_not_raise(self, capsys):
+        enforce_numerus_fixus_keys(
+            {56604: 350},
+            {
+                "cumulatief": pd.Series([56604], dtype="Int64"),
+                "individueel": pd.Series(["B Geneeskunde"]),
+            },
+        )
+        out = capsys.readouterr().out
+        assert "WAARSCHUWING" in out
+        assert "individueel" in out


### PR DESCRIPTION
Closes #258 gedeeltelijk (zie **Scope** onderaan).

## Het probleem in één zin

Een `numerus_fixus`-sleutel die niet exact matcht met de programmakolom (`Croho groepeernaam`) faalde **stil**: `.isin`/`==` gaf simpelweg `False`, zonder error of waarschuwing. De numerus-fixus-behandeling greep dan ongemerkt niet aan.

## Waarom dat gevaarlijk was

| Gevolg | Effect |
|--------|--------|
| NF-opleiding in gedeelde regressor-pool | Vertekende aanmelders→studenten-relatie → **bias voor álle opleidingen** van dat examentype |
| Geen capaciteitsplafond | NF-opleiding wordt **overschat** |
| Ratio-cap treedt niet op | Prognose loopt door boven de capaciteit |
| WAPE vertekend | Backtest-fout onbetrouwbaar |

De placeholder `{"B Opleiding": 0}` in `configuration.json` is precies zo'n niet-matchende sleutel — een naam tegen een numerieke Isatcode-kolom.

## De kern: de sleutel is voortaan de Isatcode

Sinds de Isatcode-migratie keyt het **cumulatieve spoor** op de numerieke **Isatcode** (`56604`), niet meer op de leesbare naam. De `numerus_fixus`-sleutel moet daarom exact die Isatcode zijn:

```json
"numerus_fixus": {
    "56604": 350
}
```

Het dtype maakt niet uit — `"56604"` (string) en `56604` (int) worden equivalent behandeld. Een leesbare naam als sleutel matcht de kolom nooit en wordt door de guard hieronder tegengehouden.

## Wat deze PR doet

**1. Guard (`data/nf_validation.py`)**
- Hard error als een sleutel de geladen (cumulatieve) programmakolom **niet** matcht (typefout / verkeerd dtype / naam i.p.v. Isatcode). → stil falen onmogelijk.

**2. Nette foutafhandeling in beide routes**
- `NumerusFixusConfigError(ValueError)`: de **CLI** vangt hem en sluit netjes af met exitcode 1 (geen traceback); het **in-memory API-pad** kan de exception gewoon afvangen — geen `sys.exit` in een bibliotheekaanroep.

**3. Config-hygiëne**
- Kapotte placeholder `{"B Opleiding": 0}` → `{}` (eerlijke "niet-geconfigureerd"-staat).

**4. Docs** (verplicht per CLAUDE.md)
- `docs/configuratie.md`: NF-sleutel = Isatcode voor het cumulatieve spoor, dtype-normalisatie, en de guard.
- `docs/validatie.md`: nieuwe sectie "Numerus-fixus-sleutels".

**5. Tests** — `tests/studentprognose/test_nf_validation.py`.

## Verificatie

- ✅ Volledige unit suite: **502 passed**
- ✅ Smoke test (`scripts/test_package.sh`): exit 0
- ✅ `ruff check` schoon op alle gewijzigde bestanden
- ✅ **End-to-end op demodata:**
  - niet-matchende key → nette melding, **exitcode 1** (guard grijpt aan)
  - matchende Isatcode → **exitcode 0** + output gegenereerd

Omdat de guard exact dezelfde `sleutel in kolomwaarden`-semantiek gebruikt als de NF-branch (`cumulative.py:435`), betekent "guard slaagt" dat de NF-split + ratio-cap daadwerkelijk aangrijpen (acceptatiecriterium 4).

## Scope — wat deze PR bewust NIET doet

Acceptatiecriteria **1 & 2** (de echte UvA-Isatcodes + capaciteiten invullen) vereisen UvA-capaciteitsdata die hier niet beschikbaar is. Foute nummers verzinnen is erger dan leeg laten. Deze PR levert de **mechaniek** die dat invullen voortaan veilig en verifieerbaar maakt: zet je een verkeerde sleutel, dan stopt de pipeline nu hard i.p.v. stil te falen. Het invullen zelf blijft open (zie #255).

## Acceptatiecriteria

- [ ] NF-keys zijn Isatcodes — *blijft open (data-invoer, #255)*
- [ ] Correcte caps ingevuld — *blijft open (data-invoer, #255)*
- [x] **Guard die hard faalt bij niet-matchende sleutel** — ✅ deze PR
- [x] **Geverifieerd dat NF-behandeling aangrijpt** (guard-semantiek = NF-branch-semantiek) — ✅ deze PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
