### PR TITLE
feat: multi-instelling filter voor teldata (#200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ uv run studentprognose -w 6 -y 2020
 studentprognose -w 6 -y 2024                  # specifieke week en jaar
 studentprognose -w 10 : 20 -y 2023            # weekbereik
 studentprognose -d c                           # alleen cumulatief spoor
+studentprognose -d c --institution 21PC        # scoop de teldata op je eigen instelling
 studentprognose -y 2023 2024 -w 10 : 20 -d b  # meerdere jaren, beide sporen
 
 studentprognose benchmark -d c -w 12           # vergelijk alternatieve modellen
@@ -127,6 +128,7 @@ studentprognose tune -d c -w 12                # stem hyperparameters af (cumula
 | `-w` | Voorspelweek(en) | weeknummers of bereik, bijv. `10 : 20` |
 | `-y` | Voorspeljaar(en) | bijv. `2024` of `2023 2024` |
 | `-d` | Dataset | `i`ndividual, `c`umulative, `b`oth (standaard) |
+| `--institution` | Beperk teldata tot instelling(en) | Brincode(s), bijv. `21PC`; standaard alle |
 | `--noetl` | Sla ETL over | als je al verwerkte data in `data/input/` hebt |
 | `--yes` | Sla interactieve prompts over | voor CI/CD en cron |
 

--- a/configuration/configuration.json
+++ b/configuration/configuration.json
@@ -53,6 +53,7 @@
     "numerus_fixus": {
         "B Opleiding": 0
     },
+    "institution_filter": [],
     "excluded_data_points": [],
     "ensemble_override_cumulative": [
         "B Geneeskunde",
@@ -75,6 +76,7 @@
         "exam_type": "Examentype",
         "origin": "Herkomst",
         "faculty": "Faculteit",
+        "institution": "Korte naam instelling",
         "enrollment_status": "Inschrijfstatus",
         "cancellation_date": "Datum intrekking vooraanmelding",
         "student_count": "Aantal_studenten",

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -216,6 +216,20 @@ studentprognose -w 10 -y 2025 -d cumulative --institution 21PC 00IC
 
 De vlag overschrijft de config-key [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen); laat je hem weg, dan geldt de configuratiewaarde (standaard: alle instellingen). Een onbekende instellingscode stopt de run met een duidelijke foutmelding in plaats van stil een lege dataset te verwerken. Zet je in je config bijvoorbeeld je eigen Brincode vast, dan hoef je de vlag niet elke keer mee te geven.
 
+!!! warning "Standaard reken je over álle instellingen"
+    Zonder `--institution` én zonder `institution_filter` in je config traint en voorspelt het cumulatieve spoor over de héle landelijke teldata (alle instellingen tegelijk). Dat is het backwards-compatibele default-gedrag, maar zelden wat je wilt als je één instelling voorspelt. Zet daarom je eigen Brincode vast in de config.
+
+!!! note "De run meldt altijd de scope"
+    Bij elke run print de tool één regel met de instellings-scope, zodat je nooit ongemerkt over de verkeerde (of alle) instellingen rekent:
+
+    ```
+    # Met filter
+    Instellingsfilter actief: 21PC — 9.650 van 211.183 rijen behouden (uit 52 beschikbare instellingen).
+
+    # Zonder filter
+    Instellingsfilter: geen — alle 52 instellingen worden meegenomen (211.183 rijen). Zet 'institution_filter' (of --institution) om je eigen instelling(en) te kiezen.
+    ```
+
 ## Gebruik als Python-package
 
 Naast de CLI kun je `studentprognose` ook direct vanuit Python-scripts importeren. Dit is handig voor geautomatiseerde pipelines, notebooks, of cloudworkflows waarbij de data al in-memory beschikbaar is.

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -189,6 +189,7 @@ studentprognose --help
 | `-sy` | `f` / `h` / `v` | `f` | Studentjaar: `first-years` (standaard), `higher-years`, `volume` |
 | `-c` | pad | `configuration/configuration.json` | Configuratiebestand |
 | `-f` | pad | `configuration/filtering/base.json` | Filterbestand |
+| `--institution` | instellingscode(s) | alle instellingen | Beperk de teldata tot één of meer instellingen (Brincode), bijv. `--institution 21PC` |
 | `-sk` | getal | `0` | Skip N jaren (backtesting) |
 | `--noetl` | — | uit | Sla ETL én validatie over |
 | `--yes` | — | uit | Sla validatieprompts over (voor CI/CD) |
@@ -200,6 +201,20 @@ Weekbereiken zijn mogelijk: `-w 8:12` is gelijk aan `-w 8 9 10 11 12`.
 
 !!! note "Eerstejaars als focus"
     De tool draait standaard op `-sy f` (eerstejaars). De modus `-sy v` (volume) is een vervolgstap — gebruik die pas als je eerstejaarsvoorspelling op orde is.
+
+### `--institution`
+
+De landelijke Studielink-teldata bevat rijen van álle instellingen. Met `--institution` scoop je de run op je eigen instelling(en):
+
+```bash
+# Alleen instelling 21PC
+studentprognose -w 10 -y 2025 -d cumulative --institution 21PC
+
+# Meerdere instellingen
+studentprognose -w 10 -y 2025 -d cumulative --institution 21PC 00IC
+```
+
+De vlag overschrijft de config-key [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen); laat je hem weg, dan geldt de configuratiewaarde (standaard: alle instellingen). Een onbekende instellingscode stopt de run met een duidelijke foutmelding in plaats van stil een lege dataset te verwerken. Zet je in je config bijvoorbeeld je eigen Brincode vast, dan hoef je de vlag niet elke keer mee te geven.
 
 ## Gebruik als Python-package
 

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -261,6 +261,30 @@ Een object met opleidingsnamen als sleutels en het maximale inschrijvingsaantal 
 
 Als de gesommeerde voorspelling over herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Opleidingen die hier niet staan worden niet gecapped.
 
+## `institution_filter` — beperk de teldata tot één of meer instellingen
+
+De landelijke Studielink-teldata bevat rijen van **álle** instellingen (elke Brincode staat in de kolom `Korte naam instelling`). Met `institution_filter` beperk je de pipeline tot je eigen instelling(en), zodat de modellen niet op andermans instroom trainen.
+
+```json
+{
+    "institution_filter": ["21PC"]
+}
+```
+
+- **Type:** lijst van instellingscodes (Brincodes, bijv. `"21PC"`) of leesbare instellingsnamen — precies zoals ze in de kolom `Korte naam instelling` staan.
+- **Standaard (`[]`):** geen filter — **alle instellingen** in de data worden meegenomen. Dit is het backwards-compatibele default-gedrag.
+- Meerdere instellingen: `["21PC", "00IC"]`.
+
+Het filter grijpt aan op **load-tijd**, vóór preprocessing, zodat zowel de training als de voorspelling op de gekozen instelling(en) draaien.
+
+!!! info "Welke sporen worden gefilterd?"
+    Alleen sporen die een instellingskolom dragen — dat is het **cumulatieve spoor** (de landelijke teldata). Het **individuele spoor** is doorgaans de eigen aanmeldexport van één instelling en heeft geen instellingskolom; daar is het filter een no-op. Het studentaantallenbestand (`student_count`) wordt eveneens verondersteld al instelling-specifiek te zijn.
+
+!!! warning "Onbekende instelling faalt hard"
+    Komt een opgegeven code in het geheel niet voor in de data, dan stopt de pipeline met een duidelijke foutmelding (en de lijst van beschikbare instellingen) in plaats van stil een lege dataset te verwerken. Komt een code wél gedeeltelijk voor, dan zie je een waarschuwing voor de ontbrekende codes.
+
+Je kunt deze config-waarde op de commandline overschrijven met de vlag [`--institution`](aan-de-slag.md#-institution) — handig om snel voor één instelling te draaien zonder de config aan te passen.
+
 ## `excluded_data_points` — anomaliejaren uitsluiten van trainingsdata
 
 Optionele lijst van filterregels voor het verwijderen van bekende problematische datapunten uit de **trainingsdata**. De tool past de regels toe vóór elk model wordt getraind. Het voorspeljaar (`predict_year`) wordt **altijd** beschermd en nooit uitgesloten, ongeacht de regels.
@@ -399,6 +423,9 @@ Waar `columns` instellings-specifieke namen vertaalt naar kanonieke namen, koppe
 | `weighted_applicants` | `Gewogen vooraanmelders` | `unweighted_applicants` | `Ongewogen vooraanmelders` |
 | `single_applicants` | `Aantal aanmelders met 1 aanmelding` | `higher_years` | `Hogerejaars` |
 | `croho_source` | `Groepeernaam Croho` | `higher_education_type` | `Type hoger onderwijs` |
+| `institution` | `Korte naam instelling` | | |
+
+De rol `institution` bepaalt op welke kolom [`institution_filter`](#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen) filtert.
 
 Pas dit alleen aan als je de **interne** kanonieke namen wijzigt — in de meeste gevallen gebruik je `columns` (voor je ruwe inputkolommen) en laat je `column_roles` ongemoeid.
 

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -43,6 +43,9 @@ De velden hieronder zijn de kolommen die de demo-telbestanden bevatten en die de
 | `meercode_V` | int | §5.12 | Gemiddeld aantal aanmeldingen per student met status V/U/I. Wordt door de ETL als deler gebruikt: `Gewogen vooraanmelders = Aantal / meercode_V`. Voor status A-rijen is deze waarde 0 — die rijen worden door de ETL uitgefilterd. |
 | `Status` | str | §5.13 | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
 
+!!! tip "Teldata bevat meerdere instellingen — scoop op je eigen Brincode"
+    Een Studielink-telbestand is landelijk: de kolom `Brincode` (na ETL `Korte naam instelling`) bevat rijen van álle instellingen. Wil je alleen je eigen instelling voorspellen, gebruik dan [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen) in je configuratie of de CLI-vlag [`--institution`](aan-de-slag.md#-institution). Zonder filter traint en voorspelt de tool over alle aanwezige instellingen tegelijk. Het filter geldt voor het cumulatieve spoor; het individuele spoor is doorgaans al de eigen aanmeldexport van één instelling.
+
 #### Afwijkende bestandsnamen
 
 Gebruikt jouw instelling een andere conventie dan `telbestandY{jaar}W{week}.csv`? Geef in `configuration.json` één of meer eigen patronen op:

--- a/scripts/test_package.sh
+++ b/scripts/test_package.sh
@@ -16,6 +16,9 @@
 #      TerminatedWorkerError in de parallel-helper; de fallback uit PR #198 moet
 #      kicken en de pipeline moet doorlopen tot outputbestand. Bewaakt issue #197
 #      structureel, ook op Windows-runners.
+#   9. Multi-instelling filter (#200) — --institution scoopt de teldata tot één
+#      instelling (pipeline slaagt), en een onbekende instelling faalt hard
+#      (exitcode != 0) i.p.v. stil een lege pipeline te draaien.
 #
 # Gebruik: bash scripts/test_package.sh [--skip-build]
 
@@ -131,6 +134,20 @@ fi
     || { echo "FOUT: output ontbreekt na crash-injectie run"; exit 1; }
 grep -q "Opnieuw proberen met n_jobs=2" "$CRASH_LOG" \
     || { echo "FOUT: fallback-waarschuwing niet gevonden in log — fallback fired niet"; tail -n 30 "$CRASH_LOG"; exit 1; }
+echo "OK"
+
+echo ""
+echo "=== [9] Multi-instelling filter (--institution) ==="
+# De demo-teldata bevat 52 instellingen (Brincodes). --institution 21PC moet de
+# pipeline tot die ene instelling scopen en gewoon een outputbestand opleveren.
+rm -f data/output/output_prelim_cumulatief.xlsx
+uv run studentprognose -w 6 -y 2024 -d cumulative --noetl --yes --institution 21PC > /dev/null
+[ -f data/output/output_prelim_cumulatief.xlsx ] || { echo "FOUT: output ontbreekt na --institution run"; exit 1; }
+# Een onbekende instelling mag NIET stil een lege pipeline draaien: harde fout.
+if uv run studentprognose -w 6 -y 2024 -d cumulative --noetl --yes --institution ZZZZ 2>/dev/null; then
+    echo "FOUT: exitcode 0 verwacht bij onbekende instelling, maar pipeline slaagde"
+    exit 1
+fi
 echo "OK"
 
 echo ""

--- a/scripts/test_package.sh
+++ b/scripts/test_package.sh
@@ -140,9 +140,19 @@ echo ""
 echo "=== [9] Multi-instelling filter (--institution) ==="
 # De demo-teldata bevat 52 instellingen (Brincodes). --institution 21PC moet de
 # pipeline tot die ene instelling scopen en gewoon een outputbestand opleveren.
+# Verwijder eerst een eventueel achtergebleven outputbestand (van een vorige
+# lokale run of eerdere stap), zodat de -f check hieronder écht bewijst dat déze
+# run output produceerde en niet stilletjes slaagt op een oud bestand.
 rm -f data/output/output_prelim_cumulatief.xlsx
-uv run studentprognose -w 6 -y 2024 -d cumulative --noetl --yes --institution 21PC > /dev/null
+FILTER_LOG="$(uv run studentprognose -w 6 -y 2024 -d cumulative --noetl --yes --institution 21PC)"
 [ -f data/output/output_prelim_cumulatief.xlsx ] || { echo "FOUT: output ontbreekt na --institution run"; exit 1; }
+# De run moet de gebruiker informeren waarvoor er gerekend wordt.
+echo "$FILTER_LOG" | grep -q "Instellingsfilter actief: 21PC" \
+    || { echo "FOUT: scope-melding voor actief filter niet gevonden"; echo "$FILTER_LOG" | tail -n 20; exit 1; }
+# Zonder filter moet de tool expliciet melden dat álle instellingen meedraaien.
+NOFILTER_LOG="$(uv run studentprognose -w 6 -y 2024 -d cumulative --noetl --yes)"
+echo "$NOFILTER_LOG" | grep -q "Instellingsfilter: geen — alle" \
+    || { echo "FOUT: scope-melding voor 'geen filter' niet gevonden"; echo "$NOFILTER_LOG" | tail -n 20; exit 1; }
 # Een onbekende instelling mag NIET stil een lege pipeline draaien: harde fout.
 if uv run studentprognose -w 6 -y 2024 -d cumulative --noetl --yes --institution ZZZZ 2>/dev/null; then
     echo "FOUT: exitcode 0 verwacht bij onbekende instelling, maar pipeline slaagde"

--- a/src/studentprognose/cli.py
+++ b/src/studentprognose/cli.py
@@ -23,6 +23,7 @@ class PipelineConfig:
     dashboard: bool = False
     command: str | None = None
     tune_target: str = "regressor"
+    institutions: list | None = None
 
 
 def _expand_slices(tokens):
@@ -113,6 +114,18 @@ def parse_args(argv):
         "-f", "-F", "-filtering", nargs="*", default=None, dest="filtering"
     )
     parser.add_argument(
+        "--institution",
+        "-institution",
+        "-inst",
+        nargs="*",
+        default=None,
+        dest="institutions",
+        metavar="INSTELLING",
+        help="Beperk de teldata tot één of meer instellingen (Brincode / 'Korte naam "
+             "instelling'), bijv. --institution 21PC. Overschrijft de config-key "
+             "'institution_filter'. Weglaten = alle instellingen (default).",
+    )
+    parser.add_argument(
         "-sy",
         "-SY",
         "-studentyear",
@@ -158,6 +171,12 @@ def parse_args(argv):
     if args.filtering is not None:
         for path in args.filtering:
             cfg.filtering_path = path
+
+    # Instellingsfilter (issue #200). None = geen override (config-key geldt);
+    # een (evt. lege) lijst overschrijft de config: `--institution` zonder
+    # waarden zet expliciet "alle instellingen".
+    if args.institutions is not None:
+        cfg.institutions = args.institutions
 
     # Dataset
     if args.dataset is not None:

--- a/src/studentprognose/config.py
+++ b/src/studentprognose/config.py
@@ -68,6 +68,7 @@ def load_configuration(file_path: str) -> dict:
     _validate_model_config(cfg, file_path)
     _validate_runtime(cfg, file_path)
     _validate_telbestand_filename_patterns(cfg, file_path)
+    _validate_institution_filter(cfg, file_path)
 
     # Normaliseer de numerus_fixus-keys (programmesleutels) naar hetzelfde dtype
     # als de datakolom: een numerieke Isatcode-key wordt int en matcht zo de
@@ -352,3 +353,32 @@ def _validate_runtime(cfg, file_path):
             f"cores ({available}). Verlaagd naar {available}."
         )
         cfg["runtime"]["cpu_count"] = available
+
+
+def _validate_institution_filter(cfg, file_path):
+    """Valideer ``institution_filter`: een lijst van instellingscodes/-namen.
+
+    Leeg of afwezig = geen filter (alle instellingen). Elke waarde moet een string
+    of geheel getal zijn (Brincodes zijn tekstcodes zoals ``"00IC"``, maar een
+    numerieke code als int wordt geaccepteerd en later als string vergeleken).
+    """
+    institutions = cfg.get("institution_filter")
+    if institutions is None:
+        return
+
+    if not isinstance(institutions, list):
+        print(
+            f"Configuratiefout in {file_path}: "
+            f"'institution_filter' moet een lijst van instellingscodes zijn, "
+            f"niet {type(institutions).__name__}."
+        )
+        sys.exit(1)
+
+    for i, value in enumerate(institutions):
+        if isinstance(value, bool) or not isinstance(value, (str, int)):
+            print(
+                f"Configuratiefout in {file_path}: "
+                f"'institution_filter[{i}]' moet een string of geheel getal zijn, "
+                f"niet {type(value).__name__}."
+            )
+            sys.exit(1)

--- a/src/studentprognose/configuration/configuration.json
+++ b/src/studentprognose/configuration/configuration.json
@@ -53,6 +53,7 @@
         "cumulative_regressor": "xgboost"
     },
     "numerus_fixus": {},
+    "institution_filter": [],
     "excluded_data_points": [],
     "ensemble_override_cumulative": [],
     "exclude_from_combined": [],
@@ -69,6 +70,7 @@
         "exam_type": "Examentype",
         "origin": "Herkomst",
         "faculty": "Faculteit",
+        "institution": "Korte naam instelling",
         "enrollment_status": "Inschrijfstatus",
         "cancellation_date": "Datum intrekking vooraanmelding",
         "student_count": "Aantal_studenten",

--- a/src/studentprognose/data/loader.py
+++ b/src/studentprognose/data/loader.py
@@ -79,21 +79,85 @@ def filter_datasets_by_institution(datasets, configuration):
             ``(individual, cumulative, student_numbers, latest, ensemble)``.
         configuration: De configuratiedict.
 
+    Print altijd één regel met de instellings-scope van de run (issue #200), of
+    er nu wél of níét gefilterd wordt, zodat de eindgebruiker nooit ongemerkt
+    over alle instellingen (of over de verkeerde) rekent.
+
     Returns:
         De (mogelijk) gefilterde 5-tuple, in dezelfde volgorde.
     """
     institutions = configuration.get("institution_filter", [])
-    if not institutions:
-        return datasets
-
     institution_col = configuration.get("column_roles", {}).get(
         "institution", "Korte naam instelling"
     )
 
     data_individual, data_cumulative, *rest = datasets
+
+    # Rapporteer de scope op basis van het cumulatieve spoor: het enige spoor dat
+    # de instellingsdimensie (Brincode) draagt. Gebeurt vóór het filteren, zodat
+    # de melding "X van Y rijen" het totaal vóór filtering laat zien.
+    _report_institution_scope(data_cumulative, institutions, institution_col)
+
+    if not institutions:
+        return datasets
+
     data_individual = apply_institution_filter(data_individual, institutions, institution_col)
     data_cumulative = apply_institution_filter(data_cumulative, institutions, institution_col)
     return (data_individual, data_cumulative, *rest)
+
+
+def _format_nl_int(n: int) -> str:
+    """Formatteer een geheel getal met een Nederlandse duizendtalscheiding (``.``)."""
+    return f"{n:,}".replace(",", ".")
+
+
+def _report_institution_scope(reference_df, institutions, institution_col) -> None:
+    """Print één regel die samenvat waarvoor deze run rekent.
+
+    De eindgebruiker moet altijd weten of er gefilterd wordt (en op welke
+    instelling(en)) of niet (alle instellingen). De telling is gebaseerd op
+    ``reference_df`` — het cumulatieve spoor, het enige spoor met een
+    instellingskolom.
+
+    Args:
+        reference_df: Het cumulatieve DataFrame (of ``None`` als dat spoor niet
+            geladen is), gebruikt om het totaal en de beschikbare instellingen
+            te tellen.
+        institutions: De actieve filterlijst (leeg = geen filter).
+        institution_col: Naam van de instellingskolom.
+    """
+    has_column = reference_df is not None and institution_col in reference_df.columns
+
+    if not has_column:
+        # Geen spoor met instellingsdimensie geladen (bijv. individueel-only run).
+        # Alleen melden als de gebruiker tóch een filter zette dat hier niet
+        # toegepast kan worden — anders zou de regel ruis zijn.
+        if institutions:
+            gevraagd = ", ".join(str(i) for i in institutions)
+            print(
+                f"Instellingsfilter: '{gevraagd}' opgegeven, maar er is geen spoor met "
+                f"een instellingskolom ('{institution_col}') geladen — filter niet toegepast."
+            )
+        return
+
+    col_as_str = reference_df[institution_col].astype(str)
+    total_rows = len(col_as_str)
+    available = col_as_str.nunique()
+
+    if not institutions:
+        print(
+            f"Instellingsfilter: geen — alle {available} instellingen worden meegenomen "
+            f"({_format_nl_int(total_rows)} rijen). "
+            "Zet 'institution_filter' (of --institution) om je eigen instelling(en) te kiezen."
+        )
+        return
+
+    wanted = [str(i) for i in institutions]
+    kept_rows = int(col_as_str.isin(wanted).sum())
+    print(
+        f"Instellingsfilter actief: {', '.join(wanted)} — {_format_nl_int(kept_rows)} van "
+        f"{_format_nl_int(total_rows)} rijen behouden (uit {available} beschikbare instellingen)."
+    )
 
 
 def get_path_latest(paths, data_option):

--- a/src/studentprognose/data/loader.py
+++ b/src/studentprognose/data/loader.py
@@ -3,6 +3,7 @@ import os
 from studentprognose.utils.weeks import DataOption
 from studentprognose.utils.programme_key import normalize_programme_series
 from studentprognose.data.preprocessing.add_zero_weeks import AddWeeksWherePreapplicantsAreZero
+from studentprognose.data.preprocessing.institution_filter import apply_institution_filter
 
 
 def _normalize_programme_code(df, column):
@@ -60,6 +61,39 @@ def _merge_new_cumulative_data(data_cumulative, src_path, dst_path):
     os.remove(src_path)
 
     return data_cumulative
+
+
+def filter_datasets_by_institution(datasets, configuration):
+    """Scoop de geladen datasets tot de instelling(en) uit ``institution_filter``.
+
+    Toegepast op de sporen die een instellingskolom dragen (het cumulatieve spoor
+    uit de landelijke teldata). Het individuele spoor (eigen aanmeldexport, geen
+    Brincode-kolom) en het label ``student_count`` worden ongemoeid gelaten:
+    :func:`apply_institution_filter` is een no-op wanneer de kolom ontbreekt.
+
+    Een lege ``institution_filter`` (default) laat alle datasets ongewijzigd —
+    dan behoudt de pipeline alle instellingen (backwards compatible).
+
+    Args:
+        datasets: De 5-tuple uit :func:`load_data`
+            ``(individual, cumulative, student_numbers, latest, ensemble)``.
+        configuration: De configuratiedict.
+
+    Returns:
+        De (mogelijk) gefilterde 5-tuple, in dezelfde volgorde.
+    """
+    institutions = configuration.get("institution_filter", [])
+    if not institutions:
+        return datasets
+
+    institution_col = configuration.get("column_roles", {}).get(
+        "institution", "Korte naam instelling"
+    )
+
+    data_individual, data_cumulative, *rest = datasets
+    data_individual = apply_institution_filter(data_individual, institutions, institution_col)
+    data_cumulative = apply_institution_filter(data_cumulative, institutions, institution_col)
+    return (data_individual, data_cumulative, *rest)
 
 
 def get_path_latest(paths, data_option):

--- a/src/studentprognose/data/preprocessing/institution_filter.py
+++ b/src/studentprognose/data/preprocessing/institution_filter.py
@@ -1,0 +1,74 @@
+import warnings
+
+import pandas as pd
+
+
+def apply_institution_filter(
+    df: pd.DataFrame | None,
+    institutions,
+    institution_col: str = "Korte naam instelling",
+) -> pd.DataFrame | None:
+    """Beperk een dataset tot de opgegeven instelling(en).
+
+    De landelijke Studielink-teldata bevat rijen van álle instellingen (elke
+    Brincode staat in de kolom ``Korte naam instelling``). Deze filter scoopt de
+    data tot de instelling(en) die de gebruiker wil voorspellen, zodat de
+    modellen niet op andermans instroom trainen.
+
+    Toegepast op load-tijd (vóór preprocessing en CI-subset), zodat zowel de
+    training als de predictie op de gekozen instelling(en) draaien.
+
+    Args:
+        df: De te filteren dataset, of ``None``. ``None`` wordt ongewijzigd
+            teruggegeven (spoor niet geladen).
+        institutions: Lijst van instellingscodes/-namen om te behouden. Een lege
+            lijst (of ``None``) betekent: geen filter — alle instellingen
+            behouden (het default-gedrag).
+        institution_col: Naam van de instellingskolom. Config-driven via
+            ``column_roles.institution``; valt terug op ``"Korte naam instelling"``.
+
+    Returns:
+        Het gefilterde DataFrame (index gereset), of het originele object wanneer
+        er niet gefilterd wordt.
+
+    Raises:
+        ValueError: Wanneer een niet-lege filter op een aanwezige instellingskolom
+            geen enkele rij overhoudt. Stil doorgaan met een lege trainingsset zou
+            de pipeline verderop met een cryptische fout laten crashen; dit maakt
+            de oorzaak (verkeerde code) direct zichtbaar.
+    """
+    if df is None or not institutions:
+        return df
+
+    # Het spoor draagt geen instellingsdimensie (bijv. het individuele spoor is
+    # de eigen aanmeldexport van één instelling). Niets te filteren — geen fout.
+    if institution_col not in df.columns:
+        return df
+
+    # Vergelijk als string: Brincodes zijn tekstcodes ("00IC"), maar een gebruiker
+    # kan een numerieke code als int in de config zetten. Casten voorkomt een
+    # stille no-match op int-vs-str.
+    wanted = [str(i) for i in institutions]
+    col_as_str = df[institution_col].astype(str)
+
+    present = set(col_as_str.unique())
+    missing = [w for w in wanted if w not in present]
+    if missing:
+        warnings.warn(
+            f"institution_filter: instelling(en) {sorted(missing)} komen niet voor in "
+            f"kolom '{institution_col}'. Beschikbaar: {sorted(present)}. "
+            f"Controleer of de code exact overeenkomt (hoofdlettergevoelig).",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    filtered = df[col_as_str.isin(wanted)]
+
+    if filtered.empty:
+        raise ValueError(
+            f"institution_filter: geen enkele rij komt overeen met de gevraagde "
+            f"instelling(en) {wanted} in kolom '{institution_col}'. "
+            f"Beschikbare instellingen: {sorted(present)}."
+        )
+
+    return filtered.reset_index(drop=True)

--- a/src/studentprognose/main.py
+++ b/src/studentprognose/main.py
@@ -9,7 +9,11 @@ from studentprognose.cli import PipelineConfig, parse_args
 from studentprognose.config import (
     load_configuration, load_defaults_filtering, load_filtering, get_final_academic_week,
 )
-from studentprognose.data.loader import load_data, _normalize_programme_code
+from studentprognose.data.loader import (
+    load_data,
+    filter_datasets_by_institution,
+    _normalize_programme_code,
+)
 from studentprognose.data.prediction_validator import run_pre_prediction_checks
 from studentprognose.data.range_check import (
     detect_data_range_mismatch,
@@ -123,6 +127,12 @@ def main(argv):
     print("Loading configuration...")
     configuration = load_configuration(cfg.configuration_path)
 
+    # De CLI-vlag --institution overschrijft de config-key institution_filter,
+    # analoog aan hoe -f de filtering-file overschrijft. None = geen override,
+    # dan geldt de waarde uit configuration.json (default: [] = alle instellingen).
+    if cfg.institutions is not None:
+        configuration["institution_filter"] = cfg.institutions
+
     if not cfg.noetl:
         from studentprognose.data.validation import validate_raw_data
         from studentprognose.data.etl import run_etl
@@ -135,6 +145,15 @@ def main(argv):
 
     print("Loading data...")
     datasets = load_data(configuration, cfg.data_option)
+    # Scoop op instelling(en) vóór de CI-subset en preprocessing, zodat training
+    # én predictie alleen op de gekozen instelling(en) draaien (issue #200). Een
+    # niet-matchende instelling faalt hard, maar met een nette melding i.p.v. een
+    # kale traceback.
+    try:
+        datasets = filter_datasets_by_institution(datasets, configuration)
+    except ValueError as exc:
+        print(f"\nFout: {exc}")
+        sys.exit(1)
     if cfg.ci_test_n is not None:
         datasets = apply_ci_test_subset(cfg.ci_test_n, *datasets)
 
@@ -504,6 +523,11 @@ def _prepare_in_memory_run(
         data_latest,
         data_weighted_ensemble,
     )
+
+    # Zelfde instellingsfilter als het CLI-pad (issue #200): scoop de in-memory
+    # DataFrames op configuration["institution_filter"] vóór de pipeline-kern.
+    # Leeg (default) = alle instellingen, dus no-op voor bestaande aanroepers.
+    datasets = filter_datasets_by_institution(datasets, configuration)
 
     return cfg, datasets, configuration, filtering, cwd
 

--- a/tests/studentprognose/test_cli.py
+++ b/tests/studentprognose/test_cli.py
@@ -88,6 +88,28 @@ class TestParseArgs:
             parse_args(["prog", "tune", "--tune-target", "ensemble"])
         assert exc.value.code == 2
 
+    def test_institution_defaults_to_none(self):
+        # Geen vlag = None → de config-key institution_filter blijft leidend.
+        cfg = parse_args(["prog", "-w", "10"])
+        assert cfg.institutions is None
+
+    def test_institution_single(self):
+        cfg = parse_args(["prog", "--institution", "21PC"])
+        assert cfg.institutions == ["21PC"]
+
+    def test_institution_multiple(self):
+        cfg = parse_args(["prog", "--institution", "21PC", "00IC"])
+        assert cfg.institutions == ["21PC", "00IC"]
+
+    def test_institution_alias_inst(self):
+        cfg = parse_args(["prog", "-inst", "21PC"])
+        assert cfg.institutions == ["21PC"]
+
+    def test_institution_empty_means_all(self):
+        # Expliciete lege lijst overschrijft de config met "alle instellingen".
+        cfg = parse_args(["prog", "--institution"])
+        assert cfg.institutions == []
+
     def test_default_command_is_none(self):
         cfg = parse_args(["prog"])
         assert cfg.command is None

--- a/tests/studentprognose/test_institution_filter.py
+++ b/tests/studentprognose/test_institution_filter.py
@@ -115,6 +115,67 @@ class TestFilterDatasetsByInstitution:
         assert list(out[1]["waarde"]) == [1, 2]
 
 
+class TestInstitutionScopeReport:
+    """De run moet altijd melden waarvoor er gerekend wordt (issue #200)."""
+
+    def _config(self, institutions):
+        return {
+            "institution_filter": institutions,
+            "column_roles": {"institution": "Korte naam instelling"},
+        }
+
+    def test_reports_no_filter_all_institutions(self, capsys):
+        # 4 rijen, 3 unieke instellingen (21PC, 00IC, 02NR).
+        datasets = (_df(), _df(), None, None, None)
+        filter_datasets_by_institution(datasets, self._config([]))
+        out = capsys.readouterr().out
+        assert "geen" in out
+        assert "alle 3 instellingen" in out
+        assert "4 rijen" in out
+
+    def test_reports_active_filter_with_counts(self, capsys):
+        datasets = (_df(), _df(), None, None, None)
+        filter_datasets_by_institution(datasets, self._config(["21PC"]))
+        out = capsys.readouterr().out
+        assert "actief" in out
+        assert "21PC" in out
+        # 2 van de 4 rijen zijn 21PC.
+        assert "2 van 4 rijen" in out
+
+    def test_reports_multiple_institutions(self, capsys):
+        datasets = (_df(), _df(), None, None, None)
+        filter_datasets_by_institution(datasets, self._config(["21PC", "00IC"]))
+        out = capsys.readouterr().out
+        assert "21PC, 00IC" in out
+        assert "3 van 4 rijen" in out
+
+    def test_reports_when_filter_cannot_apply(self, capsys):
+        # Cumulatief spoor niet geladen én filter gezet: meld dat 't niet toepast.
+        datasets = (_df(), None, None, None, None)
+        filter_datasets_by_institution(datasets, self._config(["21PC"]))
+        out = capsys.readouterr().out
+        assert "niet toegepast" in out
+        assert "21PC" in out
+
+    def test_silent_when_no_filter_and_no_institution_column(self, capsys):
+        # Individueel-only run zonder filter: geen ruis.
+        datasets = (_df(), None, None, None, None)
+        filter_datasets_by_institution(datasets, self._config([]))
+        assert capsys.readouterr().out == ""
+
+    def test_uses_dutch_thousands_separator(self, capsys):
+        big = pd.DataFrame(
+            {
+                "Korte naam instelling": ["21PC"] * 1500 + ["00IC"] * 500,
+                "waarde": range(2000),
+            }
+        )
+        datasets = (None, big, None, None, None)
+        filter_datasets_by_institution(datasets, self._config([]))
+        out = capsys.readouterr().out
+        assert "2.000 rijen" in out
+
+
 class TestConfigValidation:
     def _write(self, tmp_path, value):
         p = tmp_path / "configuration.json"

--- a/tests/studentprognose/test_institution_filter.py
+++ b/tests/studentprognose/test_institution_filter.py
@@ -1,0 +1,150 @@
+"""Tests voor de multi-instelling filter (issue #200).
+
+Bewaakt drie lagen:
+  * ``apply_institution_filter`` — de rij-filter zelf.
+  * ``filter_datasets_by_institution`` — de orchestratie over de dataset-tuple.
+  * ``_validate_institution_filter`` — de config-validatie (via load_configuration).
+"""
+
+import json
+import warnings
+
+import pandas as pd
+import pytest
+
+from studentprognose.config import load_configuration
+from studentprognose.data.loader import filter_datasets_by_institution
+from studentprognose.data.preprocessing.institution_filter import apply_institution_filter
+
+
+def _df():
+    return pd.DataFrame(
+        {
+            "Korte naam instelling": ["21PC", "21PC", "00IC", "02NR"],
+            "Croho groepeernaam": ["A", "B", "A", "C"],
+            "waarde": [1, 2, 3, 4],
+        }
+    )
+
+
+class TestApplyInstitutionFilter:
+    def test_empty_filter_is_noop(self):
+        df = _df()
+        # Leeg = alle instellingen: exact hetzelfde object terug (geen kopie).
+        assert apply_institution_filter(df, []) is df
+
+    def test_none_filter_is_noop(self):
+        df = _df()
+        assert apply_institution_filter(df, None) is df
+
+    def test_none_dataframe_passthrough(self):
+        assert apply_institution_filter(None, ["21PC"]) is None
+
+    def test_single_institution(self):
+        result = apply_institution_filter(_df(), ["21PC"])
+        assert list(result["waarde"]) == [1, 2]
+        # Index is gereset zodat downstream .iloc/.loc voorspelbaar blijft.
+        assert list(result.index) == [0, 1]
+
+    def test_multiple_institutions(self):
+        result = apply_institution_filter(_df(), ["21PC", "00IC"])
+        assert sorted(result["waarde"]) == [1, 2, 3]
+
+    def test_missing_column_passthrough(self):
+        # Een spoor zonder instellingskolom (bijv. individueel) wordt niet geraakt.
+        df = pd.DataFrame({"Croho groepeernaam": ["A"], "waarde": [1]})
+        assert apply_institution_filter(df, ["21PC"]) is df
+
+    def test_int_code_coerced_to_string(self):
+        df = pd.DataFrame({"Korte naam instelling": ["123", "456"], "waarde": [1, 2]})
+        result = apply_institution_filter(df, [123])
+        assert list(result["waarde"]) == [1]
+
+    def test_absent_institution_warns(self):
+        with pytest.warns(UserWarning, match="ZZZZ"):
+            result = apply_institution_filter(_df(), ["21PC", "ZZZZ"])
+        # De aanwezige instelling wordt gewoon behouden.
+        assert list(result["waarde"]) == [1, 2]
+
+    def test_no_match_raises(self):
+        # De missing-warning vuurt vóór de ValueError; hier gaat het om de fout.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(ValueError, match="geen enkele rij"):
+                apply_institution_filter(_df(), ["ONBEKEND"])
+
+    def test_custom_column_name(self):
+        df = pd.DataFrame({"Brincode": ["21PC", "00IC"], "waarde": [1, 2]})
+        result = apply_institution_filter(df, ["00IC"], institution_col="Brincode")
+        assert list(result["waarde"]) == [2]
+
+
+class TestFilterDatasetsByInstitution:
+    def _config(self, institutions):
+        return {
+            "institution_filter": institutions,
+            "column_roles": {"institution": "Korte naam instelling"},
+        }
+
+    def test_empty_filter_returns_unchanged(self):
+        datasets = (_df(), _df(), None, None, None)
+        assert filter_datasets_by_institution(datasets, self._config([])) is datasets
+
+    def test_filters_individual_and_cumulative(self):
+        individual = _df()
+        cumulative = _df()
+        datasets = (individual, cumulative, "sc", "latest", "ens")
+        out = filter_datasets_by_institution(datasets, self._config(["21PC"]))
+        assert list(out[0]["waarde"]) == [1, 2]
+        assert list(out[1]["waarde"]) == [1, 2]
+        # De overige elementen (student_count, latest, ensemble) blijven ongemoeid.
+        assert out[2:] == ("sc", "latest", "ens")
+
+    def test_none_tracks_survive(self):
+        # Individueel spoor niet geladen (None) mag geen crash geven.
+        datasets = (None, _df(), None, None, None)
+        out = filter_datasets_by_institution(datasets, self._config(["00IC"]))
+        assert out[0] is None
+        assert list(out[1]["waarde"]) == [3]
+
+    def test_falls_back_to_default_column(self):
+        # column_roles zonder 'institution' → val terug op "Korte naam instelling".
+        cfg = {"institution_filter": ["21PC"], "column_roles": {}}
+        datasets = (None, _df(), None, None, None)
+        out = filter_datasets_by_institution(datasets, cfg)
+        assert list(out[1]["waarde"]) == [1, 2]
+
+
+class TestConfigValidation:
+    def _write(self, tmp_path, value):
+        p = tmp_path / "configuration.json"
+        p.write_text(json.dumps({"institution_filter": value}), encoding="utf-8")
+        return str(p)
+
+    def test_valid_string_list(self, tmp_path):
+        cfg = load_configuration(self._write(tmp_path, ["21PC", "00IC"]))
+        assert cfg["institution_filter"] == ["21PC", "00IC"]
+
+    def test_valid_int_and_str_mixed(self, tmp_path):
+        cfg = load_configuration(self._write(tmp_path, [123, "21PC"]))
+        assert cfg["institution_filter"] == [123, "21PC"]
+
+    def test_default_is_empty_list(self):
+        # De packaged/repo-config levert een lege lijst → alle instellingen.
+        cfg = load_configuration("configuration/configuration.json")
+        assert cfg["institution_filter"] == []
+
+    def test_rejects_non_list(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(self._write(tmp_path, "21PC"))
+        assert exc.value.code == 1
+
+    def test_rejects_non_scalar_element(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(self._write(tmp_path, [1.5]))
+        assert exc.value.code == 1
+
+    def test_rejects_bool_element(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            load_configuration(self._write(tmp_path, [True]))
+        assert exc.value.code == 1


### PR DESCRIPTION
Sluit #200.

## Probleem
De landelijke Studielink-teldata bevat rijen van **álle** instellingen (elke Brincode in `Korte naam instelling` — 52 in de demodata). Er was geen filter waarmee een gebruiker de eigen instelling(en) kon kiezen: het cumulatieve spoor traint/voorspelt impliciet over alle instellingen tegelijk (`institution` zit niet in `TRANSFORM_GROUP_COLS` en de kolom wordt vóór de pivot weggegooid). Het bestaande `-f`-mechanisme filtert alleen op programme/herkomst/examentype.

## Oplossing
Een nieuwe config-optie `institution_filter` (+ CLI-override `--institution`) die de teldata op load-tijd scoopt tot één of meer instellingen, vóór preprocessing — zodat zowel training als predictie op de gekozen instelling(en) draaien.

- **Config-driven:** filtert op de kolom uit `column_roles.institution` (default `Korte naam instelling`).
- **Default = alle instellingen** (`institution_filter: []`) → backwards compatible, huidig gedrag ongewijzigd.
- **Alleen sporen met een instellingskolom** worden gefilterd (cumulatief). Het individuele spoor (eigen aanmeldexport) en `student_count` blijven ongemoeid.
- **Geen stille fouten:** waarschuwing bij een deels-ontbrekende code, harde `ValueError` (nette CLI-melding, exit 1) bij een 0-match.
- **Zichtbare scope-melding bij elke run:** de tool print altijd één regel met waarvoor er gerekend wordt — of er nu wél of níét gefilterd wordt — zodat een gebruiker nooit ongemerkt over alle (of de verkeerde) instellingen rekent. Zowel het CLI-pad als het in-memory API-pad zijn gedekt.
  ```
  # Met filter
  Instellingsfilter actief: 21PC — 9.650 van 211.183 rijen behouden (uit 52 beschikbare instellingen).

  # Zonder filter
  Instellingsfilter: geen — alle 52 instellingen worden meegenomen (211.183 rijen). Zet 'institution_filter' (of --institution) om je eigen instelling(en) te kiezen.
  ```
- Werkt op zowel het **CLI-pad** als het **in-memory API-pad**.

## Acceptatiecriteria (#200)
- [x] Config-optie om op één of meerdere instellingen te filteren (`institution_filter` + `--institution`)
- [x] Default-gedrag vastgelegd en gedocumenteerd (leeg = alle instellingen)
- [x] Gebruiker wordt bij elke run geïnformeerd over de scope (gefilterd én ongefilterd)
- [x] Getest met data van meerdere instellingen (unit + smoke stap [9] + end-to-end: 52 → 1 instelling, 211.183 → 9.650 rijen)

## Tests
- `test_institution_filter.py` — filterlogica, orchestratie over de dataset-tuple, config-validatie, en de scope-melding (gefilterd / ongefilterd / niet-toepasbaar / Nederlandse duizendtalscheiding).
- `test_cli.py` — `--institution` parsing + default.
- `scripts/test_package.sh` — stap **[9]**: filter op de 52-instelling demodata (exit 0 + output), assert nu ook de scope-melding (met én zonder filter), onbekende instelling faalt hard.
- Volledige suite: **520 passed**, ruff clean, `mkdocs build --strict` exit 0.

## Docs (per CLAUDE.md docs-regel)
- `docs/configuratie.md` — `institution_filter` + `column_roles.institution`
- `docs/aan-de-slag.md` — `--institution`-vlag + waarschuwing dat je standaard over álle instellingen rekent + note met de scope-melding
- `docs/je-data-voorbereiden.md` — instellingskolom / Brincode + welke sporen gefilterd worden
- `README.md` — featurevermelding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
