### PR TITLE
docs: beginner-vriendelijke documentatie-overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 > [!NOTE]
 > Dit model is oorspronkelijk ontwikkeld door **Radboud Universiteit** en vervolgens samen met CEDA open source gemaakt zodat andere instellingen er ook van kunnen profiteren. Lees meer in het [VOX-artikel](https://www.voxweb.nl/nieuws/de-universiteit-heeft-nu-haar-eigen-glazen-bol-nieuw-model-voorspelt-toekomstige-instroom-van-studenten).
 
+> [!TIP]
+> **Zie het in actie:** bekijk een [voorbeeld-dashboard en een uitgewerkte prognose](https://cedanl.github.io/studentprognose/) op de documentatiesite — van vooraanmelders op een peilmoment naar het verwachte aantal inschrijvingen, met demodata.
+
 ---
 
 ## 📦 Aan de slag
@@ -36,7 +39,7 @@ Installeer met [uv](https://docs.astral.sh/uv/):
 uv tool install studentprognose
 ```
 
-> Heb je uv nog niet? Eenmalig installeren met `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) of `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows). Voor pip-instructies, zie de [documentatie](https://cedanl.github.io/studentprognose/aan-de-slag/#andere-installatiemethoden).
+> Heb je uv nog niet? Eenmalig installeren met `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux) of `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows). Voor pip-instructies, zie de [documentatie](https://cedanl.github.io/studentprognose/installeren/).
 
 Na installatie:
 
@@ -103,14 +106,11 @@ uv run studentprognose -w 6 -y 2020
 
 ---
 
-## 🗃️ Studielink Data
+## ✨ Gebruik
 
 > [!IMPORTANT]
-> Dit model werkt met **Studielink-telbestanden**. Je hebt deze data nodig om voorspellingen te maken voor jouw instelling. Demodata is meegeleverd zodat je het model eerst kunt uitproberen.
+> Dit model werkt met **Studielink-telbestanden**. Je hebt deze data nodig om voorspellingen te maken voor jouw instelling; de meegeleverde demodata laat je het model eerst uitproberen. Zie [Je data voorbereiden](https://cedanl.github.io/studentprognose/je-data-voorbereiden/).
 
----
-
-## ✨ Gebruik
 
 ```bash
 studentprognose -w 6 -y 2024                  # specifieke week en jaar

--- a/docs/aan-de-slag.md
+++ b/docs/aan-de-slag.md
@@ -1,563 +1,124 @@
-# Aan de slag
+# Draaien & CLI
 
-## Voordat je begint
+Deze pagina legt uit wat de CLI-vlaggen doen en hoe je gerichte runs draait. Wil je eerst gewoon íéts zien draaien? Doe de [Snelstart](snelstart.md) met demodata.
 
-Je hebt **Python 3.12** nodig. Controleer je versie:
+!!! abstract "In het kort"
+    - `studentprognose` (zonder vlaggen) draait beide sporen op de laatste beschikbare week/jaar.
+    - `-w` = **peilweek**, `-y` = **collegejaar**, `-d` = welk(e) **spoor/sporen**.
+    - Output staat in `data/output/`. Zie [Output lezen](output-begrijpen.md).
 
-```bash
-python --version
-```
+## Projectmap aanmaken
 
-!!! warning "Alleen Python 3.12 wordt ondersteund"
-    De pipeline wordt op één Python-versie ontwikkeld en getest. Nieuwere minor-versies (3.13, 3.14) zijn bewust uitgesloten — onder andere omdat `statsforecast` voor sommige minors nog geen Windows-wheels publiceert, wat tot een C-compiler-error tijdens `uv sync` leidt. Pin je Python-versie expliciet op 3.12:
-
-    ```bash
-    uv python pin 3.12
-    ```
-
-    `uv` downloadt zelf de juiste versie als die nog niet op je systeem staat — je hoeft niks van python.org te halen.
-
-??? tip "Python niet gevonden of te oud?"
-
-    Als je `python: command not found` ziet, of een versie lager dan 3.12:
-
-    - **Windows**: Download Python via [python.org](https://www.python.org/downloads/). Vink bij installatie **"Add python.exe to PATH"** aan.
-    - **macOS**: Installeer via [python.org](https://www.python.org/downloads/) of met Homebrew: `brew install python@3.12`
-    - **Linux**: Gebruik je pakketbeheerder, bijv. `sudo apt install python3.12` (Ubuntu/Debian) of `sudo dnf install python3.12` (Fedora).
-
-    Op sommige systemen heet het commando `python3` in plaats van `python`. Probeer `python3 --version` als `python --version` niet werkt.
-
-## Installatie
-
-We gebruiken [uv](https://docs.astral.sh/uv/) — een snelle Python-pakketbeheerder die virtual environments automatisch afhandelt.
-
-**Stap 1 — Installeer uv** (eenmalig):
-
-=== "macOS / Linux"
-
-    ```bash
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    ```
-
-=== "Windows"
-
-    ```powershell
-    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-    ```
-
-**Stap 2 — Installeer studentprognose:**
+Draai eenmalig in je werkmap:
 
 ```bash
-uv tool install studentprognose
-```
-
-**Updaten** naar een nieuwere versie:
-
-```bash
-uv tool upgrade studentprognose
-```
-
-## Eerste keer: mapstructuur aanmaken
-
-Maak een werkmap aan voor je prognoseproject en draai daar `init`:
-
-```bash
-mkdir mijn-prognose
-cd mijn-prognose
 studentprognose init
 ```
 
-Dit schrijft:
+Dit schrijft de configuratie en mapstructuur:
 
-- `configuration/configuration.json` — aanpasbare configuratie met alle standaardwaarden
-- `configuration/filtering/base.json` — lege filtering (geen opleiding- of herkomstfilter)
+- `configuration/configuration.json` — configuratie met alle standaardwaarden
+- `configuration/filtering/base.json` — leeg filter (geen opleiding-/herkomstfilter)
 - `data/input_raw/telbestanden/` — map voor je Studielink-telbestanden
 - `data/input_raw/README.md` — beschrijving van welke bestanden hier horen
-- `data/output/` — map waarin de wekelijkse outputs én de doorlopende audittrail (`_totaal_*.xlsx`) worden opgeslagen
+- `data/output/` — map voor de output én de doorlopende audittrail (`_totaal_*.xlsx`)
 
-Bestaat een bestand al, dan wordt het overgeslagen. Je kunt `init` dus veilig opnieuw uitvoeren.
+Bestaat een bestand al, dan wordt het overgeslagen; je kunt `init` veilig opnieuw draaien. Eigen data klaarzetten doe je op [Je data klaarzetten](je-data-voorbereiden.md).
 
-## Je data neerzetten
+## Wat voorspelt `-w 16 -y 2024`?
 
-Zet je inputbestanden in de juiste mappen voordat je de pipeline start:
+`-w` is de **peilweek** (kalenderweek 1–52) en `-y` het **collegejaar** waarvoor je een prognose wilt. `-w 16 -y 2024` betekent: *"gebruik alle vooraanmelddata tot en met week 16 van collegejaar 2024 en geef me het verwachte aantal inschrijvingen voor datzelfde jaar"*.
 
-```text
-data/
-├── input/                          ← verwerkte inputbestanden (na ETL)
-│   ├── vooraanmeldingen_cumulatief.csv
-│   ├── vooraanmeldingen_individueel.csv
-│   ├── student_count_first-years.xlsx
-│   └── student_volume.xlsx
-└── input_raw/                      ← ruwe bronbestanden (NIET nodig met --noetl)
-    ├── telbestanden/               ← Studielink telbestanden
-    │   ├── telbestandY2024W01.csv
-    │   └── ...
-    ├── individuele_aanmelddata.csv ← Osiris/Usis export
-    └── oktober_bestand.xlsx        ← telbestand studenten
-```
-
-Zie [Je data voorbereiden](je-data-voorbereiden.md) voor kolomspecificaties per bestand.
-
-## ETL overslaan met `--noetl`
-
-**Heb je al verwerkte bestanden in `data/input/`** (bijv. uit een eigen ETL-proces, een eerdere run, of aangeleverd door een collega)? Dan hoef je de ruwe bronbestanden in `data/input_raw/` helemaal niet neer te zetten. Sla de ETL én de bijbehorende validatie over met `--noetl`:
-
-```bash
-studentprognose --noetl
-```
-
-Welke bestanden je dan precies in `data/input/` nodig hebt — en in welk formaat — lees je op [ETL overslaan](je-data-voorbereiden.md#etl-overslaan).
-
-!!! warning "Wanneer je `--noetl` níét moet gebruiken"
-    Heb je alleen ruwe bronbestanden (Studielink-telbestanden, Osiris/Usis-export, telbestand studenten)? Laat `--noetl` dan weg, zodat de ingebouwde ETL de verwerkte bestanden voor je aanmaakt.
-
-## Wat voorspelt `-w 16 -y 2025`?
-
-Voor `studentprognose` is `-w` de **peilweek** (kalenderweek 1–52) en `-y` het **collegejaar** waarvoor je een prognose wilt. Met `-w 16 -y 2025` zeg je dus: *"gebruik alle vooraanmelddata tot en met week 16 van collegejaar 2025 en geef me een prognose voor het uiteindelijke aantal inschrijvingen voor datzelfde collegejaar"*.
-
-!!! example "Voorbeeld-run · B Bedrijfskunde · NL (demodata)"
-    **178** vooraanmelders @ wk 16 (peilmoment) &nbsp;→&nbsp; **520** verwacht @ wk 38 &nbsp;→&nbsp; **400** ingeschreven (77% yield)
-
-=== "Week voor week"
+!!! example "Voorbeeld · B Bedrijfskunde · NL (demodata)"
+    **178** vooraanmelders @ wk 16 &nbsp;→&nbsp; **520** verwacht @ wk 38 &nbsp;→&nbsp; **400** ingeschreven (77% yield)
 
     <iframe src="../assets/plots/whatif_timeline.html" width="100%" height="540" frameborder="0" style="border-radius: 8px;"></iframe>
 
-    De blauwe lijn toont de geobserveerde cumulatieve vooraanmelders tot peilmoment (wk 16). De oranje gestippelde lijn extrapoleert naar week 38 — met scherp knikpunt rond de 1-mei-deadline en een late-zomer-naloop. De gearceerde band groeit met de horizon: ±12 bij peilmoment, ±34 bij wk 38.
-
-=== "In één oogopslag"
-
-    <iframe src="../assets/plots/whatif_slope.html" width="100%" height="420" frameborder="0" style="border-radius: 8px;"></iframe>
-
-    Drie kerngetallen op één schaal: peilmoment → SARIMA-extrapolatie naar wk 38 → verwachte inschrijvingen. De badges tussen de punten kwantificeren de overgangen — eerst de groei (×2.92 in vooraanmelders), daarna de yield (77% conversie naar ingeschreven).
+    De blauwe lijn toont de geobserveerde cumulatieve vooraanmelders tot peilmoment (wk 16); de oranje lijn extrapoleert naar week 38. De band groeit met de horizon: ±12 bij peilmoment, ±34 bij wk 38.
 
 !!! info "Waarom elke week opnieuw draaien?"
-    Een prognose op één peilweek geeft je het beeld van *dat* moment. Door de pipeline wekelijks te draaien volg je de trends en fluctuaties in vooraanmeldingen mee — bijvoorbeeld het knikpunt rond de 1-mei-deadline of een achterblijvende naloop in de zomer. Zo zie je vroege signalen om je capaciteits- en marketingbeslissingen tijdig bij te sturen, in plaats van pas na het seizoen één eindprognose te hebben.
-
-!!! tip "Andere peilweek of collegejaar?"
-    Vervang `-w 16` door je eigen peilweek (1–52) en `-y 2025` door het collegejaar dat je wilt voorspellen. De pipeline pakt automatisch de data tot en met die week om het uiteindelijke aantal inschrijvingen voor datzelfde collegejaar te schatten.
+    Eén peilweek geeft het beeld van *dat* moment. Draai je wekelijks, dan volg je de trends mee — het knikpunt rond de 1-mei-deadline, een achterblijvende zomernaloop — en zie je vroege signalen om capaciteit en marketing tijdig bij te sturen.
 
 ## Eerste run
 
-Als je `-w` en `-y` weglaat, kiest de pipeline automatisch de **laatste beschikbare week en het laatste jaar uit je inputdata**. Je ziet dan een melding zoals:
-
-```
-Geen week/jaar opgegeven — automatisch gekozen op basis van beschikbare data: jaar 2024, week 38.
-Geef -w en -y mee om een andere combinatie te gebruiken.
-```
-
-Dit voorkomt dat de tool faalt omdat de huidige systeemweek/-jaar nog niet in je trainingsdata zit.
+Laat je `-w` en `-y` weg, dan kiest de pipeline automatisch de **laatste beschikbare week en jaar uit je inputdata**. Dat voorkomt dat de tool faalt omdat de huidige systeemweek nog niet in je trainingsdata zit.
 
 ```bash
-# Beide sporen + ensemble (standaard) — automatisch laatste beschikbare week/jaar
-studentprognose
-
-# Specifieke week en jaar
-studentprognose -w 10 -y 2025
-
-# Alleen cumulatief spoor (geen individuele data nodig)
-studentprognose -d c
-
-# ETL overslaan (data al eerder verwerkt)
-studentprognose --noetl
+studentprognose                    # beide sporen, laatste week/jaar (standaard)
+studentprognose -w 10 -y 2024      # specifieke week en jaar
+studentprognose -d c               # alleen cumulatief spoor
+studentprognose --noetl            # data al eerder verwerkt — sla ETL over
 ```
-
-De output verschijnt in `data/output/`.
 
 ## CLI-referentie
 
-Alle subcommando's en vlaggen zijn te bekijken via:
-
-```bash
-studentprognose --help
-```
+Alle opties: `studentprognose --help`.
 
 ### Subcommando's
 
 | Commando | Beschrijving |
 |----------|-------------|
 | `init` | Maak een nieuwe projectmap aan met configuratie en mappenstructuur |
-| `benchmark` | Vergelijk alternatieve ML-modellen (`-d c` of `-d i` verplicht, zie [Benchmarks](methodologie/benchmarks.md)) |
-| `tune` | Stem het cumulatieve spoor af — regressor (stap 2) en/of SARIMA (stap 1) via `--tune-target` (`-d c` verplicht, zie [Hyperparameter tuning](#hyperparameter-tuning)) |
+| `benchmark` | Vergelijk alternatieve modellen (`-d c` of `-d i` verplicht, zie [Benchmarks](methodologie/benchmarks.md)) |
+| `tune` | Stem het cumulatieve spoor af (`-d c` verplicht, zie [Hyperparameter tuning](gevorderd-gebruik.md#hyperparameter-tuning)) |
 
 ### Vlaggen
 
 | Vlag | Waarden | Standaard | Beschrijving |
 |------|---------|-----------|-------------|
 | `-w` | weeknummer(s) | laatste week in data | Voorspelweek(en), bijv. `-w 10` of `-w 8:12` |
-| `-y` | jaar(en) | laatste jaar in data | Voorspeljaar(en), bijv. `-y 2025` of `-y 2024 2025` |
+| `-y` | jaar(en) | laatste jaar in data | Voorspeljaar(en), bijv. `-y 2024` of `-y 2023 2024` |
 | `-d` | `b` / `c` / `i` | `b` | Dataset: `both`, `cumulative`, `individual` |
-| `-sy` | `f` / `h` / `v` | `f` | Studentjaar: `first-years` (standaard), `higher-years`, `volume` |
+| `-sy` | `f` / `h` / `v` | `f` | Studentjaar: `first-years`, `higher-years`, `volume` |
 | `-c` | pad | `configuration/configuration.json` | Configuratiebestand |
 | `-f` | pad | `configuration/filtering/base.json` | Filterbestand |
-| `--institution` | instellingscode(s) | alle instellingen | Beperk de teldata tot één of meer instellingen (Brincode), bijv. `--institution 21PC` |
+| `--institution` | instellingscode(s) | alle instellingen | Beperk de teldata tot één of meer instellingen — zie [hieronder](#-institution) |
 | `-sk` | getal | `0` | Skip N jaren (backtesting) |
 | `--noetl` | — | uit | Sla ETL én validatie over |
 | `--yes` | — | uit | Sla validatieprompts over (voor CI/CD) |
-| `--dashboard` | — | uit | Genereer interactieve Plotly-dashboards (`data/output/visualisations/`) |
-| `--tune-target` | `regressor` / `sarima` / `both` | `regressor` | Welke trap het `tune`-commando afstemt |
+| `--dashboard` | — | uit | Genereer interactieve dashboards (`data/output/visualisations/`) |
+| `--tune-target` | `regressor` / `sarima` / `both` | `regressor` | Welke trap `tune` afstemt |
 | `--ci test N` | getal | — | Testmodus: beperkt tot N opleidingen |
 
-Weekbereiken zijn mogelijk: `-w 8:12` is gelijk aan `-w 8 9 10 11 12`.
+Weekbereiken mogen: `-w 8:12` = `-w 8 9 10 11 12`.
 
 !!! note "Eerstejaars als focus"
-    De tool draait standaard op `-sy f` (eerstejaars). De modus `-sy v` (volume) is een vervolgstap — gebruik die pas als je eerstejaarsvoorspelling op orde is.
+    De tool draait standaard op `-sy f` (eerstejaars). Volume (`-sy v`) is een vervolgstap — gebruik die pas als je eerstejaarsvoorspelling op orde is.
 
 ### `--institution`
 
 De landelijke Studielink-teldata bevat rijen van álle instellingen. Met `--institution` scoop je de run op je eigen instelling(en):
 
 ```bash
-# Alleen instelling 21PC
-studentprognose -w 10 -y 2025 -d cumulative --institution 21PC
-
-# Meerdere instellingen
-studentprognose -w 10 -y 2025 -d cumulative --institution 21PC 00IC
+studentprognose -d c --institution 21PC          # één instelling
+studentprognose -d c --institution 21PC 00IC      # meerdere
 ```
 
-De vlag overschrijft de config-key [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen); laat je hem weg, dan geldt de configuratiewaarde (standaard: alle instellingen). Een onbekende instellingscode stopt de run met een duidelijke foutmelding in plaats van stil een lege dataset te verwerken. Zet je in je config bijvoorbeeld je eigen Brincode vast, dan hoef je de vlag niet elke keer mee te geven.
+De vlag overschrijft de config-key [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen); laat je hem weg, dan geldt de configuratiewaarde. Een onbekende code stopt de run met een duidelijke fout. Zet je je eigen Brincode vast in de config, dan hoef je de vlag niet elke keer mee te geven.
 
 !!! warning "Standaard reken je over álle instellingen"
-    Zonder `--institution` én zonder `institution_filter` in je config traint en voorspelt het cumulatieve spoor over de héle landelijke teldata (alle instellingen tegelijk). Dat is het backwards-compatibele default-gedrag, maar zelden wat je wilt als je één instelling voorspelt. Zet daarom je eigen Brincode vast in de config.
+    Zonder filter rekent het cumulatieve spoor over de héle landelijke teldata — zelden wat je wilt. De run print bij elke start één regel met de scope, zodat je nooit ongemerkt over de verkeerde (of alle) instellingen rekent. Zet daarom je eigen Brincode vast via [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen).
 
-!!! note "De run meldt altijd de scope"
-    Bij elke run print de tool één regel met de instellings-scope, zodat je nooit ongemerkt over de verkeerde (of alle) instellingen rekent:
+## De tool vanuit Python of de cloud aansturen
 
-    ```
-    # Met filter
-    Instellingsfilter actief: 21PC — 9.650 van 211.183 rijen behouden (uit 52 beschikbare instellingen).
-
-    # Zonder filter
-    Instellingsfilter: geen — alle 52 instellingen worden meegenomen (211.183 rijen). Zet 'institution_filter' (of --institution) om je eigen instelling(en) te kiezen.
-    ```
-
-## Gebruik als Python-package
-
-Naast de CLI kun je `studentprognose` ook direct vanuit Python-scripts importeren. Dit is handig voor geautomatiseerde pipelines, notebooks, of cloudworkflows waarbij de data al in-memory beschikbaar is.
-
-!!! tip "Uitvoerbaar voorbeeld — implementatienotebook"
-    Voor een direct inpasbaar startpunt voor MS Fabric, Databricks of Azure: zie [`notebooks/implementatie.ipynb`](https://github.com/cedanl/studentprognose/blob/main/notebooks/implementatie.ipynb). Vereist alleen `pip install studentprognose` — geen repo-clone nodig.
-
-### Beschikbare bouwstenen
-
-```python
-from studentprognose import (
-    load_configuration,            # laad configuration.json (of package defaults)
-    load_filtering,                # laad filtering JSON (of package defaults)
-    load_data,                     # laad data vanaf schijf als DataFrames
-    run_pipeline_cli,              # volledige CLI-pipeline (accepteert argv-lijst)
-    run_pipeline_from_dataframes,  # pipeline met DataFrames in-memory
-    build_dashboard_from_dataframes,  # interactieve HTML-dashboards uit DataFrames
-    evaluate_predictions,          # output → scalaire evaluatiemetrieken per model
-    pivot_metrics,                 # metrieken → model × jaar/week-matrix (backtest)
-    to_mlflow_metrics,             # metrieken afvlakken voor mlflow.log_metrics (Fabric)
-    PipelineConfig,                # configuratie-dataclass voor de pipeline
-    DataOption,                    # enum: INDIVIDUAL / CUMULATIVE / BOTH_DATASETS
-    StudentYearPrediction,         # enum: FIRST_YEARS / VOLUME
-)
-```
-
-!!! tip "Het model evalueren"
-    `evaluate_predictions` zet de pipeline-output om in scalaire metrieken (MAE, MAPE,
-    WAPE, RMSE, bias, R²) per model; `pivot_metrics` vat een backtest over meerdere jaren
-    samen tot een model × jaar-matrix; en `to_mlflow_metrics` levert ze klaar voor MLflow
-    in MS Fabric / Databricks. Zie [Output begrijpen → Het model evalueren](output-begrijpen.md#het-model-evalueren-evaluate_predictions).
-
-### Minimaal werkend voorbeeld (bestandsgebaseerd)
-
-```python
-from studentprognose import run_pipeline_cli
-
-# Zelfde als de CLI — start de volledige pipeline inclusief ETL
-run_pipeline_cli(["studentprognose", "-d", "c", "-y", "2025", "-w", "10"])
-
-# Of sla ETL over als de data al verwerkt is
-run_pipeline_cli(["studentprognose", "--noetl", "-d", "c", "-y", "2025", "-w", "10"])
-```
-
-### Cloud-gebruik (data al in-memory)
-
-Gebruik `run_pipeline_from_dataframes` als je de data al geladen hebt, bijvoorbeeld vanuit Azure Blob Storage of Amazon S3. De ETL-stap wordt volledig overgeslagen.
-
-```python
-import pandas as pd
-from studentprognose import run_pipeline_from_dataframes, DataOption
-
-# Laad data uit cloud-opslag (voorbeeld met Azure SDK)
-# from azure.storage.blob import BlobServiceClient
-# blob_data = blob_client.download_blob().readall()
-# df_cum = pd.read_csv(io.BytesIO(blob_data), sep=";", skiprows=[1])
-
-# Of lokaal voor testen
-df_cum = pd.read_csv("vooraanmeldingen_cumulatief.csv", sep=";", skiprows=[1])
-
-result = run_pipeline_from_dataframes(
-    year=2025,
-    week=10,
-    data_cumulative=df_cum,
-    dataset=DataOption.CUMULATIVE,
-    save_output=False,  # geen lokale uitvoerbestanden aanmaken (ook geen tussenresultaat)
-)
-
-if result is not None:
-    print(result[["Croho groepeernaam", "Weighted_ensemble_prediction"]].head())
-```
-
-De functie accepteert ook een eigen configuratiedict, zodat je geen bestandssysteem nodig hebt:
-
-```python
-from studentprognose import run_pipeline_from_dataframes, DataOption
-from studentprognose.config import load_defaults
-
-# Begin met package-defaults en pas aan
-config = load_defaults()
-config["numerus_fixus"] = ["B Geneeskunde", "B Tandheelkunde"]
-
-result = run_pipeline_from_dataframes(
-    year=2025,
-    week=10,
-    data_cumulative=df_cum,
-    configuration=config,
-    dataset=DataOption.CUMULATIVE,
-)
-```
-
-!!! warning "`year`/`week` moeten binnen je trainingsdata vallen"
-    `run_pipeline_from_dataframes` controleert — net als de CLI — of `year` en `week`
-    voorkomen in de meegegeven DataFrames. Valt een van beide buiten bereik, dan krijg je
-    een heldere `ValueError` met de wél beschikbare range, in plaats van een stille `None`
-    of een onverwachte kernel-crash in een notebook.
-
-    ```python
-    # Stel: je data loopt t/m 2025
-    run_pipeline_from_dataframes(
-        year=2030,            # buiten bereik
-        week=10,
-        data_cumulative=df_cum,
-        dataset=DataOption.CUMULATIVE,
-    )
-    # ValueError: year=2030 valt buiten de beschikbare trainingsdata.
-    #   Beschikbare data: jaren 2018-2025, weken 1-52.
-    #   Pas year/week aan binnen deze range, of voeg trainingsdata toe.
-    ```
-
-    Pas `year`/`week` aan binnen de range, of voeg aanvullende trainingsdata toe.
-
-### Dashboards genereren vanuit DataFrames
-
-De interactieve Plotly-dashboards (die de CLI met `--dashboard` maakt) kun je vanuit een
-notebook of cloud-run genereren met `build_dashboard_from_dataframes`. Dit is een
-**aparte functie** die je ná (of in plaats van) `run_pipeline_from_dataframes` aanroept,
-met dezelfde in-memory DataFrames. Ze draait de pipeline (zonder iets naar schijf te
-schrijven) en schrijft daarna de dashboards weg naar `<cwd>/data/output/visualisations/`.
-
-```python
-from studentprognose import build_dashboard_from_dataframes, DataOption
-
-output_dir = build_dashboard_from_dataframes(
-    year=2025,
-    week=10,
-    data_cumulative=df_cum,
-    data_student_numbers=sc,   # nodig voor de realisatie-/conversiegrafieken
-    dataset=DataOption.CUMULATIVE,
-    configuration=config,
-)
-print(f"Dashboards geschreven naar {output_dir}")
-# -> <cwd>/data/output/visualisations/{individual,cumulative,final}/dashboard.html
-```
-
-!!! tip "Losse functie, geen extra parameter"
-    Het dashboard is bewust een aparte functie en géén parameter op
-    `run_pipeline_from_dataframes`: zo blijft de voorspelfunctie ongewijzigd en is de
-    dashboard-stap los te draaien en te testen. Gebruik `cwd` om de uitvoermap te sturen.
-    De `year`/`week`-rangecontrole is identiek aan die van `run_pipeline_from_dataframes`;
-    komt geen enkele rij door de filters, dan krijg je een heldere `ValueError` in plaats
-    van een leeg dashboard.
-
-## Hyperparameter tuning
-
-Het cumulatieve spoor is twee-traps en je kunt **beide trappen** afstemmen op je
-eigen data:
-
-| Trap | Wat | Wat tuning kiest | Vastgelegd in |
-|------|-----|------------------|---------------|
-| **Stap 1 — SARIMA** | extrapoleert de vooraanmeldcurve | ARIMA-ordes `(p,d,q)(P,D,Q,s)` | `forecaster_params.sarima` |
-| **Stap 2 — regressor** | vertaalt de curve naar inschrijvingen | hyperparameters (default XGBoost) | `regressor_params.<naam>` |
-
-Beide gebruiken een **tijd-bewuste** zoektocht (geen random k-fold — dat lekt
-toekomst) met dezelfde MAPE-metriek als de [benchmark](methodologie/benchmarks.md),
-en laten het operationele voorspelpad standaard onaangeroerd. Zie
-[XGBoost → Hyperparameter tuning](methodologie/xgboost.md#hyperparameter-tuning)
-(regressor) en [SARIMA → Orde-selectie](methodologie/sarima.md#orde-selectie-tuning)
-voor de methodologie.
-
-### Via de CLI — zoeken en vastleggen
-
-```bash
-studentprognose tune -d c -w 12                    # default: regressor (stap 2)
-studentprognose tune -d c -w 12 --tune-target sarima   # alleen SARIMA (stap 1)
-studentprognose tune -d c -w 12 --tune-target both     # beide trappen
-```
-
-Dit draait de zoektocht op je geladen data, print per trap een overzicht van alle
-geteste sets met hun MAPE (de best presterende set gemarkeerd met `✓`), en geeft
-een kant-en-klaar config-snippet terug. Plak dat snippet in `configuration.json`
-om de gevonden waarden vast te leggen (zie
-[Configuratie → vastleggen](configuratie.md#waarden-vastleggen)).
-Vastgelegde waarden zijn reproduceerbaar: ze worden bij elke run gebruikt zonder
-opnieuw te tunen.
-
-### Via de Python-API — tunen en voorspellen in één keer
-
-`run_pipeline_from_dataframes` heeft een `tune`-parameter (standaard `False`) waarmee
-je kiest **welke trap(pen)** getuned worden:
-
-```python
-result = run_pipeline_from_dataframes(
-    year=2025,
-    week=10,
-    data_cumulative=df_cum,
-    data_student_numbers=data_studentcount,
-    dataset=DataOption.CUMULATIVE,
-    tune="both",  # tune stap 1 (SARIMA) én stap 2 (regressor), daarna voorspellen
-)
-```
-
-De ondersteunde waarden:
-
-| `tune=` | Wat wordt getuned |
-|---------|-------------------|
-| `False` *(default)* | niets — gebruikt vastgelegde/default-waarden |
-| `True` of `"regressor"` | alleen de regressor (stap 2) |
-| `"sarima"` | alleen SARIMA-ordes (stap 1) |
-| `"both"` | beide trappen, elk apart gelogd |
-| `{"regressor": {...}, "sarima": {...}}` | beide/één trap met **eigen zoekruimte** (waarde weglaten of `None` = ingebouwde grid) |
-
-Elke gekozen trap draait de zoektocht éénmaal, voorspelt met de beste waarden en
-koppelt ze terug in de configuratie zodat je ze kunt vastleggen. Het overzicht (met
-`✓` op de winnaar) gaat naar de console; de functie **retourneert het
-voorspellings-DataFrame**, niet het tuning-resultaat.
-
-Bij `tune="both"` zie je twee aparte tabellen — één per trap, elk met een eigen `✓`:
-
-```
-           MAPE   Folds  Parameters
-  ─────────────────────────────────
-  ✓      0.0912       6  {"order": [1, 1, 1], "seasonal_order": [1, 1, 0, 52]}
-         0.1041       6  {"order": [1, 0, 1], "seasonal_order": [1, 1, 1, 52]}
-
-Beste parameters voor 'sarima' (MAPE=0.0912, 6 kandidaten):
-Plak dit in je configuration.json om de ordes vast te leggen:
-{ "model_config": { "forecaster_params": { "sarima": { ... } } } }
-
-           MAPE   Folds  Parameters
-  ─────────────────────────────────
-  ✓      0.1424      12  {"learning_rate": 0.25, "n_estimators": 200, "max_depth": 5}
-         0.1487      12  {"learning_rate": 0.1, "n_estimators": 200, "max_depth": 3}
-
-Beste parameters voor 'xgboost' (MAPE=0.1424, 12 kandidaten):
-Plak dit in je configuration.json om de parameters vast te leggen:
-{ "model_config": { "regressor_params": { "xgboost": { ... } } } }
-```
-
-!!! note "Tuning is opt-in"
-    Standaard (`tune=False`) gebruikt de pipeline de waarden uit
-    `model_config.regressor_params` / `forecaster_params` of de modeldefaults —
-    snel en reproduceerbaar. Zet `tune` alleen aan wanneer je bewust wilt afstemmen;
-    het maakt de run langzamer en, zonder de uitkomst vast te leggen,
-    niet-deterministisch.
+Wil je `studentprognose` aanroepen vanuit een notebook, MS Fabric, Databricks of cloud-opslag, hyperparameters afstemmen, of het model evalueren met scalaire metrieken? Zie [Gevorderd gebruik](gevorderd-gebruik.md). Voor een gewone prognose via de command line heb je dat niet nodig.
 
 ## Bekende valkuil: stille modus-downgrade
 
 !!! warning "Let op bij `-d b`"
-    Als je `-d both` (standaard) gebruikt maar de individuele aanmelddata ontbreekt of
-    bevat niet de verwachte jaren, **valt de pipeline terug op `-d cumulative`**.
-    De tool toont dan een waarschuwing, maar de output bevat alleen cumulatieve
-    voorspellingen — geen ensemble, geen `SARIMA_individual`.
+    Gebruik je `-d both` (standaard) maar ontbreekt de individuele aanmelddata (of mist die de verwachte jaren), dan **valt de pipeline terug op `-d cumulative`**. Je krijgt een waarschuwing, maar de output bevat dan alleen cumulatieve voorspellingen — geen ensemble, geen `SARIMA_individual`.
 
-    Controleer altijd of `SARIMA_individual` kolommen aanwezig zijn in je output als je
-    het ensemble verwacht.
+    Verwacht je het ensemble? Controleer of de `SARIMA_individual`-kolommen in je output staan.
 
 ## Veelvoorkomende fouten
 
-??? failure "`python: command not found` of versie te laag"
-
-    Python is niet geïnstalleerd of niet beschikbaar in je PATH. Zie [Voordat je begint](#voordat-je-begint) voor installatie-instructies.
-
-    Op sommige systemen heet het commando `python3` in plaats van `python`.
-
-??? failure "`studentprognose: command not found` na installatie"
-
-    Start je terminal opnieuw op zodat het `studentprognose`-commando beschikbaar wordt. Als het probleem aanhoudt, draai `uv tool update-shell` en open een nieuwe terminal.
-
-??? failure "`ModuleNotFoundError: No module named 'studentprognose'`"
-
-    Je draait Python buiten de omgeving waarin studentprognose is geïnstalleerd. Gebruik `uv run studentprognose ...` om de juiste Python-omgeving te kiezen.
+Installatiefouten (`command not found`, `ModuleNotFoundError`) staan bij [Installeren → Installatie mislukt?](installeren.md#installatie-mislukt).
 
 ??? failure "`TerminatedWorkerError` tijdens SARIMA (Windows)"
-
-    Een worker-proces is op signaal-niveau gestopt — meestal door geheugendruk wanneer er veel parallelle workers tegelijk draaien op een laptop met beperkt RAM, soms door een crash in onderliggende C-code.
-
-    De pipeline probeert vanaf nu automatisch opnieuw met 2 workers. Werkt dat ook niet, zet dan handmatig in `configuration/configuration.json`:
+    Een worker-proces is op signaal-niveau gestopt — meestal geheugendruk bij veel parallelle workers op een laptop met beperkt RAM. De pipeline probeert automatisch opnieuw met 2 workers. Werkt dat niet, zet dan in `configuration/configuration.json`:
 
     ```json
     "runtime": { "cpu_count": 1 }
     ```
 
-    `cpu_count: 1` schakelt parallelisatie helemaal uit. Trager, maar zonder worker-spawns en daarmee zonder deze klasse fouten.
-
-## Andere installatiemethoden
-
-??? note "Installeren met pip in een virtual environment"
-
-    !!! warning "Installeer niet zonder virtual environment"
-        Een `pip install` buiten een virtual environment plaatst packages in je systeemomgeving en kan conflicten veroorzaken met andere projecten.
-
-    **Stap 1 — Maak een projectmap en virtual environment aan:**
-
-    ```bash
-    mkdir mijn-prognose
-    cd mijn-prognose
-    python -m venv .venv
-    ```
-
-    **Stap 2 — Activeer de virtual environment:**
-
-    === "Windows (PowerShell)"
-
-        ```powershell
-        .venv\Scripts\Activate.ps1
-        ```
-
-    === "Windows (CMD)"
-
-        ```cmd
-        .venv\Scripts\activate.bat
-        ```
-
-    === "macOS / Linux"
-
-        ```bash
-        source .venv/bin/activate
-        ```
-
-    Je ziet nu `(.venv)` voor je prompt — dat bevestigt dat de omgeving actief is.
-
-    **Stap 3 — Installeer studentprognose:**
-
-    ```bash
-    pip install studentprognose
-    ```
-
-    **Updaten:** `pip install --upgrade studentprognose`
-
-    Elke nieuwe terminal vereist een nieuwe activatie (stap 2) vóór `studentprognose` werkt.
-
-??? note "Bijdragen aan de broncode"
-
-    ```bash
-    git clone https://github.com/cedanl/studentprognose.git
-    cd studentprognose
-    uv run studentprognose --help
-    ```
-
-    `uv run` maakt automatisch een virtual environment aan op basis van `pyproject.toml`.
+    `cpu_count: 1` schakelt parallelisatie uit. Trager, maar zonder worker-spawns en daarmee zonder deze klasse fouten.

--- a/docs/begrippen.md
+++ b/docs/begrippen.md
@@ -1,0 +1,57 @@
+# Begrippen
+
+Een korte woordenlijst van termen die in deze documentatie terugkomen. Kom je een term tegen die hier niet staat? Meld het via [GitHub Issues](https://github.com/cedanl/studentprognose/issues).
+
+## Kernbegrippen
+
+| Term | In gewone taal |
+|------|----------------|
+| **Peilweek** | De kalenderweek (1–52) waarop je de aanmeldstand "bevriest" en waarvandaan je vooruit voorspelt. Vlag `-w`. |
+| **Collegejaar** | Het jaar waarvoor je de instroom voorspelt. Vlag `-y`. |
+| **Instroom / inschrijvingen** | Het uiteindelijke aantal studenten dat zich daadwerkelijk inschrijft — dat is wat de tool voorspelt. |
+| **(Voor)aanmelding** | Een aanmelding via Studielink die (nog) geen inschrijving is. Niet elke aanmelder schrijft zich in. |
+| **Conversie / yield** | Het aandeel aanmelders dat uiteindelijk inschrijft. |
+
+## De twee sporen
+
+De tool kan langs twee routes voorspellen, afhankelijk van je data:
+
+| Term | In gewone taal |
+|------|----------------|
+| **Cumulatief spoor** (`-d c`) | Werkt met de opgetelde aanmeldaantallen per opleiding en week (Studielink-telbestanden). Trekt de aanmeldcurve door naar het einde van het seizoen. |
+| **Individueel spoor** (`-d i`) | Werkt met één regel per aanmelder (Osiris/Usis). Schat per persoon de kans op inschrijving en telt die op. |
+| **Beide** (`-d b`) | Draait beide sporen en combineert ze tot één [ensemble](#modellen)-voorspelling. Dit is de standaard. |
+
+## Data
+
+| Term | In gewone taal |
+|------|----------------|
+| **ETL** | *Extract, Transform, Load* — de stap die je ruwe bronbestanden inleest, opschoont en omzet naar het formaat dat het model verwacht. De tool doet dit automatisch; sla het over met `--noetl` als je data al verwerkt is. |
+| **Telbestand** | Het Studielink-bestand met opgetelde aanmeldaantallen per opleiding, herkomst en week. |
+| **Gewogen vooraanmelders** | Aanmeldingen gecorrigeerd voor studenten die zich voor meerdere opleidingen aanmelden (een aanmelding telt dan voor een deel mee). |
+| **Ongewogen vooraanmelders** | Het "kale" aantal aanmeldingen, zonder die correctie. |
+| **Brincode / instellingscode** | De landelijke code van een onderwijsinstelling (bijv. `21PC`). De teldata bevat álle instellingen; met `--institution` beperk je de run tot de jouwe. |
+| **Kanonieke naam** | De vaste, interne kolomnaam die de tool verwacht. Heten je eigen kolommen anders, dan vertaal je ze via het `columns`-blok in de configuratie. |
+| **Herkomst** | Onderscheid tussen bijv. Nederlandse en niet-Nederlandse studenten, gebruikt als voorspeldimensie. |
+
+## Modellen
+
+| Term | In gewone taal |
+|------|----------------|
+| **SARIMA** | Een tijdreeksmodel dat een curve doortrekt op basis van het patroon in eerdere jaren, inclusief het seizoenspatroon. Zie [SARIMA](methodologie/sarima.md). |
+| **XGBoost** | Een machine-learning-model dat verbanden leert tussen kenmerken (features) en de uitkomst. Wordt zowel per student (kans op inschrijving) als op de curve gebruikt. Zie [XGBoost](methodologie/xgboost.md). |
+| **Ratio-model** | Een eenvoudig model dat de historische verhouding aanmelding → inschrijving toepast op de huidige aanmeldingen. Zie [Ratio-model](methodologie/ratio-model.md). |
+| **Ensemble** | De gewogen combinatie van de losse modellen tot één eindvoorspelling. Zie [Ensemble](methodologie/ensemble.md). |
+| **Baseline** | Een bewust simpele referentievoorspelling (gelijk aan het ratio-model) om de complexere modellen tegen af te zetten. |
+| **Numerus fixus** | Opleiding met een vast maximum aantal plaatsen; de voorspelling wordt afgekapt op dat maximum. |
+
+## Evaluatie
+
+| Term | In gewone taal |
+|------|----------------|
+| **MAE** | *Mean Absolute Error* — het gemiddelde aantal studenten waarmee een voorspelling ernaast zat. MAE 8 = gemiddeld 8 studenten afwijking. |
+| **MAPE** | *Mean Absolute Percentage Error* — dezelfde afwijking als percentage. MAPE 0,12 = gemiddeld 12% ernaast. |
+| **WAPE** | Procentuele fout over de hele instelling; grote opleidingen wegen zwaarder, waardoor kleine opleidingen de uitkomst niet domineren. |
+| **Bias** | Of een model structureel te hoog (positief) of te laag (negatief) voorspelt. |
+| **Backtest** | Een voorspelling maken voor een reeds **afgerond** jaar en die vergelijken met wat er echt gebeurde — de eerlijke manier om een model te beoordelen. |
+| **Data leakage** | Wanneer een model per ongeluk informatie gebruikt die op het voorspelmoment nog niet bekend kon zijn. Dat maakt resultaten te mooi; de tool voorkomt dit bewust. |

--- a/docs/configuratie-referentie.md
+++ b/docs/configuratie-referentie.md
@@ -1,0 +1,404 @@
+# Configuratie — referentie
+
+Deze pagina beschrijft **alle** configuratiesecties die je zelden of nooit hoeft aan te passen. Voor de dagelijkse instellingen (je eigen instelling, numerus fixus) zie [Configuratie](configuratie.md).
+
+!!! tip "Heb je dit nodig?"
+    De meeste gebruikers komen hier niet. Alle secties hieronder vallen terug op zinnige standaardwaarden; pas ze alleen aan als je een specifieke reden hebt.
+
+## `paths` — bestandspaden
+
+Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
+
+| Sleutel | Standaard | Omschrijving |
+|---------|-----------|-------------|
+| `path_cumulative` | `data/input/vooraanmeldingen_cumulatief.csv` | Cumulatieve vooraanmelddata (ETL-output) |
+| `path_individual` | `data/input/vooraanmeldingen_individueel.csv` | Individuele aanmelddata (ETL-output) |
+| `path_cumulative_new` | `""` | Optioneel nieuw cumulatief bestand; wordt ingemergt en daarna verwijderd — zie [waarschuwing](je-data-voorbereiden.md#bekende-valkuil-path_cumulative_new) |
+| `path_latest_cumulative` | `data/input/totaal_cumulatief.xlsx` | Historische cumulatieve voorspellingen (post-processing output) |
+| `path_latest_individual` | `data/input/totaal_individueel.xlsx` | Historische individuele voorspellingen (post-processing output) |
+| `path_ensemble_weights` | `data/input/ensemble_weights.xlsx` | Ensemble-gewichten per opleiding/herkomst/examentype |
+| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | Telbestand studenten (ruwe bron, eigen levering instelling). De sleutel heet `_october` om historische redenen. |
+| `path_raw_telbestanden` | `data/input_raw/telbestanden` | Map met Studielink telbestanden |
+| `path_raw_individueel` | `data/input_raw/individuele_aanmelddata.csv` | Ruwe individuele aanmelddata |
+| `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (afgeleid uit telbestand studenten) |
+| `path_student_count_higher-years` | `data/input/student_count_higher-years.xlsx` | Werkelijk aantal hogerejaars (alleen nodig bij `-sy h`) |
+| `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (afgeleid uit telbestand studenten) |
+| `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
+
+## `telbestand_filename_patterns` — bestandsnaampatronen voor telbestanden
+
+De meegeleverde (`init`-)config herkent standaard zowel het legacy- als het UvA Studielink SQL-formaat: `["telbestandY{year}W{week}", "telbestand_sl_{date}_v{volgnummer}_{year}"]`. Laat je de sleutel volledig weg, dan valt de code terug op alleen `telbestandY{year}W{week}`.
+
+De pipeline herkent telbestanden in `path_raw_telbestanden` aan hun bestandsnaam. Instellingen met afwijkende naamconventies kunnen hier hun eigen patroon opgeven. De ETL en de validatie gebruiken hetzelfde patroon om jaar en weeknummer uit de bestandsnaam te halen.
+
+**Placeholder-syntax:**
+
+- `{year}` — vierdigit collegejaar (bijv. `2024`); **verplicht**
+- `{week}` — weeknummer (1–2 cijfers, gevalideerd op bereik 1–53)
+- `{date}` — leverdatum `YYYYMMDD` (8 cijfers); de week wordt afgeleid als **ISO-kalenderweek** van die datum (gebruikt door het UvA SQL-telbestand)
+- `{volgnummer}` — Studielink-volgnummer (genegeerd voor de week-afleiding, maar mag in het patroon staan)
+- Alle andere karakters worden letterlijk gematcht. Punten, streepjes en underscores zijn veilig (`re.escape` op de achtergrond).
+
+Een patroon moet `{year}` bevatten én een week kunnen opleveren: dus `{week}` **of** `{date}`.
+
+**Voorbeelden:**
+
+```json
+{
+    "telbestand_filename_patterns": [
+        "telbestandY{year}W{week}",
+        "VU_telbestand_{year}_W{week}",
+        "telbestand_sl_{date}_v{volgnummer}_{year}"
+    ]
+}
+```
+
+Met meerdere patronen kan de pipeline bestanden van verschillende leveranciers naast elkaar verwerken — handig tijdens een migratie van oude naar nieuwe naamgeving. Het laatste voorbeeld is het UvA SQL-formaat: `telbestand_sl_20260525_v34_2026.csv` levert ISO-week 22 (uit leverdatum `20260525`).
+
+**Foutgedrag:** Een patroon zonder `{year}`, of zonder zowel `{week}` als `{date}`, leidt tot een configuratiefout en stopt de pipeline direct, met een melding die het probleempatroon noemt.
+
+## `runtime` — uitvoerparameters
+
+Instellingen die bepalen hoe de pipeline zich gedraagt tijdens uitvoer (los van de modelkeuze).
+
+### `cpu_count`
+
+Standaard: `null`
+
+Het aantal CPU-cores dat de pipeline gebruikt voor parallelle voorspellingen. De voorspelling van individuele SARIMA-modellen wordt verdeeld over deze cores via `joblib.Parallel`.
+
+| Waarde | Gedrag |
+|--------|--------|
+| `null` | Automatisch — `os.cpu_count()` wordt gebruikt, of `1` als het besturingssysteem geen waarde teruggeeft (kan voorkomen in containers met cgroup-limieten). |
+| Geheel getal `>= 1` | Gebruikt deze waarde. Als de waarde hoger is dan het aantal beschikbare cores, wordt deze automatisch verlaagd naar dat aantal en verschijnt er een waarschuwing. |
+
+Pas dit aan als:
+
+- De pipeline crasht omdat `os.cpu_count()` geen betrouwbare waarde teruggeeft op jouw hardware of in jouw container (achtergrond van [issue #162](https://github.com/cedanl/studentprognose/issues/162)).
+- Je het CPU-gebruik wilt beperken op een gedeelde machine.
+
+Ongeldige waarden (`0`, negatieve getallen, niet-gehele getallen) leiden tot een configuratiefout en stoppen de pipeline direct.
+
+## `model_config` — modelparameters
+
+### `status_mapping`
+
+Bepaalt welke inschrijfstatussen als "ingeschreven" (1) of "niet-ingeschreven" (0) worden gelabeld voor het XGBoost-classificatiemodel.
+
+Standaardwaarden:
+
+| Status | Label |
+|--------|-------|
+| `Ingeschreven` | `1` |
+| `Uitgeschreven` | `1` |
+| `Geannuleerd` | `0` |
+| `Verzoek tot inschrijving` | `0` |
+| `Studie gestaakt` | `0` |
+| `Aanmelding vervolgen` | `0` |
+
+Pas dit aan als jouw instelling andere statuswaarden gebruikt. Onbekende statussen worden niet gemapt en veroorzaken een fout.
+
+### `min_training_year`
+
+Standaard: `2016`
+
+Het vroegste collegejaar dat als trainingsdata wordt meegenomen. Data van vóór dit jaar wordt genegeerd. Verlaag dit alleen als je betrouwbare historische data hebt die verder teruggaat.
+
+### `cumulative_timeseries`
+
+Standaard: `"sarima"`
+
+Het tijdreeksmodel voor de cumulatieve curve-extrapolatie (stap 1 van het cumulatieve spoor). De keuze bepaalt hoe de vooraanmelderscurve tot week 38 wordt geëxtrapoleerd.
+
+| Waarde | Model | Omschrijving |
+|--------|-------|-------------|
+| `sarima` | SARIMA(1,0,1)×(1,1,1,52) | Standaard — vaste ordes, bewezen in productie |
+| `ets` | AutoETS | Automatische componentkeuze (error/trend/seizoen), stabieler bij korte reeksen |
+| `theta` | AutoTheta | Zeer simpel, competitief bij korte tijdreeksen |
+| `auto_arima` | AutoARIMA | Automatische orde-selectie via AICc, flexibeler dan vaste SARIMA |
+
+Gebruik `studentprognose benchmark` om te vergelijken welk model het best presteert op jouw data.
+
+### `cumulative_regressor`
+
+Standaard: `"xgboost"`
+
+Het regressiemodel dat vooraanmelderscijfers vertaalt naar verwachte inschrijvingen (stap 2 van het cumulatieve spoor).
+
+| Waarde | Model | Omschrijving |
+|--------|-------|-------------|
+| `xgboost` | XGBoost Regressor | Standaard — gradient boosting, krachtig bij voldoende data |
+| `ridge` | Ridge Regression | L2-regularisatie, stabiel bij weinig trainingsdata en multicollineariteit |
+| `random_forest` | Random Forest | Robuust bij kleine datasets, ingebouwde feature importance |
+
+??? note "Geavanceerd: hyperparameters tunen"
+    De volgende sleutels leggen de instellingen van de modellen zelf vast. Je hebt ze alleen nodig als je de modellen wilt fijnafstellen (tunen); voor een normale run kun je ze overslaan.
+
+    ### `regressor_params` — hyperparameters vastleggen
+
+    Optioneel. Een object dat per regressor de hyperparameters vastlegt waarmee het model wordt geïnstantieerd. Niet-opgegeven parameters vallen terug op de modeldefaults. Dit is het **reproduceerbare** pad: de waarden worden bij elke run gebruikt, zonder opnieuw te tunen.
+
+    ```json
+    "model_config": {
+        "cumulative_regressor": "xgboost",
+        "regressor_params": {
+            "xgboost": { "learning_rate": 0.1, "n_estimators": 200, "max_depth": 5 }
+        }
+    }
+    ```
+
+    De parameters per regressor worden direct doorgegeven aan het onderliggende model (bijv. `XGBRegressor`, `Ridge`, `RandomForestRegressor`). Alleen het model dat in `cumulative_regressor` actief is, gebruikt zijn parameters; vermeldingen voor andere regressors worden genegeerd.
+
+    Vul je dit liever niet handmatig in? Het commando `studentprognose tune -d c` zoekt de beste waarden en print een kant-en-klaar snippet om hier te plakken (zie [Waarden vastleggen](#waarden-vastleggen) hieronder en [XGBoost → Hyperparameter tuning](methodologie/xgboost.md#hyperparameter-tuning)).
+
+    ### `tuning_grid` — eigen zoekruimte voor tuning
+
+    Optioneel. Een object dat de zoekruimte voor `studentprognose tune` (en de API-parameter `tune`) overschrijft: per hyperparameter een lijst van te proberen waarden. Bij afwezigheid wordt de ingebouwde, regularisatie-gerichte standaardgrid gebruikt.
+
+    ```json
+    "model_config": {
+        "tuning_grid": {
+            "max_depth": [3, 5, 7],
+            "n_estimators": [100, 200, 400]
+        }
+    }
+    ```
+
+    ### `forecaster_params` — SARIMA-ordes vastleggen
+
+    Optioneel. Het tijdreeks-equivalent van `regressor_params`: een object dat per forecaster de instantiatie-parameters vastlegt. Voor SARIMA zijn dat de ARIMA-ordes `order` en `seasonal_order`; voor de overige forecasters bijv. `season_length`. Niet-opgegeven waarden vallen terug op de modeldefaults. Ook dit is het **reproduceerbare** pad.
+
+    ```json
+    "model_config": {
+        "cumulative_timeseries": "sarima",
+        "forecaster_params": {
+            "sarima": { "order": [1, 1, 1], "seasonal_order": [1, 1, 0, 52] }
+        }
+    }
+    ```
+
+    De vierde waarde van `seasonal_order` is de seizoenslengte; die wordt bij fit nog afgestemd op de werkelijke jaar-periode van je data (net als in productie). Alleen de forecaster die in `cumulative_timeseries` actief is, gebruikt zijn parameters.
+
+    ### `sarima_tuning_grid` — eigen zoekruimte voor SARIMA-tuning
+
+    Optioneel. Net als `tuning_grid`, maar voor `studentprognose tune --tune-target sarima` (en de API `tune="sarima"`/`"both"`): per orde een lijst van te proberen waarden. Bij afwezigheid wordt de ingebouwde SARIMA-grid gebruikt.
+
+    ```json
+    "model_config": {
+        "sarima_tuning_grid": {
+            "order": [[1, 0, 1], [1, 1, 1], [2, 1, 1]],
+            "seasonal_order": [[1, 1, 0, 52], [1, 1, 1, 52]]
+        }
+    }
+    ```
+
+    #### Waarden vastleggen
+
+    De aanbevolen werkwijze: draai `studentprognose tune -d c -w <week>` (eventueel met `--tune-target sarima` of `both`), kopieer de getoonde snippets naar je `configuration.json`, en draai daarna normaal. Zo zijn de getunede waarden expliciet, reproduceerbaar en deelbaar — in plaats van impliciet bij elke run opnieuw gezocht.
+
+### `final_academic_week`
+
+Standaard: `38`
+
+De **laatste week van het academisch jaar** in de Studielink-cyclus. Bepaalt de seizoensvolgorde van de weken (het jaar loopt van week `final_academic_week + 1` via week 52 door naar `final_academic_week`), de voorspelhorizon (`pred_len`) en de reset-week-injectie in het cumulatieve spoor.
+
+- Het legacy instellingsformaat loopt tot **week 38** (eind september) — dit is de standaard.
+- Het UvA SQL-telbestand levert de aanmeldfase tot **week 36**; er zijn geen leveringen in de weken 37–39. Zet daarvoor `final_academic_week` op `36`.
+
+Een verkeerde waarde laat de cumulatieve voorspelling crashen (de pipeline slicet kolommen tot deze week) of geeft een onjuiste voorspelhorizon. De waarde geldt voor het **cumulatieve spoor**; het individuele spoor gebruikt de vaste Studielink-kalender.
+
+## `cumulative_input` — UvA SQL-telbestand omzetten
+
+Stuurt hoe de ETL-rowbind (`_rowbind_and_reformat`) de ruwe telbestanden uit `path_raw_telbestanden` omzet naar de 16-koloms `vooraanmeldingen_cumulatief.csv`. **De meegeleverde (`init`-)config bevat dit blok al, ingesteld op het raw Studielink SQL-formaat** — dat is de standaard-doelgroep. De `Default`-kolom hieronder beschrijft de code-terugval wanneer je het blok (of een sleutel) volledig weglaat; dan vervalt de ETL naar de legacy-defaults (`;`-gescheiden). Voor het UvA SQL-formaat (zie [Je data klaarzetten](je-data-voorbereiden.md#uva-sql-telbestand-fijnmazig-studielink-formaat)):
+
+```json
+{
+    "cumulative_input": {
+        "separator": ",",
+        "value_maps": {
+            "Type hoger onderwijs": {"P": "Bachelor", "B": "Bachelor", "M": "Master", "A": "Associate degree", "O": "Onbekend"},
+            "Herkomst": {"N": "NL", "E": "EER", "R": "Niet-EER", "O": "Onbekend"}
+        },
+        "faculteit_sentinel": "Onbekend",
+        "aggregate": true,
+        "drop_deleted": true
+    }
+}
+```
+
+| Sleutel | Default | Betekenis |
+|---------|---------|-----------|
+| `separator` | `";"` | Scheidingsteken van de ruwe telbestanden (UvA SQL: `","`). |
+| `rename` | legacy-map | Bronkolom → canonieke kolomnaam. De UvA-bronkolommen (`Brincode`, `Studiejaar`, `Type_HO`, `Isatcode`, `Aantal`) zijn gelijk aan legacy, dus meestal niet nodig. |
+| `value_maps` | legacy-vertalingen | Waardevertalingen per canonieke kolom. Per kolom volledig overschrijfbaar; niet-genoemde kolommen (bijv. `Herinschrijving`/`Hogerejaars`) houden hun default. Niet-gemapte waarden gaan onveranderd door (met een waarschuwing). |
+| `faculteit_sentinel` | `null` | Vulwaarde voor een ontbrekende `Faculteit`. **Moet niet-leeg zijn** als de kolom in de bron ontbreekt: een lege (NaN) Faculteit laat de cumulatieve `groupby`/pivot de rijen vallen. |
+| `programme_name_source` | `"Groepeernaam"` | Bronkolom voor de leesbare opleidingsnaam; valt terug op `Croho` (Isatcode) als de kolom ontbreekt. |
+| `aggregate` | `false` | Tel de fijnmazige rijen op naar de canonieke grain (verplicht voor UvA: bereken `Gewogen` per rij, sommeer daarna; anders crasht de pivot op dubbele indexrijen). |
+| `drop_deleted` | `false` | Filter rijen met `etl_is_deleted != 0` (UvA SQL soft-delete vlag). |
+
+De canonieke output is altijd `;`-gescheiden, ongeacht de input-separator.
+
+## `excluded_data_points` — anomaliejaren uitsluiten van trainingsdata
+
+Optionele lijst van filterregels voor het verwijderen van bekende problematische datapunten uit de **trainingsdata**. De tool past de regels toe vóór elk model wordt getraind. Het voorspeljaar (`predict_year`) wordt **altijd** beschermd en nooit uitgesloten, ongeacht de regels.
+
+Gebruik dit alleen voor aantoonbare datakwaliteitsproblemen: foutieve Studielink-snapshots, deadlineverschuivingen die een historische reeks onvergelijkbaar maken, of structureel afwijkende populaties. Uitsluiten om een betere modelfit te forceren is misbruik — documenteer altijd de reden.
+
+```json
+{
+    "excluded_data_points": [
+        {
+            "year": 2024,
+            "herkomst": "Niet-EER",
+            "examentype": ["Bachelor", "Pre-master"]
+        },
+        {
+            "year_before": 2024,
+            "examentype": "Pre-master",
+            "opleiding": "B Voorbeeldopleiding"
+        }
+    ]
+}
+```
+
+### Filtersleutels per regel
+
+Alle sleutels binnen één regel worden gecombineerd met **AND**. Meerdere regels worden gecombineerd met **OR**.
+
+| Sleutel | Type | Omschrijving |
+|---------|------|-------------|
+| `year` | `int` | Sluit exact dit collegejaar uit |
+| `year_before` | `int` | Sluit alle jaren vóór (exclusief) deze waarde uit |
+| `year_after` | `int` | Sluit alle jaren na (exclusief) deze waarde uit |
+| `herkomst` | `str` of `list[str]` | Filter op herkomst (`"NL"`, `"EER"`, `"Niet-EER"`) |
+| `examentype` | `str` of `list[str]` | Filter op examentype (`"Bachelor"`, `"Master"`, `"Pre-master"`) |
+| `opleiding` | `str` of `list[str]` | Filter op `Croho groepeernaam` |
+
+Een lege lijst (`[]`) schakelt uitsluiting volledig uit — dit is de standaard.
+
+!!! warning "Gebruik dit bewust"
+    Elk uitgesloten datapunt verkleint de trainingsset. Bij kleine opleidingen kan dat de modelkwaliteit ernstig verslechteren. Beperk uitsluiting tot jaren waarvan je kunt aantonen dat de data structureel fout of onvergelijkbaar is.
+
+## `ensemble_weights` — weging SARIMA-individueel vs. SARIMA-cumulatief
+
+Bepaalt per weekperiode hoe zwaar het individuele en het cumulatieve SARIMA-model meewegen in de ensemble-voorspelling. Elke sleutel is een situatie; de waarde is een object met `individual` en `cumulative` (moeten optellen tot 1.0).
+
+```json
+{
+    "ensemble_weights": {
+        "master_week_17_23": {"individual": 0.2, "cumulative": 0.8},
+        "week_30_34":        {"individual": 0.6, "cumulative": 0.4},
+        "week_35_37":        {"individual": 0.7, "cumulative": 0.3},
+        "default":           {"individual": 0.5, "cumulative": 0.5}
+    }
+}
+```
+
+| Sleutel | Van toepassing wanneer |
+|---------|----------------------|
+| `master_week_17_23` | Examentype = Master én weeknummer 17–23 |
+| `week_30_34` | Weeknummer 30–34 |
+| `week_35_37` | Weeknummer 35 t/m `final_academic_week - 1` |
+| `default` | Alle overige gevallen |
+
+De einddeadline (`final_academic_week`, standaard week 38; UvA week 36) is altijd 100% individueel en wordt niet door deze instelling beïnvloed. Zie [Ensemble](methodologie/ensemble.md) voor achtergrond bij de keuze van gewichten.
+
+!!! note "Weekgrenzen volgen `final_academic_week`"
+    De sleutelnamen (zoals `week_30_34`) beschrijven de weekperiode waarop een gewicht van toepassing is; de **gewichten** zijn instelbaar via dit blok. De bovengrens van `week_35_37` en de 100%-individueel-eindweek schalen mee met [`model_config.final_academic_week`](#final_academic_week) (bij week 36 loopt `week_35_37` dus alleen over week 35). De overige weekgrenzen (17–23, 30–34) liggen vast in `output/postprocessor.py` en vereisen een codewijziging om aan te passen.
+
+## `columns` — kolomnamen mapping
+
+De pipeline verwacht voor elke kolom een vaste, interne standaardnaam — de zogenoemde *kanonieke naam*. Gebruikt jouw databestand andere kolomnamen, dan vertaal je die hier naar de kanonieke naam. Specificeer alleen de namen die afwijken — ontbrekende sleutels vallen terug op de kanonieke naam.
+
+### `individual` — individuele aanmelddata
+
+Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
+
+`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `Is hogerejaars`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
+
+### `oktober` — telbestand studenten
+
+`Collegejaar`, `Isatcode`, `Groepeernaam Croho`, `Aantal eerstejaars croho`, `EER-NL-nietEER`, `Examentype code`, `Aantal Hoofdinschrijvingen`
+
+De sleutel heet `oktober` om historische redenen — zie [Je data klaarzetten](je-data-voorbereiden.md#telbestand-studenten). `Isatcode` is de **joinsleutel** met de vooraanmeldingen (de studentaantallen worden hierop gekoppeld, niet op `Groepeernaam Croho`); zorg dat de codes overeenkomen met die in je telbestanden.
+
+### `cumulative` — Studielink cumulatieve data
+
+`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Hogerejaars`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
+
+Dit zijn de kolommen ná de ETL-transformatie (na het inlezen en hernoemen van de ruwe Studielink-velden). Zie [Studielink telbestanden](je-data-voorbereiden.md#studielink-telbestanden) voor de mapping van ruwe PvL-velden naar deze kanonieke namen.
+
+## `column_roles` — interne rolnamen → kanonieke kolomnaam
+
+!!! note "Deze sectie raak je vrijwel nooit aan"
+    `column_roles` is een interne koppeling. Wil je eigen kolomnamen gebruiken, dan doe je dat via [`columns`](#columns-kolomnamen-mapping) hierboven. Laat `column_roles` in bijna alle gevallen ongemoeid.
+
+De code verwijst naar kolommen niet met hun naam, maar met een korte *rol* die zegt wat de kolom betékent — bijvoorbeeld `programme` (de opleiding), `academic_year` (het collegejaar) of `origin` (de herkomst). Deze rol heet in vaktaal een **semantische rol**. Waar `columns` jouw eigen kolomnamen vertaalt naar kanonieke namen, koppelt `column_roles` zo'n rol aan de kanonieke kolomnaam, zodat een hernoeming op één plek volstaat.
+
+| Rol | Standaard kolom | Rol | Standaard kolom |
+|-----|-----------------|-----|-----------------|
+| `academic_year` | `Collegejaar` | `week` | `Weeknummer` |
+| `programme` | `Croho groepeernaam` | `exam_type` | `Examentype` |
+| `origin` | `Herkomst` | `faculty` | `Faculteit` |
+| `enrollment_status` | `Inschrijfstatus` | `cancellation_date` | `Datum intrekking vooraanmelding` |
+| `student_count` | `Aantal_studenten` | `enrollments` | `Inschrijvingen` |
+| `weighted_applicants` | `Gewogen vooraanmelders` | `unweighted_applicants` | `Ongewogen vooraanmelders` |
+| `single_applicants` | `Aantal aanmelders met 1 aanmelding` | `higher_years` | `Hogerejaars` |
+| `croho_source` | `Groepeernaam Croho` | `higher_education_type` | `Type hoger onderwijs` |
+| `institution` | `Korte naam instelling` | | |
+
+De rol `institution` bepaalt op welke kolom [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen) filtert.
+
+Pas dit alleen aan als je de **interne** kanonieke namen wijzigt — in de meeste gevallen gebruik je `columns` (voor je ruwe inputkolommen) en laat je `column_roles` ongemoeid.
+
+## `model_features` — featurelijsten per model
+
+Bepaalt welke kolommen als features in de modellen gaan. Twee subsleutels:
+
+- `classifier` — de individuele XGBoost-classifier, met `numeric` en `categorical` featurelijsten (zie [XGBoost](methodologie/xgboost.md#features)).
+- `regressor` — de cumulatieve XGBoost-regressor, met een `categorical` featurelijst; numerieke features (vooraanmelders, lags, acceleratie) worden afgeleid tijdens feature-engineering.
+
+Voeg of verwijder features hier als je inputdata extra (of minder) kolommen bevat. Verwijderde features mogen niet meer in `columns`/`column_roles` als verplicht gemarkeerd staan.
+
+## `validation` — validatiedrempels overschrijven
+
+Optionele sectie. Hoeft niet in je configuratiebestand te staan. Voeg alleen toe wat afwijkt van de standaard:
+
+```json
+{
+    "validation": {
+        "nan_error_threshold": 0.20,
+        "telbestand": {
+            "herkomst_allowed": ["N", "E", "R", "ONBEKEND"]
+        }
+    }
+}
+```
+
+| Sleutel | Standaard | Omschrijving |
+|---------|-----------|-------------|
+| `nan_warning_threshold` | `0.05` | Fractie ontbrekende waarden die een waarschuwing geeft |
+| `nan_error_threshold` | `0.30` | Fractie ontbrekende waarden die een fout geeft |
+| `collegejaar_min_offset` | `15` | Collegejaren ouder dan `huidig jaar - 15` geven een fout |
+| `collegejaar_max_offset` | `2` | Collegejaren na `huidig jaar + 2` geven een fout |
+| `telbestand.herkomst_allowed` | `["N","E","R"]` | Toegestane herkomstwaarden in telbestanden |
+| `telbestand.required_columns` | legacy-lijst | Vereiste ruwe kolommen. Het UvA SQL-formaat mist `Groepeernaam`, dus zet hier een lijst zonder die kolom. |
+| `telbestand.separator` | `";"` | Scheidingsteken waarmee de validatie de telbestanden inleest. Zet op `","` voor het UvA SQL-formaat (gelijk aan `cumulative_input.separator`). |
+| `telbestand.programme_column` | `"Groepeernaam"` | Kolom waarop categorale fouten worden gegroepeerd. Zet op `"Isatcode"` als `Groepeernaam` ontbreekt (UvA). |
+
+Net als bij `cumulative_input` levert de meegeleverde (`init`-)config dit `validation.telbestand`-blok al mee, ingesteld op het raw Studielink SQL-formaat; de `Standaard`-kolom beschrijft de code-terugval als je een sleutel weglaat. De `validation`-overrides en het [`cumulative_input`](#cumulative_input-uva-sql-telbestand-omzetten)-blok horen samen; ze beschrijven hetzelfde ruwe formaat voor respectievelijk de validatie en de ETL:
+
+```json
+{
+    "validation": {
+        "telbestand": {
+            "separator": ",",
+            "programme_column": "Isatcode",
+            "required_columns": ["Studiejaar", "Isatcode", "Aantal", "meercode_V", "Status", "Herinschrijving", "Hogerejaars", "Herkomst"],
+            "herkomst_allowed": ["N", "E", "R", "O"]
+        }
+    }
+}
+```
+
+Zie [Validatie](validatie.md) voor een volledig overzicht van alle controles.

--- a/docs/configuratie.md
+++ b/docs/configuratie.md
@@ -1,10 +1,32 @@
 # Configuratie
 
+!!! tip "Snelste route"
+    De meeste gebruikers hoeven alleen hun eigen instelling (`institution_filter`) en eventueel een `numerus_fixus` in te stellen. Alle andere secties kunnen op hun standaardwaarde blijven staan.
+
 De pipeline wordt geconfigureerd via `configuration/configuration.json`.
 
 ## Beginnen
 
 Voer eenmalig `studentprognose init` uit in je werkmap. Dit schrijft een startconfiguratie met alle standaardwaarden. Je hoeft daarna alleen de velden aan te passen die bij jouw instelling afwijken.
+
+## Voorbeeld minimale configuratie
+
+In de praktijk pas je meestal maar 2-3 velden aan. Alle andere secties op deze pagina zijn referentie die je gerust kunt overslaan tot je ze nodig hebt.
+
+Omdat de pipeline standaardwaarden inbouwt, hoef je alleen te specificeren wat afwijkt. Een typische startconfiguratie bevat alleen de instelling-specifieke velden:
+
+```json
+{
+    "numerus_fixus": {
+        "B Geneeskunde": 340
+    },
+    "ensemble_override_cumulative": [
+        "B Geneeskunde"
+    ]
+}
+```
+
+Alle overige velden — paden, kolomnamen, modelparameters, ensemble-gewichten — vallen terug op de ingebakken standaardwaarden. Voer `studentprognose init` uit om een volledig ingevuld startbestand te krijgen dat je als referentie kunt gebruiken.
 
 ## Hoe configuratie laden werkt
 
@@ -14,237 +36,25 @@ De pipeline laadt altijd eerst de **ingebakken standaardwaarden** uit het packag
 - Een ontbrekend veld in jouw bestand valt automatisch terug op de standaardwaarde.
 - Als het configuratiebestand helemaal niet bestaat, worden de standaardwaarden gebruikt en verschijnt er een waarschuwing.
 
-Het bestand heeft de volgende secties: `paths`, `telbestand_filename_patterns`, `cumulative_input`, `validation`, `runtime`, `model_config`, `numerus_fixus`, `excluded_data_points`, `ensemble_override_cumulative`, `exclude_from_combined`, `ensemble_weights`, `column_roles`, `model_features` en `columns`.
-
-## `paths` — bestandspaden
-
-Alle paden zijn relatief aan de werkmap waar je de pipeline uitvoert.
-
-| Sleutel | Standaard | Omschrijving |
-|---------|-----------|-------------|
-| `path_cumulative` | `data/input/vooraanmeldingen_cumulatief.csv` | Cumulatieve vooraanmelddata (ETL-output) |
-| `path_individual` | `data/input/vooraanmeldingen_individueel.csv` | Individuele aanmelddata (ETL-output) |
-| `path_cumulative_new` | `""` | Optioneel nieuw cumulatief bestand; wordt ingemergt en daarna verwijderd — zie [waarschuwing](je-data-voorbereiden.md#bekende-valkuil-path_cumulative_new) |
-| `path_latest_cumulative` | `data/input/totaal_cumulatief.xlsx` | Historische cumulatieve voorspellingen (post-processing output) |
-| `path_latest_individual` | `data/input/totaal_individueel.xlsx` | Historische individuele voorspellingen (post-processing output) |
-| `path_ensemble_weights` | `data/input/ensemble_weights.xlsx` | Ensemble-gewichten per opleiding/herkomst/examentype |
-| `path_raw_october` | `data/input_raw/oktober_bestand.xlsx` | Telbestand studenten (ruwe bron, eigen levering instelling). De sleutel heet `_october` om historische redenen. |
-| `path_raw_telbestanden` | `data/input_raw/telbestanden` | Map met Studielink telbestanden |
-| `path_raw_individueel` | `data/input_raw/individuele_aanmelddata.csv` | Ruwe individuele aanmelddata |
-| `path_student_count_first-years` | `data/input/student_count_first-years.xlsx` | Werkelijk aantal eerstejaars (afgeleid uit telbestand studenten) |
-| `path_student_count_higher-years` | `data/input/student_count_higher-years.xlsx` | Werkelijk aantal hogerejaars (alleen nodig bij `-sy h`) |
-| `path_student_volume` | `data/input/student_volume.xlsx` | Totaal studentvolume (afgeleid uit telbestand studenten) |
-| `path_ratios` | `data/input/ratiobestand.xlsx` | Ratiobestand (optioneel) |
-
-## `telbestand_filename_patterns` — bestandsnaampatronen voor telbestanden
-
-De meegeleverde (`init`-)config herkent standaard zowel het legacy- als het UvA Studielink SQL-formaat: `["telbestandY{year}W{week}", "telbestand_sl_{date}_v{volgnummer}_{year}"]`. Laat je de sleutel volledig weg, dan valt de code terug op alleen `telbestandY{year}W{week}`.
-
-De pipeline herkent telbestanden in `path_raw_telbestanden` aan hun bestandsnaam. Instellingen met afwijkende naamconventies kunnen hier hun eigen patroon opgeven. De ETL en de validatie gebruiken hetzelfde patroon om jaar en weeknummer uit de bestandsnaam te halen.
-
-**Placeholder-syntax:**
-
-- `{year}` — vierdigit collegejaar (bijv. `2024`); **verplicht**
-- `{week}` — weeknummer (1–2 cijfers, gevalideerd op bereik 1–53)
-- `{date}` — leverdatum `YYYYMMDD` (8 cijfers); de week wordt afgeleid als **ISO-kalenderweek** van die datum (gebruikt door het UvA SQL-telbestand)
-- `{volgnummer}` — Studielink-volgnummer (genegeerd voor de week-afleiding, maar mag in het patroon staan)
-- Alle andere karakters worden letterlijk gematcht. Punten, streepjes en underscores zijn veilig (`re.escape` op de achtergrond).
-
-Een patroon moet `{year}` bevatten én een week kunnen opleveren: dus `{week}` **of** `{date}`.
-
-**Voorbeelden:**
-
-```json
-{
-    "telbestand_filename_patterns": [
-        "telbestandY{year}W{week}",
-        "VU_telbestand_{year}_W{week}",
-        "telbestand_sl_{date}_v{volgnummer}_{year}"
-    ]
-}
-```
-
-Met meerdere patronen kan de pipeline bestanden van verschillende leveranciers naast elkaar verwerken — handig tijdens een migratie van oude naar nieuwe naamgeving. Het laatste voorbeeld is het UvA SQL-formaat: `telbestand_sl_20260525_v34_2026.csv` levert ISO-week 22 (uit leverdatum `20260525`).
-
-**Foutgedrag:** Een patroon zonder `{year}`, of zonder zowel `{week}` als `{date}`, leidt tot een configuratiefout en stopt de pipeline direct, met een melding die het probleempatroon noemt.
-
-## `runtime` — uitvoerparameters
-
-Instellingen die bepalen hoe de pipeline zich gedraagt tijdens uitvoer (los van de modelkeuze).
-
-### `cpu_count`
-
-Standaard: `null`
-
-Het aantal CPU-cores dat de pipeline gebruikt voor parallelle voorspellingen. De voorspelling van individuele SARIMA-modellen wordt verdeeld over deze cores via `joblib.Parallel`.
-
-| Waarde | Gedrag |
-|--------|--------|
-| `null` | Automatisch — `os.cpu_count()` wordt gebruikt, of `1` als het besturingssysteem geen waarde teruggeeft (kan voorkomen in containers met cgroup-limieten). |
-| Geheel getal `>= 1` | Gebruikt deze waarde. Als de waarde hoger is dan het aantal beschikbare cores, wordt deze automatisch verlaagd naar dat aantal en verschijnt er een waarschuwing. |
-
-Pas dit aan als:
-
-- De pipeline crasht omdat `os.cpu_count()` geen betrouwbare waarde teruggeeft op jouw hardware of in jouw container (achtergrond van [issue #162](https://github.com/cedanl/studentprognose/issues/162)).
-- Je het CPU-gebruik wilt beperken op een gedeelde machine.
-
-Ongeldige waarden (`0`, negatieve getallen, niet-gehele getallen) leiden tot een configuratiefout en stoppen de pipeline direct.
-
-## `model_config` — modelparameters
-
-### `status_mapping`
-
-Bepaalt welke inschrijfstatussen als "ingeschreven" (1) of "niet-ingeschreven" (0) worden gelabeld voor het XGBoost-classificatiemodel.
-
-Standaardwaarden:
-
-| Status | Label |
-|--------|-------|
-| `Ingeschreven` | `1` |
-| `Uitgeschreven` | `1` |
-| `Geannuleerd` | `0` |
-| `Verzoek tot inschrijving` | `0` |
-| `Studie gestaakt` | `0` |
-| `Aanmelding vervolgen` | `0` |
-
-Pas dit aan als jouw instelling andere statuswaarden gebruikt. Onbekende statussen worden niet gemapt en veroorzaken een fout.
-
-### `min_training_year`
-
-Standaard: `2016`
-
-Het vroegste collegejaar dat als trainingsdata wordt meegenomen. Data van vóór dit jaar wordt genegeerd. Verlaag dit alleen als je betrouwbare historische data hebt die verder teruggaat.
-
-### `cumulative_timeseries`
-
-Standaard: `"sarima"`
-
-Het tijdreeksmodel voor de cumulatieve curve-extrapolatie (stap 1 van het cumulatieve spoor). De keuze bepaalt hoe de vooraanmelderscurve tot week 38 wordt geëxtrapoleerd.
-
-| Waarde | Model | Omschrijving |
-|--------|-------|-------------|
-| `sarima` | SARIMA(1,0,1)×(1,1,1,52) | Standaard — vaste ordes, bewezen in productie |
-| `ets` | AutoETS | Automatische componentkeuze (error/trend/seizoen), stabieler bij korte reeksen |
-| `theta` | AutoTheta | Zeer simpel, competitief bij korte tijdreeksen |
-| `auto_arima` | AutoARIMA | Automatische orde-selectie via AICc, flexibeler dan vaste SARIMA |
-
-Gebruik `studentprognose benchmark` om te vergelijken welk model het best presteert op jouw data.
-
-### `cumulative_regressor`
-
-Standaard: `"xgboost"`
-
-Het regressiemodel dat vooraanmelderscijfers vertaalt naar verwachte inschrijvingen (stap 2 van het cumulatieve spoor).
-
-| Waarde | Model | Omschrijving |
-|--------|-------|-------------|
-| `xgboost` | XGBoost Regressor | Standaard — gradient boosting, krachtig bij voldoende data |
-| `ridge` | Ridge Regression | L2-regularisatie, stabiel bij weinig trainingsdata en multicollineariteit |
-| `random_forest` | Random Forest | Robuust bij kleine datasets, ingebouwde feature importance |
-
-### `regressor_params` — hyperparameters vastleggen
-
-Optioneel. Een object dat per regressor de hyperparameters vastlegt waarmee het model wordt geïnstantieerd. Niet-opgegeven parameters vallen terug op de modeldefaults. Dit is het **reproduceerbare** pad: de waarden worden bij elke run gebruikt, zonder opnieuw te tunen.
-
-```json
-"model_config": {
-    "cumulative_regressor": "xgboost",
-    "regressor_params": {
-        "xgboost": { "learning_rate": 0.1, "n_estimators": 200, "max_depth": 5 }
-    }
-}
-```
-
-De parameters per regressor worden direct doorgegeven aan het onderliggende model (bijv. `XGBRegressor`, `Ridge`, `RandomForestRegressor`). Alleen het model dat in `cumulative_regressor` actief is, gebruikt zijn parameters; vermeldingen voor andere regressors worden genegeerd.
-
-Vul je dit liever niet handmatig in? Het commando `studentprognose tune -d c` zoekt de beste waarden en print een kant-en-klaar snippet om hier te plakken (zie [Waarden vastleggen](#waarden-vastleggen) hieronder en [XGBoost → Hyperparameter tuning](methodologie/xgboost.md#hyperparameter-tuning)).
-
-### `tuning_grid` — eigen zoekruimte voor tuning
-
-Optioneel. Een object dat de zoekruimte voor `studentprognose tune` (en de API-parameter `tune`) overschrijft: per hyperparameter een lijst van te proberen waarden. Bij afwezigheid wordt de ingebouwde, regularisatie-gerichte standaardgrid gebruikt.
-
-```json
-"model_config": {
-    "tuning_grid": {
-        "max_depth": [3, 5, 7],
-        "n_estimators": [100, 200, 400]
-    }
-}
-```
-
-### `forecaster_params` — SARIMA-ordes vastleggen
-
-Optioneel. Het tijdreeks-equivalent van `regressor_params`: een object dat per forecaster de instantiatie-parameters vastlegt. Voor SARIMA zijn dat de ARIMA-ordes `order` en `seasonal_order`; voor de overige forecasters bijv. `season_length`. Niet-opgegeven waarden vallen terug op de modeldefaults. Ook dit is het **reproduceerbare** pad.
-
-```json
-"model_config": {
-    "cumulative_timeseries": "sarima",
-    "forecaster_params": {
-        "sarima": { "order": [1, 1, 1], "seasonal_order": [1, 1, 0, 52] }
-    }
-}
-```
-
-De vierde waarde van `seasonal_order` is de seizoenslengte; die wordt bij fit nog afgestemd op de werkelijke jaar-periode van je data (net als in productie). Alleen de forecaster die in `cumulative_timeseries` actief is, gebruikt zijn parameters.
-
-### `sarima_tuning_grid` — eigen zoekruimte voor SARIMA-tuning
-
-Optioneel. Net als `tuning_grid`, maar voor `studentprognose tune --tune-target sarima` (en de API `tune="sarima"`/`"both"`): per orde een lijst van te proberen waarden. Bij afwezigheid wordt de ingebouwde SARIMA-grid gebruikt.
-
-```json
-"model_config": {
-    "sarima_tuning_grid": {
-        "order": [[1, 0, 1], [1, 1, 1], [2, 1, 1]],
-        "seasonal_order": [[1, 1, 0, 52], [1, 1, 1, 52]]
-    }
-}
-```
-
-#### Waarden vastleggen
-
-De aanbevolen werkwijze: draai `studentprognose tune -d c -w <week>` (eventueel met `--tune-target sarima` of `both`), kopieer de getoonde snippets naar je `configuration.json`, en draai daarna normaal. Zo zijn de getunede waarden expliciet, reproduceerbaar en deelbaar — in plaats van impliciet bij elke run opnieuw gezocht.
-
-### `final_academic_week`
-
-Standaard: `38`
-
-De **laatste week van het academisch jaar** in de Studielink-cyclus. Bepaalt de seizoensvolgorde van de weken (het jaar loopt van week `final_academic_week + 1` via week 52 door naar `final_academic_week`), de voorspelhorizon (`pred_len`) en de reset-week-injectie in het cumulatieve spoor.
-
-- Het legacy instellingsformaat loopt tot **week 38** (eind september) — dit is de standaard.
-- Het UvA SQL-telbestand levert de aanmeldfase tot **week 36**; er zijn geen leveringen in de weken 37–39. Zet daarvoor `final_academic_week` op `36`.
-
-Een verkeerde waarde laat de cumulatieve voorspelling crashen (de pipeline slicet kolommen tot deze week) of geeft een onjuiste voorspelhorizon. De waarde geldt voor het **cumulatieve spoor**; het individuele spoor gebruikt de vaste Studielink-kalender.
-
-## `cumulative_input` — UvA SQL-telbestand omzetten
-
-Stuurt hoe de ETL-rowbind (`_rowbind_and_reformat`) de ruwe telbestanden uit `path_raw_telbestanden` omzet naar de 16-koloms `vooraanmeldingen_cumulatief.csv`. **De meegeleverde (`init`-)config bevat dit blok al, ingesteld op het raw Studielink SQL-formaat** — dat is de standaard-doelgroep. De `Default`-kolom hieronder beschrijft de code-terugval wanneer je het blok (of een sleutel) volledig weglaat; dan vervalt de ETL naar de legacy-defaults (`;`-gescheiden). Voor het UvA SQL-formaat (zie [Je data voorbereiden](je-data-voorbereiden.md#uva-sql-telbestand-fijnmazig-studielink-formaat)):
-
-```json
-{
-    "cumulative_input": {
-        "separator": ",",
-        "value_maps": {
-            "Type hoger onderwijs": {"P": "Bachelor", "B": "Bachelor", "M": "Master", "A": "Associate degree", "O": "Onbekend"},
-            "Herkomst": {"N": "NL", "E": "EER", "R": "Niet-EER", "O": "Onbekend"}
-        },
-        "faculteit_sentinel": "Onbekend",
-        "aggregate": true,
-        "drop_deleted": true
-    }
-}
-```
-
-| Sleutel | Default | Betekenis |
-|---------|---------|-----------|
-| `separator` | `";"` | Scheidingsteken van de ruwe telbestanden (UvA SQL: `","`). |
-| `rename` | legacy-map | Bronkolom → canonieke kolomnaam. De UvA-bronkolommen (`Brincode`, `Studiejaar`, `Type_HO`, `Isatcode`, `Aantal`) zijn gelijk aan legacy, dus meestal niet nodig. |
-| `value_maps` | legacy-vertalingen | Waardevertalingen per canonieke kolom. Per kolom volledig overschrijfbaar; niet-genoemde kolommen (bijv. `Herinschrijving`/`Hogerejaars`) houden hun default. Niet-gemapte waarden gaan onveranderd door (met een waarschuwing). |
-| `faculteit_sentinel` | `null` | Vulwaarde voor een ontbrekende `Faculteit`. **Moet niet-leeg zijn** als de kolom in de bron ontbreekt: een lege (NaN) Faculteit laat de cumulatieve `groupby`/pivot de rijen vallen. |
-| `programme_name_source` | `"Groepeernaam"` | Bronkolom voor de leesbare opleidingsnaam; valt terug op `Croho` (Isatcode) als de kolom ontbreekt. |
-| `aggregate` | `false` | Tel de fijnmazige rijen op naar de canonieke grain (verplicht voor UvA: bereken `Gewogen` per rij, sommeer daarna; anders crasht de pivot op dubbele indexrijen). |
-| `drop_deleted` | `false` | Filter rijen met `etl_is_deleted != 0` (UvA SQL soft-delete vlag). |
-
-De canonieke output is altijd `;`-gescheiden, ongeacht de input-separator.
+Het bestand heeft de onderstaande secties. De kolom **Pas je aan?** geeft aan hoe vaak je een sectie in de praktijk zelf wijzigt — de meeste kun je op de standaard laten staan.
+
+| Sectie | Pas je aan? | Wat het doet |
+|--------|-------------|--------------|
+| `institution_filter` | Ja | Beperkt de teldata tot je eigen instelling(en). |
+| `numerus_fixus` | Ja | Legt de capaciteit vast van opleidingen met een numerus fixus. |
+| `ensemble_override_cumulative` | Ja | Radboud-specifieke lijst; vervangen of leegmaken voor je eigen instelling. |
+| `exclude_from_combined` | Ja | Radboud-specifieke lijst; vervangen of leegmaken voor je eigen instelling. |
+| `paths` | Zelden | Bestandspaden voor input- en outputbestanden. |
+| `telbestand_filename_patterns` | Zelden | Herkent telbestanden aan hun bestandsnaam; alleen nodig bij afwijkende naamgeving. |
+| `cumulative_input` | Zelden | Zet ruwe telbestanden om; staat standaard op het Studielink SQL-formaat. |
+| `validation` | Zelden | Overschrijft validatiedrempels; alleen wat afwijkt van de standaard. |
+| `runtime` | Zelden | Uitvoerparameters zoals het aantal CPU-cores. |
+| `model_config` | Zelden | Modelparameters (statusmapping, trainingsjaren, modelkeuze). |
+| `excluded_data_points` | Zelden | Sluit bekende probleemjaren uit de trainingsdata; standaard leeg. |
+| `ensemble_weights` | Zelden | Weegt het individuele en cumulatieve model in het ensemble. |
+| `model_features` | Zelden | Bepaalt welke kolommen als features in de modellen gaan. |
+| `columns` | Zelden | Vertaalt eigen kolomnamen naar de namen die de pipeline verwacht. |
+| `column_roles` | Nee | Interne koppeling van rollen aan kolomnamen; vrijwel nooit aanpassen. |
 
 ## `numerus_fixus`
 
@@ -259,7 +69,7 @@ Een object met **programmasleutels** als keys en het maximale inschrijvingsaanta
 }
 ```
 
-Als de gesommeerde voorspelling over herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Opleidingen die hier niet staan worden niet gecapped.
+Als de gesommeerde voorspelling het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep — zie [Ratio-model](methodologie/ratio-model.md) voor de achtergrond van die keuze. Opleidingen die hier niet staan worden niet gecapped.
 
 !!! danger "De sleutel moet exact matchen met de programmakolom (`Croho groepeernaam`)"
     De NF-behandeling grijpt **alleen** aan als de sleutel exact overeenkomt met een waarde in de programmakolom van je data. Welk formaat dat is, hangt af van je instelling:
@@ -299,47 +109,6 @@ Het filter grijpt aan op **load-tijd**, vóór preprocessing, zodat zowel de tra
 
 Je kunt deze config-waarde op de commandline overschrijven met de vlag [`--institution`](aan-de-slag.md#-institution) — handig om snel voor één instelling te draaien zonder de config aan te passen.
 
-## `excluded_data_points` — anomaliejaren uitsluiten van trainingsdata
-
-Optionele lijst van filterregels voor het verwijderen van bekende problematische datapunten uit de **trainingsdata**. De tool past de regels toe vóór elk model wordt getraind. Het voorspeljaar (`predict_year`) wordt **altijd** beschermd en nooit uitgesloten, ongeacht de regels.
-
-Gebruik dit alleen voor aantoonbare datakwaliteitsproblemen: foutieve Studielink-snapshots, deadlineverschuivingen die een historische reeks onvergelijkbaar maken, of structureel afwijkende populaties. Uitsluiten om een betere modelfit te forceren is misbruik — documenteer altijd de reden.
-
-```json
-{
-    "excluded_data_points": [
-        {
-            "year": 2024,
-            "herkomst": "Niet-EER",
-            "examentype": ["Bachelor", "Pre-master"]
-        },
-        {
-            "year_before": 2024,
-            "examentype": "Pre-master",
-            "opleiding": "B Voorbeeldopleiding"
-        }
-    ]
-}
-```
-
-### Filtersleutels per regel
-
-Alle sleutels binnen één regel worden gecombineerd met **AND**. Meerdere regels worden gecombineerd met **OR**.
-
-| Sleutel | Type | Omschrijving |
-|---------|------|-------------|
-| `year` | `int` | Sluit exact dit collegejaar uit |
-| `year_before` | `int` | Sluit alle jaren vóór (exclusief) deze waarde uit |
-| `year_after` | `int` | Sluit alle jaren na (exclusief) deze waarde uit |
-| `herkomst` | `str` of `list[str]` | Filter op herkomst (`"NL"`, `"EER"`, `"Niet-EER"`) |
-| `examentype` | `str` of `list[str]` | Filter op examentype (`"Bachelor"`, `"Master"`, `"Pre-master"`) |
-| `opleiding` | `str` of `list[str]` | Filter op `Croho groepeernaam` |
-
-Een lege lijst (`[]`) schakelt uitsluiting volledig uit — dit is de standaard.
-
-!!! warning "Gebruik dit bewust"
-    Elk uitgesloten datapunt verkleint de trainingsset. Bij kleine opleidingen kan dat de modelkwaliteit ernstig verslechteren. Beperk uitsluiting tot jaren waarvan je kunt aantonen dat de data structureel fout of onvergelijkbaar is.
-
 ## `ensemble_override_cumulative` — ensemble-uitzondering per opleiding
 
 Een lijst van opleidingsnamen (op `Croho groepeernaam`) waarvoor de ensemble-logica altijd het SARIMA-cumulatief model gebruikt, ongeacht weeknummer of examentype.
@@ -374,140 +143,7 @@ Gebruik dit voor opleidingen waarvoor de combined-modus aantoonbaar slechter wer
 
 De waarde in de demo-configuratie is Radboud-specifiek. **Vervang of maak deze lijst leeg voor je eigen instelling.**
 
-## `ensemble_weights` — weging SARIMA-individueel vs. SARIMA-cumulatief
+## Overige secties (referentie)
 
-Bepaalt per weekperiode hoe zwaar het individuele en het cumulatieve SARIMA-model meewegen in de ensemble-voorspelling. Elke sleutel is een situatie; de waarde is een object met `individual` en `cumulative` (moeten optellen tot 1.0).
+Alle secties met **Zelden** of **Nee** in de tabel hierboven — paden, kolomnamen, modelparameters, validatiedrempels, ensemble-gewichten — staan op de aparte pagina **[Configuratie — referentie](configuratie-referentie.md)**. Je hebt ze voor een gewone run niet nodig.
 
-```json
-{
-    "ensemble_weights": {
-        "master_week_17_23": {"individual": 0.2, "cumulative": 0.8},
-        "week_30_34":        {"individual": 0.6, "cumulative": 0.4},
-        "week_35_37":        {"individual": 0.7, "cumulative": 0.3},
-        "default":           {"individual": 0.5, "cumulative": 0.5}
-    }
-}
-```
-
-| Sleutel | Van toepassing wanneer |
-|---------|----------------------|
-| `master_week_17_23` | Examentype = Master én weeknummer 17–23 |
-| `week_30_34` | Weeknummer 30–34 |
-| `week_35_37` | Weeknummer 35 t/m `final_academic_week - 1` |
-| `default` | Alle overige gevallen |
-
-De einddeadline (`final_academic_week`, standaard week 38; UvA week 36) is altijd 100% individueel en wordt niet door deze instelling beïnvloed. Zie [Ensemble](methodologie/ensemble.md) voor achtergrond bij de keuze van gewichten.
-
-!!! note "Weekgrenzen volgen `final_academic_week`"
-    De sleutelnamen (zoals `week_30_34`) beschrijven de weekperiode waarop een gewicht van toepassing is; de **gewichten** zijn instelbaar via dit blok. De bovengrens van `week_35_37` en de 100%-individueel-eindweek schalen mee met [`model_config.final_academic_week`](#final_academic_week) (bij week 36 loopt `week_35_37` dus alleen over week 35). De overige weekgrenzen (17–23, 30–34) liggen vast in `output/postprocessor.py` en vereisen een codewijziging om aan te passen.
-
-## `columns` — kolomnamen mapping
-
-Maakt het mogelijk dat instellingen andere kolomnamen gebruiken dan de kanonieke namen die de pipeline intern hanteert. Specificeer alleen de namen die afwijken — ontbrekende sleutels vallen terug op de kanonieke naam.
-
-### `individual` — individuele aanmelddata
-
-Volledige lijst van kanonieke kolomnamen die gemapped kunnen worden:
-
-`Sleutel`, `Datum Verzoek Inschr`, `Ingangsdatum`, `Collegejaar`, `Datum intrekking vooraanmelding`, `Inschrijfstatus`, `Faculteit`, `Examentype`, `Croho`, `Croho groepeernaam`, `Opleiding`, `Hoofdopleiding`, `Eerstejaars croho jaar`, `Is eerstejaars croho opleiding`, `Is hogerejaars`, `BBC ontvangen`, `Type vooropleiding`, `Nationaliteit`, `EER`, `Geslacht`, `Geverifieerd adres postcode`, `Geverifieerd adres plaats`, `Geverifieerd adres land`, `Studieadres postcode`, `Studieadres land`, `School code eerste vooropleiding`, `School eerste vooropleiding`, `Plaats code eerste vooropleiding`, `Land code eerste vooropleiding`, `Aantal studenten`
-
-### `oktober` — telbestand studenten
-
-`Collegejaar`, `Isatcode`, `Groepeernaam Croho`, `Aantal eerstejaars croho`, `EER-NL-nietEER`, `Examentype code`, `Aantal Hoofdinschrijvingen`
-
-De sleutel heet `oktober` om historische redenen — zie [Je data voorbereiden](je-data-voorbereiden.md#telbestand-studenten). `Isatcode` is de **joinsleutel** met de vooraanmeldingen (de studentaantallen worden hierop gekoppeld, niet op `Groepeernaam Croho`); zorg dat de codes overeenkomen met die in je telbestanden.
-
-### `cumulative` — Studielink cumulatieve data
-
-`Korte naam instelling`, `Collegejaar`, `Weeknummer rapportage`, `Weeknummer`, `Faculteit`, `Type hoger onderwijs`, `Groepeernaam Croho`, `Naam Croho opleiding Nederlands`, `Croho`, `Herinschrijving`, `Hogerejaars`, `Herkomst`, `Gewogen vooraanmelders`, `Ongewogen vooraanmelders`, `Aantal aanmelders met 1 aanmelding`, `Inschrijvingen`
-
-Dit zijn de kolommen ná de ETL-transformatie (na het inlezen en hernoemen van de ruwe Studielink-velden). Zie [Studielink telbestanden](je-data-voorbereiden.md#studielink-telbestanden) voor de mapping van ruwe PvL-velden naar deze kanonieke namen.
-
-## `column_roles` — semantische rollen → kanonieke kolomnaam
-
-Waar `columns` instellings-specifieke namen vertaalt naar kanonieke namen, koppelt `column_roles` een **semantische rol** (die de code intern gebruikt) aan de kanonieke kolomnaam. De pipeline benadert kolommen via deze rollen (bijv. `programme`, `academic_year`, `origin`), zodat een hernoeming op één plek volstaat.
-
-| Rol | Standaard kolom | Rol | Standaard kolom |
-|-----|-----------------|-----|-----------------|
-| `academic_year` | `Collegejaar` | `week` | `Weeknummer` |
-| `programme` | `Croho groepeernaam` | `exam_type` | `Examentype` |
-| `origin` | `Herkomst` | `faculty` | `Faculteit` |
-| `enrollment_status` | `Inschrijfstatus` | `cancellation_date` | `Datum intrekking vooraanmelding` |
-| `student_count` | `Aantal_studenten` | `enrollments` | `Inschrijvingen` |
-| `weighted_applicants` | `Gewogen vooraanmelders` | `unweighted_applicants` | `Ongewogen vooraanmelders` |
-| `single_applicants` | `Aantal aanmelders met 1 aanmelding` | `higher_years` | `Hogerejaars` |
-| `croho_source` | `Groepeernaam Croho` | `higher_education_type` | `Type hoger onderwijs` |
-| `institution` | `Korte naam instelling` | | |
-
-De rol `institution` bepaalt op welke kolom [`institution_filter`](#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen) filtert.
-
-Pas dit alleen aan als je de **interne** kanonieke namen wijzigt — in de meeste gevallen gebruik je `columns` (voor je ruwe inputkolommen) en laat je `column_roles` ongemoeid.
-
-## `model_features` — featurelijsten per model
-
-Bepaalt welke kolommen als features in de modellen gaan. Twee subsleutels:
-
-- `classifier` — de individuele XGBoost-classifier, met `numeric` en `categorical` featurelijsten (zie [XGBoost](methodologie/xgboost.md#features)).
-- `regressor` — de cumulatieve XGBoost-regressor, met een `categorical` featurelijst; numerieke features (vooraanmelders, lags, acceleratie) worden afgeleid tijdens feature-engineering.
-
-Voeg of verwijder features hier als je inputdata extra (of minder) kolommen bevat. Verwijderde features mogen niet meer in `columns`/`column_roles` als verplicht gemarkeerd staan.
-
-## `validation` — validatiedrempels overschrijven
-
-Optionele sectie. Hoeft niet in je configuratiebestand te staan. Voeg alleen toe wat afwijkt van de standaard:
-
-```json
-{
-    "validation": {
-        "nan_error_threshold": 0.20,
-        "telbestand": {
-            "herkomst_allowed": ["N", "E", "R", "ONBEKEND"]
-        }
-    }
-}
-```
-
-| Sleutel | Standaard | Omschrijving |
-|---------|-----------|-------------|
-| `nan_warning_threshold` | `0.05` | Fractie ontbrekende waarden die een waarschuwing geeft |
-| `nan_error_threshold` | `0.30` | Fractie ontbrekende waarden die een fout geeft |
-| `collegejaar_min_offset` | `15` | Collegejaren ouder dan `huidig jaar - 15` geven een fout |
-| `collegejaar_max_offset` | `2` | Collegejaren na `huidig jaar + 2` geven een fout |
-| `telbestand.herkomst_allowed` | `["N","E","R"]` | Toegestane herkomstwaarden in telbestanden |
-| `telbestand.required_columns` | legacy-lijst | Vereiste ruwe kolommen. Het UvA SQL-formaat mist `Groepeernaam`, dus zet hier een lijst zonder die kolom. |
-| `telbestand.separator` | `";"` | Scheidingsteken waarmee de validatie de telbestanden inleest. Zet op `","` voor het UvA SQL-formaat (gelijk aan `cumulative_input.separator`). |
-| `telbestand.programme_column` | `"Groepeernaam"` | Kolom waarop categorale fouten worden gegroepeerd. Zet op `"Isatcode"` als `Groepeernaam` ontbreekt (UvA). |
-
-Net als bij `cumulative_input` levert de meegeleverde (`init`-)config dit `validation.telbestand`-blok al mee, ingesteld op het raw Studielink SQL-formaat; de `Standaard`-kolom beschrijft de code-terugval als je een sleutel weglaat. De `validation`-overrides en het [`cumulative_input`](#cumulative_input-uva-sql-telbestand-omzetten)-blok horen samen; ze beschrijven hetzelfde ruwe formaat voor respectievelijk de validatie en de ETL:
-
-```json
-{
-    "validation": {
-        "telbestand": {
-            "separator": ",",
-            "programme_column": "Isatcode",
-            "required_columns": ["Studiejaar", "Isatcode", "Aantal", "meercode_V", "Status", "Herinschrijving", "Hogerejaars", "Herkomst"],
-            "herkomst_allowed": ["N", "E", "R", "O"]
-        }
-    }
-}
-```
-
-Zie [Validatie](validatie.md) voor een volledig overzicht van alle controles.
-
-## Voorbeeld minimale configuratie
-
-Omdat de pipeline standaardwaarden inbouwt, hoef je alleen te specificeren wat afwijkt. Een typische startconfiguratie bevat alleen de instelling-specifieke velden:
-
-```json
-{
-    "numerus_fixus": {
-        "B Geneeskunde": 340
-    },
-    "ensemble_override_cumulative": [
-        "B Geneeskunde"
-    ]
-}
-```
-
-Alle overige velden — paden, kolomnamen, modelparameters, ensemble-gewichten — vallen terug op de ingebakken standaardwaarden. Voer `studentprognose init` uit om een volledig ingevuld startbestand te krijgen dat je als referentie kunt gebruiken.

--- a/docs/gevorderd-gebruik.md
+++ b/docs/gevorderd-gebruik.md
@@ -1,0 +1,330 @@
+# Gevorderd gebruik
+
+Deze pagina bundelt de gevorderde onderwerpen die je **niet** nodig hebt voor een gewone prognose: de tool aanroepen vanuit Python (notebooks, cloud), hyperparameters afstemmen, en het model evalueren met scalaire metrieken. Voor de dagelijkse workflow — zie de [Snelstart](snelstart.md) en [Draaien & CLI](aan-de-slag.md).
+
+!!! tip "Heb je dit nodig?"
+    Wil je gewoon een prognose draaien via de command line? Dan kun je deze pagina overslaan. Ze is bedoeld voor gebruikers die de tool in een eigen (cloud)pipeline inbouwen, of die de modellen willen afstemmen en evalueren.
+
+## Gebruik als Python-package
+
+Naast de CLI kun je `studentprognose` ook direct vanuit Python-scripts importeren. Dit is handig voor geautomatiseerde pipelines, notebooks, of cloudworkflows waarbij de data al in-memory beschikbaar is.
+
+!!! tip "Uitvoerbaar voorbeeld — implementatienotebook"
+    Voor een direct inpasbaar startpunt voor MS Fabric, Databricks of Azure: zie [`notebooks/implementatie.ipynb`](https://github.com/cedanl/studentprognose/blob/main/notebooks/implementatie.ipynb). Vereist alleen `pip install studentprognose` — geen repo-clone nodig.
+
+### Beschikbare bouwstenen
+
+```python
+from studentprognose import (
+    load_configuration,            # laad configuration.json (of package defaults)
+    load_filtering,                # laad filtering JSON (of package defaults)
+    load_data,                     # laad data vanaf schijf als DataFrames
+    run_pipeline_cli,              # volledige CLI-pipeline (accepteert argv-lijst)
+    run_pipeline_from_dataframes,  # pipeline met DataFrames in-memory
+    build_dashboard_from_dataframes,  # interactieve HTML-dashboards uit DataFrames
+    evaluate_predictions,          # output → scalaire evaluatiemetrieken per model
+    pivot_metrics,                 # metrieken → model × jaar/week-matrix (backtest)
+    to_mlflow_metrics,             # metrieken afvlakken voor mlflow.log_metrics (Fabric)
+    PipelineConfig,                # configuratie-dataclass voor de pipeline
+    DataOption,                    # enum: INDIVIDUAL / CUMULATIVE / BOTH_DATASETS
+    StudentYearPrediction,         # enum: FIRST_YEARS / VOLUME
+)
+```
+
+!!! tip "Het model evalueren"
+    `evaluate_predictions` zet de pipeline-output om in scalaire metrieken (MAE, MAPE,
+    WAPE, RMSE, bias, R²) per model; `pivot_metrics` vat een backtest over meerdere jaren
+    samen tot een model × jaar-matrix; en `to_mlflow_metrics` levert ze klaar voor MLflow
+    in MS Fabric / Databricks. Zie [Het model evalueren](#het-model-evalueren).
+
+### Minimaal werkend voorbeeld (bestandsgebaseerd)
+
+```python
+from studentprognose import run_pipeline_cli
+
+# Zelfde als de CLI — start de volledige pipeline inclusief ETL
+run_pipeline_cli(["studentprognose", "-d", "c", "-y", "2025", "-w", "10"])
+
+# Of sla ETL over als de data al verwerkt is
+run_pipeline_cli(["studentprognose", "--noetl", "-d", "c", "-y", "2025", "-w", "10"])
+```
+
+### Cloud-gebruik (data al in-memory)
+
+Gebruik `run_pipeline_from_dataframes` als je de data al geladen hebt, bijvoorbeeld vanuit Azure Blob Storage of Amazon S3. De ETL-stap wordt volledig overgeslagen.
+
+```python
+import pandas as pd
+from studentprognose import run_pipeline_from_dataframes, DataOption
+
+# Laad data uit cloud-opslag (voorbeeld met Azure SDK)
+# from azure.storage.blob import BlobServiceClient
+# blob_data = blob_client.download_blob().readall()
+# df_cum = pd.read_csv(io.BytesIO(blob_data), sep=";", skiprows=[1])
+
+# Of lokaal voor testen
+df_cum = pd.read_csv("vooraanmeldingen_cumulatief.csv", sep=";", skiprows=[1])
+
+result = run_pipeline_from_dataframes(
+    year=2025,
+    week=10,
+    data_cumulative=df_cum,
+    dataset=DataOption.CUMULATIVE,
+    save_output=False,  # geen lokale uitvoerbestanden aanmaken (ook geen tussenresultaat)
+)
+
+if result is not None:
+    print(result[["Croho groepeernaam", "Weighted_ensemble_prediction"]].head())
+```
+
+De functie accepteert ook een eigen configuratiedict, zodat je geen bestandssysteem nodig hebt:
+
+```python
+from studentprognose import run_pipeline_from_dataframes, DataOption
+from studentprognose.config import load_defaults
+
+# Begin met package-defaults en pas aan
+config = load_defaults()
+config["numerus_fixus"] = ["B Geneeskunde", "B Tandheelkunde"]
+
+result = run_pipeline_from_dataframes(
+    year=2025,
+    week=10,
+    data_cumulative=df_cum,
+    configuration=config,
+    dataset=DataOption.CUMULATIVE,
+)
+```
+
+!!! warning "`year`/`week` moeten binnen je trainingsdata vallen"
+    `run_pipeline_from_dataframes` controleert — net als de CLI — of `year` en `week`
+    voorkomen in de meegegeven DataFrames. Valt een van beide buiten bereik, dan krijg je
+    een heldere `ValueError` met de wél beschikbare range, in plaats van een stille `None`
+    of een onverwachte kernel-crash in een notebook.
+
+    ```python
+    # Stel: je data loopt t/m 2025
+    run_pipeline_from_dataframes(
+        year=2030,            # buiten bereik
+        week=10,
+        data_cumulative=df_cum,
+        dataset=DataOption.CUMULATIVE,
+    )
+    # ValueError: year=2030 valt buiten de beschikbare trainingsdata.
+    #   Beschikbare data: jaren 2018-2025, weken 1-52.
+    #   Pas year/week aan binnen deze range, of voeg trainingsdata toe.
+    ```
+
+    Pas `year`/`week` aan binnen de range, of voeg aanvullende trainingsdata toe.
+
+### Dashboards genereren vanuit DataFrames
+
+De interactieve Plotly-dashboards (die de CLI met `--dashboard` maakt) kun je vanuit een
+notebook of cloud-run genereren met `build_dashboard_from_dataframes`. Dit is een
+**aparte functie** die je ná (of in plaats van) `run_pipeline_from_dataframes` aanroept,
+met dezelfde in-memory DataFrames. Ze draait de pipeline (zonder iets naar schijf te
+schrijven) en schrijft daarna de dashboards weg naar `<cwd>/data/output/visualisations/`.
+
+```python
+from studentprognose import build_dashboard_from_dataframes, DataOption
+
+output_dir = build_dashboard_from_dataframes(
+    year=2025,
+    week=10,
+    data_cumulative=df_cum,
+    data_student_numbers=sc,   # nodig voor de realisatie-/conversiegrafieken
+    dataset=DataOption.CUMULATIVE,
+    configuration=config,
+)
+print(f"Dashboards geschreven naar {output_dir}")
+# -> <cwd>/data/output/visualisations/{individual,cumulative,final}/dashboard.html
+```
+
+!!! tip "Losse functie, geen extra parameter"
+    Het dashboard is bewust een aparte functie en géén parameter op
+    `run_pipeline_from_dataframes`: zo blijft de voorspelfunctie ongewijzigd en is de
+    dashboard-stap los te draaien en te testen. Gebruik `cwd` om de uitvoermap te sturen.
+    De `year`/`week`-rangecontrole is identiek aan die van `run_pipeline_from_dataframes`;
+    komt geen enkele rij door de filters, dan krijg je een heldere `ValueError` in plaats
+    van een leeg dashboard.
+
+## Hyperparameter tuning
+
+Het cumulatieve spoor is twee-traps en je kunt **beide trappen** afstemmen op je
+eigen data:
+
+| Trap | Wat | Wat tuning kiest | Vastgelegd in |
+|------|-----|------------------|---------------|
+| **Stap 1 — SARIMA** | extrapoleert de vooraanmeldcurve | ARIMA-ordes `(p,d,q)(P,D,Q,s)` | `forecaster_params.sarima` |
+| **Stap 2 — regressor** | vertaalt de curve naar inschrijvingen | hyperparameters (default XGBoost) | `regressor_params.<naam>` |
+
+Beide gebruiken een **tijd-bewuste** zoektocht (geen random k-fold — dat lekt
+toekomst) met dezelfde MAPE-metriek als de [benchmark](methodologie/benchmarks.md),
+en laten het operationele voorspelpad standaard onaangeroerd. Zie
+[XGBoost → Hyperparameter tuning](methodologie/xgboost.md#hyperparameter-tuning)
+(regressor) en [SARIMA → Orde-selectie](methodologie/sarima.md#orde-selectie-tuning)
+voor de methodologie.
+
+### Via de CLI — zoeken en vastleggen
+
+```bash
+studentprognose tune -d c -w 12                    # default: regressor (stap 2)
+studentprognose tune -d c -w 12 --tune-target sarima   # alleen SARIMA (stap 1)
+studentprognose tune -d c -w 12 --tune-target both     # beide trappen
+```
+
+Dit draait de zoektocht op je geladen data, print per trap een overzicht van alle
+geteste sets met hun MAPE (de best presterende set gemarkeerd met `✓`), en geeft
+een kant-en-klaar config-snippet terug. Plak dat snippet in `configuration.json`
+om de gevonden waarden vast te leggen (zie
+[Configuratie → vastleggen](configuratie-referentie.md#waarden-vastleggen)).
+Vastgelegde waarden zijn reproduceerbaar: ze worden bij elke run gebruikt zonder
+opnieuw te tunen.
+
+### Via de Python-API — tunen en voorspellen in één keer
+
+`run_pipeline_from_dataframes` heeft een `tune`-parameter (standaard `False`) waarmee
+je kiest **welke trap(pen)** getuned worden:
+
+```python
+result = run_pipeline_from_dataframes(
+    year=2025,
+    week=10,
+    data_cumulative=df_cum,
+    data_student_numbers=data_studentcount,
+    dataset=DataOption.CUMULATIVE,
+    tune="both",  # tune stap 1 (SARIMA) én stap 2 (regressor), daarna voorspellen
+)
+```
+
+De ondersteunde waarden:
+
+| `tune=` | Wat wordt getuned |
+|---------|-------------------|
+| `False` *(default)* | niets — gebruikt vastgelegde/default-waarden |
+| `True` of `"regressor"` | alleen de regressor (stap 2) |
+| `"sarima"` | alleen SARIMA-ordes (stap 1) |
+| `"both"` | beide trappen, elk apart gelogd |
+| `{"regressor": {...}, "sarima": {...}}` | beide/één trap met **eigen zoekruimte** (waarde weglaten of `None` = ingebouwde grid) |
+
+Elke gekozen trap draait de zoektocht éénmaal, voorspelt met de beste waarden en
+koppelt ze terug in de configuratie zodat je ze kunt vastleggen. Het overzicht (met
+`✓` op de winnaar) gaat naar de console; de functie **retourneert het
+voorspellings-DataFrame**, niet het tuning-resultaat.
+
+Bij `tune="both"` zie je twee aparte tabellen — één per trap, elk met een eigen `✓`:
+
+```
+           MAPE   Folds  Parameters
+  ─────────────────────────────────
+  ✓      0.0912       6  {"order": [1, 1, 1], "seasonal_order": [1, 1, 0, 52]}
+         0.1041       6  {"order": [1, 0, 1], "seasonal_order": [1, 1, 1, 52]}
+
+Beste parameters voor 'sarima' (MAPE=0.0912, 6 kandidaten):
+Plak dit in je configuration.json om de ordes vast te leggen:
+{ "model_config": { "forecaster_params": { "sarima": { ... } } } }
+
+           MAPE   Folds  Parameters
+  ─────────────────────────────────
+  ✓      0.1424      12  {"learning_rate": 0.25, "n_estimators": 200, "max_depth": 5}
+         0.1487      12  {"learning_rate": 0.1, "n_estimators": 200, "max_depth": 3}
+
+Beste parameters voor 'xgboost' (MAPE=0.1424, 12 kandidaten):
+Plak dit in je configuration.json om de parameters vast te leggen:
+{ "model_config": { "regressor_params": { "xgboost": { ... } } } }
+```
+
+!!! note "Tuning is opt-in"
+    Standaard (`tune=False`) gebruikt de pipeline de waarden uit
+    `model_config.regressor_params` / `forecaster_params` of de modeldefaults —
+    snel en reproduceerbaar. Zet `tune` alleen aan wanneer je bewust wilt afstemmen;
+    het maakt de run langzamer en, zonder de uitkomst vast te leggen,
+    niet-deterministisch.
+
+## Het model evalueren
+
+De per-rij `MAE_*`/`MAPE_*`-kolommen in de [output](output-begrijpen.md#foutmaatkolommen) zijn handig om één rij te lezen, maar voor **modelevaluatie** wil je geaggregeerde, scalaire metrieken (één getal per model). Daarvoor levert het pakket `evaluate_predictions`:
+
+```python
+from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, DataOption
+
+result = run_pipeline_from_dataframes(
+    year=2023, week=12,
+    data_cumulative=df_cum, data_student_numbers=df_sc,
+    dataset=DataOption.CUMULATIVE, save_output=False,
+)
+
+metrics = evaluate_predictions(result, week=12)
+print(metrics)
+```
+
+De functie vergelijkt elke voorspelkolom met de gerealiseerde `Aantal_studenten` en geeft per model één rij terug met:
+
+| Metriek | Betekenis | Interpretatie |
+|---------|-----------|---------------|
+| `n` | aantal meegetelde (opleiding × herkomst)-rijen | klein `n` → metriek is ruisgevoelig |
+| `mae` | Mean Absolute Error | gemiddelde afwijking in studenten |
+| `mape` | Mean Absolute Percentage Error (fractie) | elke opleiding telt even zwaar — kleine opleidingen domineren |
+| `wape` | Weighted APE = `Σ\|fout\| / Σ\|werkelijk\|` (fractie) | instellingsbrede procentuele fout, robuust tegen kleine opleidingen |
+| `rmse` | Root Mean Squared Error | straft grote uitschieters zwaarder |
+| `bias` | gemiddelde `voorspeld − werkelijk` | positief = structurele overschatting |
+| `r2` | determinatiecoëfficiënt | aandeel verklaarde variantie |
+
+`mape` en `wape` zijn fracties (`0.08` betekent 8%). De metrieken gebruiken dezelfde primitieven en numerus-fixus-uitsluiting als de `MAE_*`-kolommen, dus ze zijn consistent met de rest van de output.
+
+!!! warning "Evalueren kan alleen via een backtest"
+    Een model evalueren betekent voorspellingen vergelijken met de **gerealiseerde** instroom. Voor het lopende, nog niet afgeronde collegejaar bestaat die realisatie nog niet — `Aantal_studenten` is dan leeg en `evaluate_predictions` geeft een foutmelding. Evalueer daarom een **afgerond** collegejaar (bijv. voorspel `year=2023` terwijl je de realisatie van 2023 als `data_student_numbers` meegeeft). De modellen trainen sowieso alleen op jaren vóór het voorspeljaar, dus zo'n backtest lekt geen toekomstinformatie.
+
+!!! tip "Geef altijd `week` mee bij cumulatieve output"
+    In het cumulatieve spoor draagt alleen de **peilweekrij** de `SARIMA_cumulative`-voorspelling; latere weken bevatten enkel de vooraanmeldcurve (met `NaN` als voorspelling). Zonder `week=`-filter mengt `Prognose_ratio` bovendien meerdere weken. Geef de gebruikte peilweek mee (`evaluate_predictions(result, week=12)`) voor een zuivere, één-rij-per-opleiding vergelijking tussen modellen.
+
+Segmenteer met `group_by` (bijv. `group_by="Examentype"` of `group_by=["Examentype", "Herkomst"]`) om te zien waar een model structureel afwijkt.
+
+### Backtesten over meerdere jaren (`pivot_metrics`)
+
+Eén afgerond jaar is **één datapunt**: de instroom schommelt jaar-op-jaar om redenen buiten het model. Voor een eerlijk beeld backtest je daarom meerdere afgeronde jaren op dezelfde peilweek, evalueer je per jaar met `group_by="Collegejaar"`, en draai je het resultaat met `pivot_metrics` tot een model × jaar-matrix:
+
+```python
+import pandas as pd
+from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, pivot_metrics, DataOption
+
+WEEK = 10
+frames = [
+    run_pipeline_from_dataframes(
+        year=jaar, week=WEEK, data_cumulative=df_cum,
+        data_student_numbers=df_sc, dataset=DataOption.CUMULATIVE, save_output=False,
+    )
+    for jaar in (2021, 2022, 2023)            # afgeronde jaren met realisatie
+]
+
+metrics = evaluate_predictions(pd.concat(frames, ignore_index=True),
+                               week=WEEK, group_by="Collegejaar")
+print(pivot_metrics(metrics, value="wape", over="Collegejaar").round(3))
+```
+
+```text
+                    2021   2022   2023   mean    min    max  n_groups
+prediction
+Prognose_ratio     0.078  0.071  0.069  0.073  0.069  0.078         3
+SARIMA_cumulative  0.063  0.058  0.066  0.062  0.058  0.066         3
+```
+
+De `mean`-kolom is het gemiddelde over de jaren; `min`/`max` tonen de spreiding. Ligt de jaar-op-jaar spreiding in dezelfde orde als het verschil tussen modellen, trek dan geen harde conclusie uit één jaar. Kies met `value=` een andere metriek (`"mae"`, `"mape"`, …) en met `over=` een andere as (bijv. `over="Weeknummer"` voor de accuraatheid-over-tijd-curve bij één jaar).
+
+### Metrieken loggen in MS Fabric / Databricks (MLflow)
+
+Beide platforms hebben **MLflow** als ingebouwde experiment-tracker. `to_mlflow_metrics` vlakt het resultaat af tot een dict die je direct kunt loggen, zodat de metrieken in de Fabric/Databricks ML-experiment-UI verschijnen en over runs (jaar/peilweek) vergelijkbaar zijn:
+
+```python
+import mlflow
+from studentprognose import evaluate_predictions, to_mlflow_metrics
+
+metrics = evaluate_predictions(result, week=WEEK)
+
+with mlflow.start_run(run_name=f"prognose_{YEAR}_wk{WEEK}"):
+    mlflow.log_params({"year": YEAR, "week": WEEK, "dataset": "cumulatief"})
+    mlflow.log_metrics(to_mlflow_metrics(metrics))
+    mlflow.log_table(metrics, "metrics.json")  # volledige tabel als artifact
+```
+
+`mlflow` zit standaard in de Fabric- en Databricks-runtime; in een Fabric-notebook worden runs automatisch aan het gekoppelde experiment gehangen. Wil je geen MLflow gebruiken, dan kun je het `metrics`-DataFrame ook gewoon naar een Lakehouse/Delta-tabel wegschrijven voor je eigen monitoring.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,61 +1,51 @@
 # Studentprognose
 
-**Studentprognose** is een open-source tool van CEDA/Npuls voor het voorspellen van eerstejaars instroom in het hoger onderwijs. Het combineert tijdreeksmodellen (SARIMA), machine learning (XGBoost) en een ratio-model tot een ensemble-voorspelling.
+**Studentprognose** voorspelt hoeveel eerstejaars zich uiteindelijk inschrijven — maanden vooruit, op basis van je eigen (voor)aanmelddata. Het is een open-source tool van CEDA/Npuls die tijdreeksmodellen (SARIMA), machine learning (XGBoost) en een ratio-model combineert tot één ensemble-voorspelling.
+
+<iframe src="assets/plots/whatif_funnel.html" width="100%" height="420" frameborder="0" style="border-radius: 8px;"></iframe>
+
+*Van vooraanmelders op een peilmoment naar het verwachte aantal inschrijvingen — voorbeeld op de meegeleverde demodata.*
+
+## Snel beginnen
+
+```bash
+uv tool install studentprognose   # zie Installeren voor uv/pip/Windows
+studentprognose init              # projectmap aanmaken
+studentprognose                   # eerste prognose (op demodata)
+```
+
+Er zit **demodata** in de installatie, dus je kunt direct draaien zonder eigen data. Details in **[Installeren](installeren.md)** en de **[Snelstart](snelstart.md)** (5 minuten).
+
+## Wat doet de tool?
+
+Je kiest een **peilweek** en een **collegejaar**, en de tool geeft een prognose van het uiteindelijke aantal inschrijvingen. Onder water lopen tot drie sporen, afhankelijk van je data:
+
+| Modus | Vlag | Databron | Wat het doet |
+|-------|------|----------|--------------|
+| Cumulatief | `-d c` | Studielink-telbestanden | Trekt de aanmeldcurve door naar het einde van het seizoen |
+| Individueel | `-d i` | Osiris/Usis per student | Schat per aanmelder de inschrijfkans, telt die op |
+| Beide | `-d b` | Beide bronnen (standaard) | Combineert beide sporen tot één ensemble-voorspelling |
+
+Zie [Methodologie](methodologie/index.md) voor de uitleg per model en [Begrippen](begrippen.md) voor onbekende termen.
+
+## Zo ziet de output eruit
+
+Naast Excel-bestanden genereert de tool desgewenst interactieve dashboards (`--dashboard`):
+
+<iframe src="assets/plots/output_cockpit.html" width="100%" height="400" frameborder="0" style="border-radius: 8px;"></iframe>
+
+Zie [Output lezen](output-begrijpen.md) voor uitleg van elk cijfer en wanneer je een prognose wel of niet moet vertrouwen.
 
 ## Voor wie is deze documentatie?
 
-Deze documentatie richt zich op **data-analisten en onderzoekers** bij Nederlandse onderwijsinstellingen. De focus ligt niet alleen op *hoe* je de tool gebruikt, maar ook op *waarom* het model werkt zoals het werkt — inclusief aannames, beperkingen en situaties waarin je de output kritisch moet interpreteren.
+Voor **data-analisten en onderzoekers** bij Nederlandse onderwijsinstellingen. Je hebt géén machine learning-expertise nodig. De focus ligt niet alleen op *hoe* je de tool gebruikt, maar ook op *waarom* het model werkt zoals het werkt — inclusief aannames, beperkingen en wanneer je de output kritisch moet interpreteren.
 
-## Snelstart
-
-Vereisten: **Python 3.12+** ([installatie-instructies](aan-de-slag.md#voordat-je-begint))
-
-```bash
-uv tool install studentprognose
-```
-
-Heb je [uv](https://docs.astral.sh/uv/) nog niet, of werk je liever met pip? Zie [Aan de slag → Installatie](aan-de-slag.md#installatie).
-
-Daarna:
-
-```bash
-studentprognose init      # mapstructuur + configuratie aanmaken
-studentprognose --help    # alle opties bekijken
-```
-
-Zie [Aan de slag](aan-de-slag.md) voor een complete walkthrough inclusief data klaarzetten en je eerste run.
-
-!!! tip "Heb je al verwerkte data?"
-    Als je verwerkte bestanden hebt die voldoen aan het [verwachte schema](je-data-voorbereiden.md#verwerkte-inputbestanden-data-input) (kolommen, types, namen), kun je de ETL overslaan met `--noetl`. Zie [ETL overslaan](je-data-voorbereiden.md#etl-overslaan) voor de exacte vereisten.
-
-## Architectuur op hoofdlijnen
-
-Het model kent drie verwerkingssporen, afhankelijk van de beschikbare data:
-
-| Modus | Vlag | Databron | Modellen |
-|-------|------|----------|----------|
-| Cumulatief | `-d c` | Studielink telbestanden | SARIMA + XGBoost regressor |
-| Individueel | `-d i` | Osiris/Usis per-student | XGBoost classifier + SARIMA |
-| Beide | `-d b` | Beide bronnen (standaard) | Volledig ensemble |
-
-Zie [Methodologie](methodologie/index.md) voor een diepgaande uitleg per model.
-
-## Uitgebreide voorbeelden — Jupyter notebooks
-
-Naast deze documentatie staan in [`notebooks/`](https://github.com/cedanl/studentprognose/tree/main/notebooks) zeven **uitvoerbare** Jupyter-notebooks die de methodologie-pagina's stap-voor-stap doorlopen op de meegeleverde demodata:
-
-- `00_overzicht.ipynb` — pipeline in vijf minuten
-- `01_data_voorbereiden.ipynb` — data laden en valideren
-- `02_sarima.ipynb` t/m `06_output_interpreteren.ipynb` — een notebook per model + outputuitleg
-
-Ze zijn bedoeld voor data-analisten en onderzoekers die niet alleen *willen lezen* maar ook *willen experimenteren* met parameters, peilweken en opleidingen. Zie [`notebooks/README.md`](https://github.com/cedanl/studentprognose/blob/main/notebooks/README.md) voor de installatie- en draai-instructies.
+!!! tip "Liever experimenteren dan lezen?"
+    In [`notebooks/`](https://github.com/cedanl/studentprognose/tree/main/notebooks) staan zeven **uitvoerbare** Jupyter-notebooks die de methodologie stap-voor-stap doorlopen op de demodata — van `00_overzicht.ipynb` tot `06_output_interpreteren.ipynb`. Zie de [notebooks-README](https://github.com/cedanl/studentprognose/blob/main/notebooks/README.md).
 
 ## In de praktijk
 
-Dit model is oorspronkelijk ontwikkeld door **Radboud Universiteit** en vervolgens samen met CEDA open source gemaakt zodat andere Nederlandse onderwijsinstellingen er ook van kunnen profiteren. Radboud is daarmee de grondlegger van dit project. VOX Nijmegen schreef hierover: [*De universiteit heeft nu haar eigen glazen bol*](https://www.voxweb.nl/nieuws/de-universiteit-heeft-nu-haar-eigen-glazen-bol-nieuw-model-voorspelt-toekomstige-instroom-van-studenten).
+Dit model is oorspronkelijk ontwikkeld door **Radboud Universiteit** en vervolgens samen met CEDA open source gemaakt. VOX Nijmegen schreef hierover: [*De universiteit heeft nu haar eigen glazen bol*](https://www.voxweb.nl/nieuws/de-universiteit-heeft-nu-haar-eigen-glazen-bol-nieuw-model-voorspelt-toekomstige-instroom-van-studenten).
 
 !!! info "Verhouding tot de Radboud-implementatie"
-    De productie-implementatie van Radboud draait intern en is niet publiek toegankelijk. Deze CEDA-versie is de publieke, generieke variant: dezelfde methodologie, maar zonder Radboud-specifieke configuratie.
-
-    - **Uitlegbaarheid** — methodologische keuzes (features, modelparameters, ensemble-gewichten) zijn onderbouwd vanuit een concrete instellingscontext en hier gedocumenteerd.
-    - **Overdraagbaarheid** — Radboud-specifieke logica is in deze versie generiek gemaakt zodat andere instellingen er direct mee aan de slag kunnen.
+    De productie-implementatie van Radboud draait intern en is niet publiek. Deze CEDA-versie is de publieke, generieke variant: dezelfde methodologie, maar zonder Radboud-specifieke configuratie. Methodologische keuzes zijn hier gedocumenteerd, en Radboud-specifieke logica is generiek gemaakt zodat andere instellingen er direct mee aan de slag kunnen.

--- a/docs/installeren.md
+++ b/docs/installeren.md
@@ -1,0 +1,98 @@
+# Installeren
+
+Je hebt **Python 3.12** en **[uv](https://docs.astral.sh/uv/)** nodig. In drie commando's ben je klaar:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # 1. uv (eenmalig, macOS/Linux)
+uv python pin 3.12                                # 2. Python 3.12 vastzetten
+uv tool install studentprognose                   # 3. de tool installeren
+```
+
+Daarna kun je meteen door naar de [Snelstart](snelstart.md).
+
+=== "Windows"
+
+    ```powershell
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    uv python pin 3.12
+    uv tool install studentprognose
+    ```
+
+**Updaten** naar een nieuwere versie: `uv tool upgrade studentprognose`.
+
+!!! warning "Alleen Python 3.12 wordt ondersteund"
+    De pipeline wordt op één Python-versie ontwikkeld en getest. Nieuwere minors (3.13, 3.14) zijn bewust uitgesloten — `statsforecast` publiceert daarvoor nog geen Windows-wheels, wat een C-compiler-error geeft tijdens installatie. `uv` downloadt zelf de juiste versie; je hoeft niks van python.org te halen.
+
+## Voordat je begint
+
+Controleer je Python-versie met `python --version` (of `python3 --version`).
+
+??? tip "Python niet gevonden of te oud?"
+    Zie je `python: command not found` of een versie lager dan 3.12? `uv python pin 3.12` regelt dit meestal vanzelf. Lukt dat niet:
+
+    - **Windows** — download via [python.org](https://www.python.org/downloads/); vink **"Add python.exe to PATH"** aan.
+    - **macOS** — [python.org](https://www.python.org/downloads/) of `brew install python@3.12`.
+    - **Linux** — `sudo apt install python3.12` (Ubuntu/Debian) of `sudo dnf install python3.12` (Fedora).
+
+## Installatie
+
+We gebruiken **uv**, een snelle Python-pakketbeheerder die virtual environments automatisch afhandelt. De drie commando's bovenaan deze pagina zijn alles wat je nodig hebt. Werk je liever met pip, of wil je aan de broncode bijdragen? Zie hieronder.
+
+??? note "Installeren met pip in een virtual environment"
+    !!! warning "Installeer niet zonder virtual environment"
+        Een `pip install` buiten een virtual environment plaatst packages in je systeemomgeving en kan conflicten veroorzaken met andere projecten.
+
+    ```bash
+    mkdir mijn-prognose && cd mijn-prognose
+    python -m venv .venv
+    ```
+
+    Activeer de omgeving:
+
+    === "Windows (PowerShell)"
+
+        ```powershell
+        .venv\Scripts\Activate.ps1
+        ```
+
+    === "Windows (CMD)"
+
+        ```cmd
+        .venv\Scripts\activate.bat
+        ```
+
+    === "macOS / Linux"
+
+        ```bash
+        source .venv/bin/activate
+        ```
+
+    Je ziet nu `(.venv)` voor je prompt. Installeer daarna:
+
+    ```bash
+    pip install studentprognose        # updaten: pip install --upgrade studentprognose
+    ```
+
+    Elke nieuwe terminal vereist een nieuwe activatie vóór `studentprognose` werkt.
+
+??? note "Bijdragen aan de broncode"
+    ```bash
+    git clone https://github.com/cedanl/studentprognose.git
+    cd studentprognose
+    uv run studentprognose --help
+    ```
+
+    `uv run` maakt automatisch een virtual environment aan op basis van `pyproject.toml`.
+
+## Installatie mislukt?
+
+??? failure "`studentprognose: command not found` na installatie"
+    Start je terminal opnieuw op zodat het commando beschikbaar wordt. Houdt het aan, draai dan `uv tool update-shell` en open een nieuwe terminal.
+
+??? failure "`ModuleNotFoundError: No module named 'studentprognose'`"
+    Je draait Python buiten de omgeving waarin de tool is geïnstalleerd. Gebruik `uv run studentprognose ...` om de juiste omgeving te kiezen.
+
+??? failure "`python: command not found` of versie te laag"
+    Python is niet geïnstalleerd of niet in je PATH. Zie [Voordat je begint](#voordat-je-begint). Op sommige systemen heet het commando `python3`.
+
+Andere fouten (bijv. `TerminatedWorkerError` tijdens het draaien) staan bij [Draaien & CLI → Veelvoorkomende fouten](aan-de-slag.md#veelvoorkomende-fouten).

--- a/docs/je-data-voorbereiden.md
+++ b/docs/je-data-voorbereiden.md
@@ -1,201 +1,149 @@
-# Je data voorbereiden
+# Je data klaarzetten
 
-De pipeline verwacht twee typen inputmappen: `data/input_raw/` voor de ruwe bronbestanden die de ETL verwerkt, en `data/input/` voor de verwerkte bestanden die het model direct inleest.
+Je zet je **ruwe** bestanden in `data/input_raw/`. De tool verwerkt die automatisch (ETL) naar de modelklare bestanden in `data/input/` — die tweede map raak je zelf niet aan. Beide mappen worden voor je aangemaakt door `studentprognose init` en de ETL.
 
-!!! tip "Uitgebreide versie — Jupyter notebook"
-    Wil je de schema's, pivot-transformatie en validatiechecks uitvoerbaar op demodata zien?
-    Zie [`notebooks/01_data_voorbereiden.ipynb`](https://github.com/cedanl/studentprognose/blob/main/notebooks/01_data_voorbereiden.ipynb).
+!!! tip "Minimaal nodig voor je eerste eigen run"
+    - [ ] **Studielink-telbestanden** in `data/input_raw/telbestanden/` — voor het cumulatieve spoor (`-d c`/`-d b`)
+    - [ ] **`individuele_aanmelddata.csv`** in `data/input_raw/` — voor het individuele spoor (`-d i`/`-d b`)
+    - [ ] **`oktober_bestand.xlsx`** in `data/input_raw/` — altijd nodig (studentaantallen / ground truth)
 
-`data/input/` wordt automatisch aangemaakt door de ETL als de map nog niet bestaat. `data/input_raw/telbestanden/` wordt aangemaakt door `studentprognose init`. Je hoeft deze mappen niet zelf te maken.
+    Alleen even uitproberen? Gebruik de [demodata via de Snelstart](snelstart.md) — dan heb je hier nog niks voor nodig.
 
-Zie de [volledige dataflow](https://github.com/cedanl/studentprognose/blob/main/doc/PIPELINE.md) voor een visueel Mermaid-diagram.
+!!! note "Twee begrippen vooraf"
+    - **ETL** — de automatische stap die je ruwe bestanden omzet naar het modelklare formaat. Sla hem over met `--noetl` als je data al verwerkt is.
+    - **Gewogen vs. ongewogen vooraanmelders** — *ongewogen* is het ruwe `Aantal`; *gewogen* corrigeert voor studenten die zich bij meerdere opleidingen aanmelden (`Gewogen = Aantal / meercode_V`).
 
-!!! tip "Heb je al verwerkte data?"
-    Heb je verwerkte bestanden uit een eigen ETL of van een collega, dan kun je de ingebouwde ETL overslaan met `--noetl`. **Let op:** de bestanden moeten voldoen aan het schema in [Verwerkte inputbestanden](#verwerkte-inputbestanden-data-input) — dezelfde kolomnamen, types en betekenis. Wijkende kolomnamen kun je remappen via `configuration.json` (zie [Institutiespecifieke kolomnamen](#institutiespecifieke-kolomnamen)).
+    De volledige woordenlijst staat op [Begrippen](begrippen.md). Voor de uitvoerbare versie met schema's en validatiechecks: [`notebooks/01_data_voorbereiden.ipynb`](https://github.com/cedanl/studentprognose/blob/main/notebooks/01_data_voorbereiden.ipynb).
 
 ## Ruwe bronbestanden (`data/input_raw/`)
 
 ### Studielink telbestanden
 
-Map: `data/input_raw/telbestanden/`
-Bestandsnaampatroon: `telbestandY{jaar}W{week}.csv` (bijv. `telbestandY2024W10.csv`) — configureerbaar, zie [Afwijkende bestandsnamen](#afwijkende-bestandsnamen) hieronder.
-Scheidingsteken: `;`
+Map: `data/input_raw/telbestanden/` · Bestandsnaam: `telbestandY{jaar}W{week}.csv` (configureerbaar, zie [Afwijkende bestandsnamen](#afwijkende-bestandsnamen)) · Scheidingsteken: `;`
+
+De ETL leest een **subset** van de officiële Studielink-velden. De belangrijkste zijn `Brincode` (instelling), `Isatcode` (CROHO-code, de joinsleutel), `Studiejaar` (collegejaar), `Aantal` (ongewogen vooraanmelders) en `meercode_V` (deler voor de gewogen vooraanmelders).
 
 !!! info "Officiële Studielink-specificatie"
-    Studielink levert de telbestanden volgens het *Programma van Levering Telbestand Studielink* (Stichting Studielink, versie Definitief 2.8, 3 november 2022). Dat document beschrijft alle velden, codetabellen en leveringskalender. PDF: [pvl telbestand studielink.pdf](https://www.tignl.eu/downloads/studielink/pvl%20telbestand%20studielink.pdf).
+    Studielink levert de telbestanden volgens het *Programma van Levering Telbestand Studielink* (versie 2.8, 3 nov. 2022): [pvl telbestand studielink.pdf](https://www.tignl.eu/downloads/studielink/pvl%20telbestand%20studielink.pdf). De §-verwijzingen in de tabel hieronder verwijzen daarnaar. De pipeline gebruikt een subset van de PvL-velden (status: [#206](https://github.com/cedanl/studentprognose/issues/206)).
 
-    De §-verwijzingen in de tabel hieronder verwijzen naar paragrafen in dit document. De pipeline gebruikt een **subset** van de PvL-velden (zie [#206](https://github.com/cedanl/studentprognose/issues/206) voor de status van demo-data t.o.v. de volledige PvL).
-
-De velden hieronder zijn de kolommen die de demo-telbestanden bevatten en die de ETL daadwerkelijk inleest:
-
-| Kolom | Type | PvL § | Omschrijving |
-|-------|------|-------|-------------|
-| `Brincode` | str | §5.2 | BRIN-code van de instelling. ETL hernoemt naar `Korte naam instelling`. |
-| `Studiejaar` | int | §5.7 | Collegejaar (bijv. `2024`). ETL hernoemt naar `Collegejaar`. |
-| `Type_HO` | str | §5.5 | Type hoger onderwijs (`B` = Bachelor, `M` = Master, etc.). ETL hernoemt naar `Type hoger onderwijs`. |
-| `Isatcode` | str | §5.4 | CROHO-code van de opleiding. ETL hernoemt naar `Croho`. |
-| `Groepeernaam` | str | — | Naam van de opleiding (afgeleid/verrijkt veld, niet in PvL). ETL kopieert naar `Groepeernaam Croho` én `Naam Croho opleiding Nederlands`. |
-| `Faculteit` | str | — | Faculteit van de opleiding (afgeleid/verrijkt veld, niet in PvL). Wordt door de ETL leeg gezet als de kolom ontbreekt. |
-| `Herkomst` | str | §5.10 | `N` (Nederland), `E` (EER), `R` (rest). ETL hertaalt naar `NL` / `EER` / `Niet-EER`. |
-| `Hogerejaars` | str | §5.14 | `J` of `N`. ETL hertaalt naar `Ja` / `Nee`. |
-| `Herinschrijving` | str | §5.15 | `J` of `N`. ETL hertaalt naar `Ja` / `Nee`. |
-| `Aantal` | int | §5.17 | Aantal (voor)aanmeldingen. ETL hernoemt naar `Ongewogen vooraanmelders`. |
-| `meercode_V` | int | §5.12 | Gemiddeld aantal aanmeldingen per student met status V/U/I. Wordt door de ETL als deler gebruikt: `Gewogen vooraanmelders = Aantal / meercode_V`. Voor status A-rijen is deze waarde 0 — die rijen worden door de ETL uitgefilterd. |
-| `Status` | str | §5.13 | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven/gestaakt) of `A` (annulering). Rijen met `A` worden uit de vooraanmelderaggregatie gehouden. |
+??? note "Volledige veldbeschrijving (referentie)"
+    | Kolom | Type | PvL § | Omschrijving |
+    |-------|------|-------|-------------|
+    | `Brincode` | str | §5.2 | BRIN-code van de instelling. ETL hernoemt naar `Korte naam instelling`. |
+    | `Studiejaar` | int | §5.7 | Collegejaar (bijv. `2024`). ETL hernoemt naar `Collegejaar`. |
+    | `Type_HO` | str | §5.5 | Type hoger onderwijs (`B` = Bachelor, `M` = Master, etc.). ETL hernoemt naar `Type hoger onderwijs`. |
+    | `Isatcode` | str | §5.4 | CROHO-code van de opleiding. ETL hernoemt naar `Croho`. |
+    | `Groepeernaam` | str | — | Naam van de opleiding (afgeleid/verrijkt veld, niet in PvL). ETL kopieert naar `Groepeernaam Croho` én `Naam Croho opleiding Nederlands`. |
+    | `Faculteit` | str | — | Faculteit (afgeleid/verrijkt veld, niet in PvL). Wordt leeg gezet als de kolom ontbreekt. |
+    | `Herkomst` | str | §5.10 | `N` (Nederland), `E` (EER), `R` (rest). ETL hertaalt naar `NL` / `EER` / `Niet-EER`. |
+    | `Hogerejaars` | str | §5.14 | `J` of `N`. ETL hertaalt naar `Ja` / `Nee`. |
+    | `Herinschrijving` | str | §5.15 | `J` of `N`. ETL hertaalt naar `Ja` / `Nee`. |
+    | `Aantal` | int | §5.17 | Aantal (voor)aanmeldingen. ETL hernoemt naar `Ongewogen vooraanmelders`. |
+    | `meercode_V` | int | §5.12 | Deler: `Gewogen vooraanmelders = Aantal / meercode_V`. Status A-rijen hebben waarde 0 en worden uitgefilterd. |
+    | `Status` | str | §5.13 | `V` (verzoek), `I` (inschrijving), `U` (uitgeschreven) of `A` (annulering). `A`-rijen worden uit de aggregatie gehouden. |
 
 !!! tip "Teldata bevat meerdere instellingen — scoop op je eigen Brincode"
-    Een Studielink-telbestand is landelijk: de kolom `Brincode` (na ETL `Korte naam instelling`) bevat rijen van álle instellingen. Wil je alleen je eigen instelling voorspellen, gebruik dan [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen) in je configuratie of de CLI-vlag [`--institution`](aan-de-slag.md#-institution). Zonder filter traint en voorspelt de tool over alle aanwezige instellingen tegelijk. Het filter geldt voor het cumulatieve spoor; het individuele spoor is doorgaans al de eigen aanmeldexport van één instelling.
+    Een telbestand is landelijk: de kolom `Brincode` bevat álle instellingen. Wil je alleen je eigen instelling, gebruik dan [`institution_filter`](configuratie.md#institution_filter-beperk-de-teldata-tot-een-of-meer-instellingen) of de CLI-vlag [`--institution`](aan-de-slag.md#-institution). Zonder filter traint en voorspelt de tool over alle instellingen tegelijk.
 
 #### Afwijkende bestandsnamen
 
-Gebruikt jouw instelling een andere conventie dan `telbestandY{jaar}W{week}.csv`? Geef in `configuration.json` één of meer eigen patronen op:
+Gebruikt jouw instelling een andere conventie? Geef in `configuration.json` eigen patronen op met placeholders `{year}` en `{week}`:
 
 ```json
-{
-    "telbestand_filename_patterns": [
-        "telbestandY{year}W{week}",
-        "VU_telbestand_{year}_W{week}"
-    ]
-}
+{ "telbestand_filename_patterns": ["telbestandY{year}W{week}", "VU_telbestand_{year}_W{week}"] }
 ```
 
-Placeholders zijn `{year}` (vier cijfers) en `{week}` (één of twee cijfers). Andere karakters worden letterlijk gematcht — punten en streepjes zijn veilig. Meerdere patronen tegelijk zijn handig tijdens een migratie van oude naar nieuwe naamgeving. Zie [`telbestand_filename_patterns`](configuratie.md#telbestand_filename_patterns-bestandsnaampatronen-voor-telbestanden) voor de volledige uitleg.
-
-### UvA SQL-telbestand (fijnmazig Studielink-formaat)
-
-Map: `data/input_raw/telbestanden/`
-Bestandsnaampatroon: `telbestand_sl_{leverdatum}_v{volgnummer}_{studiejaar}.csv` (bijv. `telbestand_sl_20260525_v34_2026.csv`)
-Scheidingsteken: `,` (komma — let op: het legacy-instellingsformaat hierboven gebruikt `;`)
-
-De UvA levert de wekelijkse Studielink-telbestanden aan als **SQL-export met 22 kolommen**. Dit is een fijnmaziger, minder voorbewerkte variant van hetzelfde bronmateriaal: het bevat extra dimensies (`Geslacht`, `Opl_vorm`, `Voertaal`, `Fixus`, `1cHO_L`/`1cHO_K`) en mist de verrijkte velden `Groepeernaam` en `Faculteit`. De ETL zet dit formaat om naar **exact dezelfde 16 kolommen** als het legacy-formaat, zodat de modellen ongewijzigd blijven.
-
-De omzetting is volledig **config-gedreven** via het `cumulative_input`-blok in `configuration.json` (separator, waardevertalingen, aggregatie); zie [`cumulative_input`](configuratie.md#cumulative_input-uva-sql-telbestand-omzetten).
-
-| Kolom | Type | Omschrijving |
-|-------|------|-------------|
-| `Brincode` | str | BRIN-code instelling → `Korte naam instelling`. Het bestand is **multi-instelling**: één levering bevat alle instellingen waar een student zich aanmeldde. |
-| `Isatcode` | str | CROHO-code opleiding → `Croho`. Wordt óók als placeholder voor `Groepeernaam Croho`/`Naam Croho opleiding Nederlands` gebruikt (zie hieronder). |
-| `Type_HO` | str | `B`/`P` → Bachelor, `M` → Master, **`A` → Associate degree** (nieuw t.o.v. de 2016–2024 historie), `O` → Onbekend. |
-| `Studiejaar` | int | Collegejaar → `Collegejaar`. |
-| `Herkomst` | str | `N`/`E`/`R`(/`O`) → `NL`/`EER`/`Niet-EER`/`Onbekend`. |
-| `Hogerejaars`, `Herinschrijving` | str | `J`/`N` → `Ja`/`Nee`. |
-| `Status` | str | `V`/`I`/`U`/`A`. Rijen met `A` (annulering) worden uitgefilterd; voor die rijen is `meercode_V == 0`. |
-| `meercode_V` | int | Deler voor `Gewogen vooraanmelders = Aantal / meercode_V`. Na het `Status != "A"`-filter komt geen `meercode_V == 0` meer voor (deel-door-nul kan niet optreden). |
-| `Aantal` | int | (Voor)aanmeldingen → `Ongewogen vooraanmelders`. |
-| `etl_is_deleted` | int | Soft-delete vlag; rijen met `1` worden uitgefilterd. |
-| `Voertaal`, `Geslacht`, `Opl_vorm`, `Fixus`, `1cHO_L`, `1cHO_K` | — | Extra split-dimensies. Staan niet in de 16-koloms output; de ETL **aggregeert** ze weg (zie ETL-stappen). |
-
-!!! info "Snapshot-semantiek (cumulatief, geen delta)"
-    Elke wekelijkse levering is een **volledige cumulatieve momentopname**: `Aantal` is een lopend totaal vanaf de openstelling, geen wekelijkse aanwas. Per seizoen stijgt het monotoon en het reset rond de jaarwisseling van de Studielink-cyclus. **Tel daarom nooit over meerdere weekleveringen heen op** — dat zou overtellen.
-
-!!! warning "Weeknummer uit de leverdatum, niet uit de data"
-    De week zit niet in de SQL-kolommen. De ETL leidt het weeknummer af uit de **leverdatum** in de bestandsnaam (`telbestand_sl_20260525_...` → ISO-kalenderweek **22**), niet uit het Studielink-volgnummer. Zo sluit het aan op de ISO-week-indexering van het bestaande `vooraanmeldingen_cumulatief.csv`.
-
-!!! note "Ontbrekende `Groepeernaam` en `Faculteit` (placeholder)"
-    De SQL-levering bevat geen leesbare opleidingsnaam of faculteit en die zijn er niet uit af te leiden. De ETL vult `Groepeernaam Croho`/`Naam Croho opleiding Nederlands` met de **`Isatcode`** en `Faculteit` met een vaste placeholder (`"Onbekend"`). Een niet-lege placeholder is noodzakelijk: een lege (NaN) `Faculteit` zou in de cumulatieve `groupby`/pivot alle UvA-rijen laten vallen.
-
-    **De join met het label is opgelost door op de `Isatcode` te koppelen i.p.v. op de leesbare naam.** Omdat de `Isatcode` een landelijke, stabiele CROHO-code is (en niet instellingsspecifiek zoals een opleidingsnaam), keyt zowel de feature-kant (`vooraanmeldingen_cumulatief.csv`) als het label (`student_count_first-years.xlsx`, afgeleid uit `oktober_bestand.xlsx`) op deze code. Daarvoor moet `oktober_bestand.xlsx` een `Isatcode`-kolom bevatten (zie [Telbestand studenten](#telbestand-studenten)). Een leesbare opleidingsnaam blijft wenselijk voor de dashboard-weergave; die mapping is belegd in [#232](https://github.com/cedanl/studentprognose/issues/232).
-
-!!! note "Andere academische-jaargrens (week 36)"
-    De UvA-aanmeldfase eindigt structureel rond **week 36**; er zijn geen leveringen in de weken 37–39. Het legacy-formaat loopt tot week 38. Daarom staat voor het UvA-formaat `model_config.final_academic_week` op `36` (zie [configuratie](configuratie.md#final_academic_week)). Dit raakt het cumulatieve spoor; het individuele spoor is hier niet op van toepassing (UvA is cumulatief-only).
-
-    **Bekende beperking:** het Plotly-dashboard ordent de week-as nog volgens de vaste week 39→38-kalender. De voorspellingen en outputbestanden kloppen, maar bij een UvA-configuratie kan de week-as van het dashboard cosmetisch afwijken (weken 37/38 leeg aan het eind). Het meeschalen van het dashboard met `final_academic_week` is een aparte follow-up.
+Andere karakters worden letterlijk gematcht. Zie [`telbestand_filename_patterns`](configuratie-referentie.md#telbestand_filename_patterns-bestandsnaampatronen-voor-telbestanden) voor de volledige uitleg.
 
 ### Individuele aanmelddata
 
-Pad: `data/input_raw/individuele_aanmelddata.csv`
-Bron: Osiris / Usis (Studenten Informatie Systeem of datawarehouse van jouw instelling)
-Scheidingsteken: `;`
+Pad: `data/input_raw/individuele_aanmelddata.csv` · Bron: Osiris / Usis · Scheidingsteken: `;`
 
-Volledige kolommenlijst (kanonieke namen — pas aan via `configuration.json` als jouw instelling andere namen gebruikt). De *Rol* geeft aan hoe de pipeline het veld gebruikt: **sleutel** = unieke identifier per aanmelding; **basis** = gebruikt door alle individuele stappen (filtering, deadlinebepaling, output-aggregatie); **classifier** = feature in het XGBoost classifier-model voor inschrijfkans; **info** = wel ingelezen, niet door modellen gebruikt.
+Eén rij per aanmelding. De *Rol* geeft aan hoe de pipeline een veld gebruikt: **sleutel** = unieke identifier; **basis** = filtering/deadline/aggregatie; **classifier** = feature in het XGBoost-model; **info** = ingelezen maar niet door modellen gebruikt (mag leeg zijn).
 
-| Canonieke naam | Rol | Omschrijving |
-|----------------|------|-------------|
-| `Sleutel` | sleutel | Unieke studentidentifier |
-| `Datum Verzoek Inschr` | basis | Datum van vooraanmelding (bepaalt aanmeldweek) |
-| `Ingangsdatum` | basis | Ingangsdatum inschrijving |
-| `Collegejaar` | basis, classifier | Collegejaar |
-| `Datum intrekking vooraanmelding` | basis | Weeknummer van intrekking (leeg als niet ingetrokken) |
-| `Inschrijfstatus` | basis | Zie `status_mapping` in configuratie |
-| `Faculteit` | classifier | Faculteit |
-| `Examentype` | basis, classifier | `Bachelor` of `Master` |
-| `Croho` | basis | CROHO-code |
-| `Croho groepeernaam` | basis, classifier | Naam van de opleiding |
-| `Opleiding` | classifier | Specifieke opleidingsnaam (variant binnen CROHO-groep) |
-| `Hoofdopleiding` | info | Markering hoofdopleiding bij duale studies |
-| `Eerstejaars croho jaar` | basis | Jaar waarin student eerstejaars is in deze CROHO |
-| `Is eerstejaars croho opleiding` | basis | Indicator eerstejaars binnen deze CROHO-opleiding |
-| `Is hogerejaars` | basis | Indicator of student hogerejaars is (`Ja` / `Nee`) |
-| `BBC ontvangen` | info | Indicator BBC (Bewijs van Betaald Collegegeld) ontvangen |
-| `Type vooropleiding` | classifier | Type vooropleiding |
-| `Nationaliteit` | classifier | Nationaliteit student |
-| `EER` | classifier | EER-indicator |
-| `Geslacht` | classifier | Geslacht |
-| `Geverifieerd adres postcode` | classifier | Geverifieerde postcode woonadres |
-| `Geverifieerd adres plaats` | classifier | Geverifieerde plaats woonadres |
-| `Geverifieerd adres land` | classifier | Geverifieerd land woonadres |
-| `Studieadres postcode` | classifier | Postcode studieadres |
-| `Studieadres land` | classifier | Land studieadres |
-| `School code eerste vooropleiding` | classifier | School-code eerste vooropleiding |
-| `School eerste vooropleiding` | classifier | Naam school eerste vooropleiding |
-| `Plaats code eerste vooropleiding` | classifier | Plaats-code eerste vooropleiding |
-| `Land code eerste vooropleiding` | classifier | Land-code eerste vooropleiding |
-| `Aantal studenten` | basis | Tellerveld (meestal `1` per rij) |
+??? note "Volledige kolommenlijst (kanonieke namen — herbenoembaar via `configuration.json`)"
+    | Canonieke naam | Rol | Omschrijving |
+    |----------------|------|-------------|
+    | `Sleutel` | sleutel | Unieke studentidentifier |
+    | `Datum Verzoek Inschr` | basis | Datum van vooraanmelding (bepaalt aanmeldweek) |
+    | `Ingangsdatum` | basis | Ingangsdatum inschrijving |
+    | `Collegejaar` | basis, classifier | Collegejaar |
+    | `Datum intrekking vooraanmelding` | basis | Weeknummer van intrekking (leeg als niet ingetrokken) |
+    | `Inschrijfstatus` | basis | Zie `status_mapping` in configuratie |
+    | `Faculteit` | classifier | Faculteit |
+    | `Examentype` | basis, classifier | `Bachelor` of `Master` |
+    | `Croho` | basis | CROHO-code |
+    | `Croho groepeernaam` | basis, classifier | Naam van de opleiding |
+    | `Opleiding` | classifier | Specifieke opleidingsnaam (variant binnen CROHO-groep) |
+    | `Hoofdopleiding` | info | Markering hoofdopleiding bij duale studies |
+    | `Eerstejaars croho jaar` | basis | Jaar waarin student eerstejaars is in deze CROHO |
+    | `Is eerstejaars croho opleiding` | basis | Indicator eerstejaars binnen deze CROHO-opleiding |
+    | `Is hogerejaars` | basis | Indicator hogerejaars (`Ja` / `Nee`) |
+    | `BBC ontvangen` | info | Indicator BBC (Bewijs van Betaald Collegegeld) ontvangen |
+    | `Type vooropleiding` | classifier | Type vooropleiding |
+    | `Nationaliteit` | classifier | Nationaliteit student |
+    | `EER` | classifier | EER-indicator |
+    | `Geslacht` | classifier | Geslacht |
+    | `Geverifieerd adres postcode` / `plaats` / `land` | classifier | Geverifieerd woonadres |
+    | `Studieadres postcode` / `land` | classifier | Studieadres |
+    | `School code eerste vooropleiding` / `School eerste vooropleiding` | classifier | Eerste vooropleiding |
+    | `Plaats code eerste vooropleiding` / `Land code eerste vooropleiding` | classifier | Locatie eerste vooropleiding |
+    | `Aantal studenten` | basis | Tellerveld (meestal `1` per rij) |
 
-De classifier-features (`numeric`/`categorical`) zijn instelbaar in `configuration.json` onder `model_features.classifier` — zie [Configuratie](configuratie.md#columns-kolomnamen-mapping). Velden met rol *info* mogen leeg of ontbrekend zijn zonder dat het model breekt.
+    De classifier-features zijn instelbaar onder `model_features.classifier` — zie [Configuratie](configuratie-referentie.md#columns-kolomnamen-mapping).
 
 ### Telbestand studenten
 
-Pad: `data/input_raw/oktober_bestand.xlsx`
-Bron: door je instelling zelf aangeleverd
+Pad: `data/input_raw/oktober_bestand.xlsx` · Bron: door je instelling aangeleverd
 
-Dit bestand bevat de werkelijke inschrijvingen per collegejaar, opleiding (`Isatcode`), herkomst (`EER-NL-nietEER`) en examentype — de ground truth waarop het model wordt geëvalueerd en die het ratio-model voedt. Elke rij is een telling geaggregeerd op die combinatie van vier dimensies. De meeste instellingen genereren dit bestand uit hun SIS/datawarehouse (Osiris, Usis, of vergelijkbaar).
-
-!!! note "Waarom heet het bestand `oktober_bestand.xlsx`?"
-    Historische naam. De bestandsnaam en de configuratiesleutels (`path_raw_october`, `columns.oktober`) zijn ongewijzigd gelaten om bestaande installaties niet te breken. Inhoudelijk is het een **telbestand met studentaantallen**.
+Bevat de werkelijke inschrijvingen per collegejaar, opleiding (`Isatcode`), herkomst en examentype — de ground truth waarop het model wordt geëvalueerd en die het ratio-model voedt. Elke rij is een telling geaggregeerd op die combinatie van dimensies; de meeste instellingen genereren dit bestand uit hun SIS/datawarehouse (Osiris, Usis, of vergelijkbaar).
 
 | Canonieke naam | Omschrijving |
 |----------------|-------------|
 | `Collegejaar` | Collegejaar |
-| `Isatcode` | **CROHO-code van de opleiding — de joinsleutel met de features.** Moet dezelfde code zijn als de `Isatcode` in de telbestanden. |
-| `Groepeernaam Croho` | Naam van de opleiding (optioneel, voor leesbaarheid; niet langer de joinsleutel) |
+| `Isatcode` | **CROHO-code — de joinsleutel met de features.** Moet gelijk zijn aan de `Isatcode` in de telbestanden. |
+| `Groepeernaam Croho` | Naam van de opleiding (optioneel, voor leesbaarheid; niet de joinsleutel) |
 | `Aantal eerstejaars croho` | Aantal eerstejaars |
 | `EER-NL-nietEER` | Herkomstgroep |
 | `Examentype code` | Examentype, bv. `Bachelor eerstejaars`, `Bachelor hogerejaars`, `Master` |
 | `Aantal Hoofdinschrijvingen` | Aantal hoofdinschrijvingen |
 
 !!! warning "`Isatcode` is verplicht en moet matchen met de telbestanden"
-    De studentaantallen worden op de **`Isatcode`** gekoppeld aan de vooraanmeldingen, niet op de opleidingsnaam (die per instelling verschilt). Zorg dat de codes in `oktober_bestand.xlsx` exact overeenkomen met die in je telbestanden, anders blijft de koppeling leeg en traint het cumulatieve model zonder labels.
+    De studentaantallen worden op de **`Isatcode`** gekoppeld aan de vooraanmeldingen, niet op de opleidingsnaam (die per instelling verschilt). Komen de codes niet overeen, dan blijft de koppeling leeg en traint het cumulatieve model zonder labels.
+
+??? note "Waarom heet het bestand `oktober_bestand.xlsx`?"
+    Historische naam. De bestandsnaam en configuratiesleutels (`path_raw_october`, `columns.oktober`) zijn ongewijzigd gelaten om bestaande installaties niet te breken. Inhoudelijk is het een telbestand met studentaantallen.
 
 ## ETL-stappen
 
-De ETL draait automatisch bij elke run (tenzij `--noetl` is opgegeven). De stappen:
+De ETL draait automatisch bij elke run (tenzij `--noetl`):
 
 | Stap | Actie | Input | Output |
 |------|-------|-------|--------|
-| 1 | Rowbind + reformat (config-gedreven via [`cumulative_input`](configuratie.md#cumulative_input-uva-sql-telbestand-omzetten): separator, waardevertalingen, aggregatie naar de grain) | `path_raw_telbestanden/*.csv` (`telbestanden/`) | Samengevoegd cumulatief bestand |
+| 1 | Rowbind + reformat (config-gedreven via [`cumulative_input`](configuratie-referentie.md#cumulative_input-uva-sql-telbestand-omzetten)) | `telbestanden/*.csv` | Samengevoegd cumulatief bestand |
 | 2 | Interpolatie ontbrekende weken | Samengevoegd bestand | `vooraanmeldingen_cumulatief.csv` |
-| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` (telbestand studenten) | `student_count_*.xlsx`, `student_volume.xlsx` |
+| 3 | Studentaantallen berekenen | `oktober_bestand.xlsx` | `student_count_*.xlsx`, `student_volume.xlsx` |
 | 4 | Kopiëren individuele data | `individuele_aanmelddata.csv` | `vooraanmeldingen_individueel.csv` |
+
+Zie de [volledige dataflow](https://github.com/cedanl/studentprognose/blob/main/doc/PIPELINE.md) voor een Mermaid-diagram.
 
 ## ETL overslaan
 
-Als je al beschikt over verwerkte data — bijvoorbeeld uit een eigen ETL-pipeline, van een collega, of uit een eerdere run — kun je de ingebouwde ETL-stappen overslaan met de `--noetl`-vlag:
+Heb je al verwerkte data (eigen ETL, collega, eerdere run)? Sla ETL én validatie over met `--noetl`. De vereiste bestanden moeten dan in `data/input/` staan.
 
 ```bash
-studentprognose --noetl -d cumulative -w 12 -y 2025
+studentprognose --noetl -d cumulative -w 12 -y 2024
 ```
 
-Zorg ervoor dat de vereiste bestanden in `data/input/` staan voordat je de tool draait. Welke bestanden je nodig hebt hangt af van de gekozen datamodus (`-d`). Zie de tabel hieronder.
+!!! warning "Heb je alleen ruwe bronbestanden? Gebruik `--noetl` dan níét"
+    `--noetl` slaat de ETL over en verwacht kant-en-klare bestanden in `data/input/`. Heb je alleen de ruwe bronbestanden (Studielink-telbestanden, Osiris/Usis-export, telbestand studenten)? Laat `--noetl` dan weg, zodat de ingebouwde ETL de verwerkte bestanden voor je aanmaakt.
 
 !!! warning "De cumulatieve data heeft historische collegejaren nodig"
-    Het cumulatieve spoor traint op data van vóór het voorspeljaar: het XGBoost-instroommodel (`SARIMA_cumulative`) en het ratio-model (`Prognose_ratio`) leiden beide hun voorspelling af uit eerdere collegejaren. Bevat je cumulatieve data (`vooraanmeldingen_cumulatief.csv`, of `df_cum` bij in-memory gebruik via [`run_pipeline_from_dataframes`](api/index.md)) **alleen het voorspeljaar**, dan blijven beide kolommen voor elke opleiding `NaN` — terwijl `Voorspelde vooraanmelders` zich wél vult en de output dus compleet *oogt*.
-
-    Lever daarom altijd minstens één, idealiter de drie, collegejaren vóór het voorspeljaar mee. De [trainingshistorie-check](validatie.md#trainingshistorie-waarom-deze-check-bestaat) stopt de pipeline (of waarschuwt, op het in-memory pad) wanneer die historie ontbreekt. Snelle controle: `sorted(df_cum["Collegejaar"].unique())`.
+    Het cumulatieve spoor traint op data van vóór het voorspeljaar: het XGBoost-instroommodel (`SARIMA_cumulative`) en het ratio-model (`Prognose_ratio`) leiden hun voorspelling af uit eerdere jaren. Bevat je data **alleen het voorspeljaar**, dan blijven beide kolommen `NaN` — terwijl `Voorspelde vooraanmelders` zich wél vult en de output dus compleet *oogt*. Lever altijd minstens één, idealiter drie collegejaren vóór het voorspeljaar mee. De [trainingshistorie-check](validatie.md#trainingshistorie-waarom-deze-check-bestaat) bewaakt dit. Snelle controle: `sorted(df_cum["Collegejaar"].unique())`.
 
 ## Verwerkte inputbestanden (`data/input/`)
 
-Dit zijn de bestanden die het model direct inleest. Ze worden aangemaakt door de ETL, of je plaatst ze zelf in `data/input/` als je `--noetl` gebruikt.
+Dit zijn de bestanden die het model direct inleest. De ETL maakt ze aan; bij `--noetl` plaats je ze zelf.
 
 | Bestand | Wanneer nodig | Bron |
 |---------|---------------|------|
@@ -204,39 +152,49 @@ Dit zijn de bestanden die het model direct inleest. Ze worden aangemaakt door de
 | `student_count_first-years.xlsx` | Altijd | ETL stap 3 |
 | `student_volume.xlsx` | Alleen bij `-sy v` | ETL stap 3 |
 | `ensemble_weights.xlsx` | Optioneel | `scripts/calculate_ensemble_weights.py` |
-| `totaal_cumulatief.xlsx` | Optioneel | `scripts/append_studentcount_and_compute_errors.py` |
-| `totaal_individueel.xlsx` | Optioneel | `scripts/append_studentcount_and_compute_errors.py` |
+| `totaal_cumulatief.xlsx` / `totaal_individueel.xlsx` | Optioneel | `scripts/append_studentcount_and_compute_errors.py` |
 
 ## Institutiespecifieke kolomnamen
 
-Jouw instelling gebruikt mogelijk andere kolomnamen dan de kanonieke namen hierboven. Pas de `columns`-sectie in `configuration.json` aan:
+Gebruikt jouw instelling andere kolomnamen dan de kanonieke? Map ze in de `columns`-sectie van `configuration.json` — alleen de afwijkende namen:
 
 ```json
-{
-    "columns": {
-        "individual": {
-            "Croho groepeernaam": "CROHO_NAAM",
-            "Inschrijfstatus": "STATUS"
-        }
-    }
-}
+{ "columns": { "individual": { "Croho groepeernaam": "CROHO_NAAM", "Inschrijfstatus": "STATUS" } } }
 ```
 
-Alleen de afwijkende namen hoeven opgegeven te worden. Zie [Configuratie](configuratie.md) voor de volledige kolommenlijst.
+Zie [Configuratie — referentie](configuratie-referentie.md#columns-kolomnamen-mapping) voor de volledige kolommenlijst.
 
-## Bekende valkuil: `path_cumulative_new`
+## Voor gevorderden
 
-!!! warning "path_cumulative_new overschrijft en verwijdert bestanden"
-    Als `path_cumulative_new` in je configuratie een bestaand bestand aanwijst, **mergt de
-    pipeline dit bestand in `vooraanmeldingen_cumulatief.csv` en verwijdert daarna het bronbestand**.
-    De pipeline toont daarvoor een melding:
+!!! info "Sla dit over tenzij het op jou van toepassing is"
+    De onderstaande onderwerpen gelden alleen bij een afwijkend inputformaat (UvA SQL) of bij bewust gebruik van `path_cumulative_new`. Gebruik je de standaard Studielink-telbestanden, dan hoef je hier niets mee.
 
-    ```
-    Merging data/input/nieuw_bestand.csv into data/input/vooraanmeldingen_cumulatief.csv and removing source file...
-    ```
+### Bekende valkuil: `path_cumulative_new`
 
-    Bij een crash ná het schrijven maar vóór het verwijderen is de originele data onherstelbaar kwijt.
-    Maak vooraf een backup als je dit mechanisme gebruikt.
+!!! warning "`path_cumulative_new` overschrijft en verwijdert bestanden"
+    Als `path_cumulative_new` in je configuratie een bestaand bestand aanwijst, **mergt de pipeline dit in `vooraanmeldingen_cumulatief.csv` en verwijdert daarna het bronbestand** (met een melding). Bij een crash ná het schrijven maar vóór het verwijderen is de originele data onherstelbaar kwijt. Maak vooraf een backup, en zet `path_cumulative_new` op `""` als je dit niet nodig hebt.
 
-    Gebruik dit mechanisme alleen als je bewust een nieuw cumulatief bestand wilt inladen.
-    Zet `path_cumulative_new` op `""` als je dit niet nodig hebt.
+### UvA SQL-telbestand (fijnmazig Studielink-formaat)
+
+Map: `data/input_raw/telbestanden/` · Bestandsnaam: `telbestand_sl_{leverdatum}_v{volgnummer}_{studiejaar}.csv` · Scheidingsteken: `,` (komma)
+
+De UvA levert de wekelijkse telbestanden als **SQL-export met 22 kolommen**: een fijnmaziger, minder voorbewerkte variant met extra dimensies (`Geslacht`, `Opl_vorm`, `Voertaal`, `Fixus`, …) en zonder de verrijkte velden `Groepeernaam`/`Faculteit`. De ETL zet dit **config-gedreven** om naar exact dezelfde 16 kolommen als het legacy-formaat, zodat de modellen ongewijzigd blijven — zie [`cumulative_input`](configuratie-referentie.md#cumulative_input-uva-sql-telbestand-omzetten).
+
+??? note "Kolommen, snapshot-semantiek en bekende beperkingen"
+    | Kolom | Omschrijving |
+    |-------|-------------|
+    | `Brincode` | → `Korte naam instelling`. **Multi-instelling**: één levering bevat alle instellingen waar een student zich aanmeldde. |
+    | `Isatcode` | → `Croho`. Ook placeholder voor `Groepeernaam Croho`/`Naam Croho opleiding Nederlands`. |
+    | `Type_HO` | `B`/`P` → Bachelor, `M` → Master, **`A` → Associate degree**, `O` → Onbekend. |
+    | `Studiejaar` | → `Collegejaar`. |
+    | `Herkomst` | `N`/`E`/`R`/`O` → `NL`/`EER`/`Niet-EER`/`Onbekend`. |
+    | `Status` | `A` (annulering) wordt uitgefilterd; voor die rijen is `meercode_V == 0`. |
+    | `meercode_V` | Deler voor `Gewogen vooraanmelders`. Na het `Status != "A"`-filter komt geen deel-door-nul voor. |
+    | `Aantal` | → `Ongewogen vooraanmelders`. |
+    | `etl_is_deleted` | Soft-delete vlag; rijen met `1` worden uitgefilterd. |
+    | `Voertaal`, `Geslacht`, `Opl_vorm`, `Fixus`, `1cHO_L`, `1cHO_K` | Extra split-dimensies; de ETL aggregeert ze weg. |
+
+    - **Snapshot-semantiek** — elke levering is een volledige cumulatieve momentopname (`Aantal` is een lopend totaal, geen wekelijkse aanwas). **Tel nooit over meerdere weekleveringen op.**
+    - **Weeknummer uit de leverdatum** — de week zit niet in de kolommen; de ETL leidt de **ISO-kalenderweek** af uit de leverdatum in de bestandsnaam (`telbestand_sl_20260525_...` → week 22).
+    - **Ontbrekende `Groepeernaam`/`Faculteit`** — de ETL vult `Groepeernaam Croho` met de `Isatcode` en `Faculteit` met een placeholder (`"Onbekend"`); een lege Faculteit zou anders alle UvA-rijen uit de pivot laten vallen. De join loopt daarom op de landelijk-stabiele `Isatcode` (zie [#232](https://github.com/cedanl/studentprognose/issues/232)).
+    - **Andere jaargrens (week 36)** — de UvA-aanmeldfase eindigt rond week 36; zet `model_config.final_academic_week` op `36` (zie [configuratie](configuratie-referentie.md#final_academic_week)). Het dashboard ordent de week-as nog volgens de vaste 39→38-kalender; de voorspellingen kloppen, maar de week-as kan cosmetisch afwijken.

--- a/docs/methodologie/benchmarks.md
+++ b/docs/methodologie/benchmarks.md
@@ -1,5 +1,10 @@
 # Benchmarks
 
+!!! abstract "In het kort"
+    - **Wat het doet:** vergelijkt alle beschikbare modellen op jouw eigen data.
+    - **Wanneer gebruik je het:** voordat je in de configuratie van model wisselt — zodat die keuze onderbouwd is in plaats van een gok.
+    - **Wat betekent de uitkomst:** het model met de laagste fout op jouw historie is de beste kandidaat. Vuistregels: bij kleine datasets (numerus fixus) presteert Ridge vaak beter dan XGBoost, en bij korte tijdreeksen zijn ETS of Theta stabieler dan SARIMA.
+
 Het benchmarkcommando vergelijkt alle beschikbare modellen op jouw eigen data, zodat je een onderbouwde keuze kunt maken vóór het wijzigen van de configuratie.
 
 ## Draaien
@@ -16,7 +21,7 @@ studentprognose benchmark -d i -w 12
 
 ### Cumulatief spoor
 
-De cumulatieve benchmark evalueert alle combinaties van tijdreeksmodellen (SARIMA, ETS, Theta, AutoARIMA) en regressiemodellen (XGBoost, Ridge, Random Forest) via time-series cross-validatie.
+De cumulatieve benchmark evalueert alle combinaties van tijdreeksmodellen (SARIMA, ETS, Theta, AutoARIMA) en regressiemodellen (XGBoost, Ridge, Random Forest). Elk model wordt daarbij getraind op oudere jaren en getest op een recenter jaar — dat heet **time-series cross-validatie** (zie [Methodologie](#methodologie) hieronder).
 
 ### Individueel spoor
 
@@ -26,7 +31,7 @@ De individuele benchmark evalueert classificatiemodellen (XGBoost, Random Forest
 
 ### Cross-validatie
 
-De benchmark gebruikt **leave-last-year-out** splits:
+De benchmark toetst elk model door het te trainen op de oudere jaren en het te testen op het eerstvolgende jaar — een aanpak die **leave-last-year-out** heet (letterlijk: "laat het laatste jaar eruit"):
 
 - **Train:** alle beschikbare jaren tot en met jaar N−1
 - **Test:** jaar N
@@ -41,20 +46,20 @@ Dit bootst de productiescenario na: het model traint op historische data en voor
 
 - Strikte temporale scheiding: traindata bevat nooit het testjaar
 - Preprocessing (OneHotEncoding) wordt alleen gefit op traindata
-- Assertions in de code controleren dat geen target-waarden van het testjaar in de trainset terechtkomen
+- De tool controleert automatisch dat geen toekomstige data (target-waarden van het testjaar) in de training lekt
 
 ### Metrics
 
-| Metric | Omschrijving |
-|--------|-------------|
-| **MAPE** | Mean Absolute Percentage Error — relatieve fout, vergelijkbaar tussen opleidingen van verschillende grootte (cumulatief) |
-| **MAE** | Mean Absolute Error — absolute fout in studentaantallen (cumulatief + individueel geaggregeerd) |
-| **RMSE** | Root Mean Squared Error — penaliseert grote fouten zwaarder (cumulatief) |
-| **Accuracy** | Fractie correct geclassificeerde aanmelders (individueel) |
-| **AUC-ROC** | Area Under the ROC Curve — hoe goed scheidt het model inschrijvers van niet-inschrijvers (individueel) |
-| **F1** | Harmonisch gemiddelde van precision en recall (individueel) |
-| **Aggregate MAE** | MAE op geaggregeerd niveau per opleiding/herkomst/examentype — de uiteindelijke business-metric (individueel) |
-| **Trainingstijd** | Gemiddelde fittijd per model in seconden |
+| Metric | Omschrijving | Wat betekent het voor mij? |
+|--------|-------------|----------------------------|
+| **MAPE** | Mean Absolute Percentage Error — relatieve fout, vergelijkbaar tussen opleidingen van verschillende grootte (cumulatief) | Lager is beter: hoeveel procent zit de voorspelling er gemiddeld naast. |
+| **MAE** | Mean Absolute Error — absolute fout in studentaantallen (cumulatief + individueel geaggregeerd) | Lager is beter: hoeveel studenten zit de voorspelling er gemiddeld naast. |
+| **RMSE** | Root Mean Squared Error — penaliseert grote fouten zwaarder (cumulatief) | Lager is beter, net als MAE, maar grote missers tellen extra zwaar. Ligt RMSE veel hoger dan MAE, dan zitten er een paar forse uitschieters in. |
+| **Accuracy** | Fractie correct geclassificeerde aanmelders (individueel) | Hoger is beter: aandeel aanmelders dat correct is ingedeeld als (niet-)inschrijver. |
+| **AUC-ROC** | Area Under the ROC Curve — hoe goed scheidt het model inschrijvers van niet-inschrijvers (individueel) | Hoger is beter: 1 is perfect onderscheid, 0,5 is niet beter dan gokken. |
+| **F1** | Harmonisch gemiddelde van precision en recall (individueel) | Hoger is beter: balans tussen "hoe vaak klopt een 'wel'-voorspelling" en "hoeveel echte inschrijvers vindt het model". |
+| **Aggregate MAE** | MAE op geaggregeerd niveau per opleiding/herkomst/examentype — de uiteindelijke business-metric (individueel) | Lager is beter: de fout op het niveau dat er echt toe doet. Kijk hier het eerst naar. |
+| **Trainingstijd** | Gemiddelde fittijd per model in seconden | Geen kwaliteitsmaat, maar praktische kost: lager = sneller draaien. |
 
 ### Twee stappen apart gemeten
 

--- a/docs/methodologie/ensemble.md
+++ b/docs/methodologie/ensemble.md
@@ -1,5 +1,11 @@
 # Ensemble
 
+!!! abstract "In het kort"
+    - **Wat het doet:** combineert de voorspellingen van SARIMA, XGBoost en het ratio-model tot één gewogen eindvoorspelling.
+    - **Vertrouw het als:** de losse modellen het onderling grotendeels eens zijn — hoge overeenkomst geeft meer vertrouwen.
+    - **Wees voorzichtig als:** de gewichten verouderd zijn (na een beleidsingreep of uitzonderlijk jaar), of bij een eerste run zonder geoptimaliseerde gewichten.
+    - **In het ensemble:** dit *is* het ensemble — alleen actief in de `-d b` (both) modus.
+
 Het ensemble combineert de voorspellingen van SARIMA, XGBoost en het ratio-model tot één eindvoorspelling. Dit is alleen beschikbaar in de `-d b` (both) modus.
 
 !!! tip "Uitgebreide versie — Jupyter notebook"
@@ -10,11 +16,33 @@ Het ensemble combineert de voorspellingen van SARIMA, XGBoost en het ratio-model
 
 Geen enkel model presteert in alle situaties het beste. SARIMA is sterk bij stabiele seizoenspatronen; XGBoost vangt individuele kenmerken beter op; het ratio-model is robuust bij weinig data. Door modellen te combineren wordt de variantie in de eindvoorspelling verlaagd — mits de modellen niet allemaal op dezelfde manier fout gaan.
 
+## Ensemble vs. individuele modellen
+
+In de output staan zowel de individuele modelvoorspellingen (`SARIMA_individual`, `SARIMA_cumulative`, `Prognose_ratio`) als de ensemble-voorspelling (`Ensemble_prediction`). Dit stelt je in staat om:
+
+- Te controleren of de modellen het eens zijn — hoge overeenkomst geeft meer vertrouwen in de uitkomst
+- Afwijkende modellen te signaleren als early warning
+- De toegevoegde waarde van het ensemble te beoordelen t.o.v. het ratio-model als simpele baseline
+
+Zie [Output lezen](../output-begrijpen.md) voor uitleg over de outputkolommen.
+
+<iframe src="../../assets/plots/ensemble_comparison.html" width="100%" height="500" frameborder="0" style="border-radius: 8px;"></iframe>
+
+*Vergelijking individuele modellen vs ensemble voor drie voorbeeldopleidingen (demodata)*
+
 ## Hoe worden de gewichten bepaald?
 
-De ensemble-gewichten worden bepaald via een **grid search** over gewichtscombinaties (percentageparen). Voor elke combinatie van gewichten wordt de historische fout (MAE en MAPE) berekend over meerdere voorgaande jaren. De combinatie met de laagste historische fout wordt gekozen als optimale weging.
+De gewichten in de pipeline komen uit **twee verschillende bronnen**, die elk iets anders wegen:
 
-Dit is bewust anders dan een eenvoudige inverse-MAE weging: de grid search optimaliseert de gewichten direct op de ensemble-uitkomst, niet op de individuele modelfouten. Hierdoor wordt rekening gehouden met correlatie tussen modellen.
+1. **Grid-search-gewichten** (`ensemble_weights.xlsx`) — bepalen per opleiding, examentype en herkomst hoe zwaar de losse modellen (SARIMA, XGBoost, ratio) meewegen. Deze worden geleerd uit historische fouten (hieronder beschreven).
+2. **Configuratiegewichten** (`ensemble_weights` in `configuration.json`) — bepalen per weekperiode hoe zwaar SARIMA-individueel versus SARIMA-cumulatief meeweegt (zie [Configureerbare ensemble-gewichten](#configureerbare-ensemble-gewichten)).
+
+!!! warning "Twee bronnen — controleer de voorrang in de configuratie-docs"
+    Deze pagina beschrijft beide gewichtbronnen los van elkaar. Welke bron voorrang krijgt wanneer ze allebei aanwezig zijn, staat niet op deze pagina vast; raadpleeg de [Configuratie](../configuratie.md)-documentatie voor de precieze voorrangsregel.
+
+De **grid-search-gewichten** worden bepaald via een grid search over gewichtscombinaties (percentageparen). Voor elke combinatie van gewichten wordt de historische fout (MAE en MAPE) berekend over meerdere voorgaande jaren. De combinatie met de laagste historische fout wordt gekozen als optimale weging.
+
+Dit is bewust anders dan een eenvoudige inverse-MAE weging (waarbij elk model automatisch gewicht krijgt omgekeerd evenredig aan zijn eigen fout — een nauwkeuriger model weegt dan zwaarder). De grid search optimaliseert de gewichten namelijk direct op de ensemble-uitkomst, niet op de individuele modelfouten. Hierdoor wordt rekening gehouden met correlatie tussen modellen.
 
 De optimale gewichten worden opgeslagen in `ensemble_weights.xlsx` en worden per opleiding, examentype en herkomst bepaald.
 
@@ -24,20 +52,6 @@ De optimale gewichten worden opgeslagen in `ensemble_weights.xlsx` en worden per
 ## Bij een eerste run
 
 Als `ensemble_weights.xlsx` nog niet bestaat, gebruikt het model gelijke gewichten voor alle modellen. Dit is een redelijke standaard, maar niet optimaal. Draai de ensemble-optimalisatie pas nadat je één volledig studiejaar aan output hebt.
-
-## Ensemble vs. individuele modellen
-
-In de output staan zowel de individuele modelvoorspellingen (`SARIMA_individual`, `SARIMA_cumulative`, `Prognose_ratio`) als de ensemble-voorspelling (`Ensemble_prediction`). Dit stelt je in staat om:
-
-- Te controleren of de modellen het eens zijn — hoge overeenkomst geeft meer vertrouwen in de uitkomst
-- Afwijkende modellen te signaleren als early warning
-- De toegevoegde waarde van het ensemble te beoordelen t.o.v. het ratio-model als simpele baseline
-
-Zie [Output begrijpen](../output-begrijpen.md) voor uitleg over de outputkolommen.
-
-<iframe src="../../assets/plots/ensemble_comparison.html" width="100%" height="500" frameborder="0" style="border-radius: 8px;"></iframe>
-
-*Vergelijking individuele modellen vs ensemble voor drie voorbeeldopleidingen (demodata)*
 
 ## Configureerbare ensemble-gewichten
 
@@ -63,6 +77,6 @@ De gewichten gelden voor specifieke weekperiodes en examentypes:
 | `week_35_37` | Weken 35 t/m `final_academic_week - 1` (vlak voor de einddeadline) |
 | `default` | Alle overige situaties |
 
-De **einddeadline** (`final_academic_week`) gebruikt altijd 100% het individuele SARIMA-model. De bovengrens van de `week_35_37`-band en deze eindweek **schalen mee met** [`model_config.final_academic_week`](../configuratie.md#final_academic_week) (standaard week 38; voor het UvA SQL-telbestand week 36). Bij `final_academic_week = 36` loopt de `week_35_37`-band dus alleen over week 35 en is week 36 de 100%-individueel-week. De gewichten zelf zijn configureerbaar; de weekgrenzen volgen `final_academic_week`.
+De **einddeadline** gebruikt altijd 100% het individuele SARIMA-model. De weekgrenzen (waaronder deze eindweek) volgen [`model_config.final_academic_week`](../configuratie-referentie.md#final_academic_week); de gewichten zelf zijn configureerbaar.
 
 Pas de gewichten aan op basis van validatieresultaten voor jouw instelling. Zie [Configuratie](../configuratie.md) voor de volledige optiedocumentatie.

--- a/docs/methodologie/index.md
+++ b/docs/methodologie/index.md
@@ -2,14 +2,10 @@
 
 Deze sectie legt per model uit **hoe het werkt**, **waarom deze keuze is gemaakt** en **wanneer je de output kritisch moet beoordelen**.
 
-!!! info "Verhouding tot de Radboud-implementatie"
-    De methodologie op deze pagina's komt voort uit het model dat oorspronkelijk bij Radboud is ontwikkeld. Die productie-implementatie draait intern en is niet publiek toegankelijk; deze CEDA-versie is de publieke, generieke variant.
-
-    Concreet betekent dat:
-
-    - Modelkeuzes (features, parameters, ensemble-gewichten) zijn dezelfde als die in de Radboud-implementatie en worden hier per pagina onderbouwd.
-    - Radboud-specifieke configuratie (faculteitsnamen, programma-lijsten) is uit de gedeelde code gehaald en moet door elke instelling zelf worden ingevuld via `configuration.json`.
-    - Waar de aanpak afwijkt van een rechttoe rechtaan implementatie — bijvoorbeeld de vaste week-38 override voor 2021 — wordt dat expliciet vermeld.
+!!! abstract "In het kort"
+    - **Wat je hier vindt:** per model hoe het werkt, waarom die keuze is gemaakt, en wanneer je de output kritisch moet beoordelen.
+    - **Twee sporen:** de pipeline draait een cumulatief spoor (telbestanden) en een individueel spoor (per-student data) en combineert ze in het ensemble.
+    - **Nieuw hier?** Begin bij de modellenkaart hieronder en klik door naar het model dat je gebruikt.
 
 ## Modellen in het ensemble
 
@@ -23,7 +19,9 @@ Deze sectie legt per model uit **hoe het werkt**, **waarom deze keuze is gemaakt
 | Ensemble | [Ensemble](ensemble.md) | Gewogen combinatie van bovenstaande modellen |
 | Benchmarks | [Benchmarks](benchmarks.md) | Vergelijking van alternatieve modellen |
 
-Het cumulatieve spoor is configureerbaar: via `model_config.cumulative_timeseries` en `model_config.cumulative_regressor` in de [configuratie](../configuratie.md#cumulative_timeseries) kies je welk tijdreeksmodel en welk regressiemodel wordt gebruikt.
+Twee termen die in de tabel terugkomen: een **geaggregeerde curve** ontstaat door de losse voorspellingen op te tellen tot één wekelijkse lijn per opleiding, en **extrapolatie** is het doortrekken van die lijn naar het einde van het jaar (week 38).
+
+Het cumulatieve spoor is configureerbaar: via `model_config.cumulative_timeseries` en `model_config.cumulative_regressor` in de [configuratie](../configuratie-referentie.md#cumulative_timeseries) kies je welk tijdreeksmodel en welk regressiemodel wordt gebruikt.
 
 ## Datasporen
 
@@ -54,6 +52,10 @@ Alleen in `-d b` worden `SARIMA_individual` en `SARIMA_cumulative` samengevoegd 
 
 *Individueel spoor: per-student records → XGBoost classifier → ΣP = verwacht cohort (demodata)*
 
+## Verhouding tot de Radboud-implementatie
+
+De methodologie op deze pagina's komt voort uit het model dat oorspronkelijk bij Radboud is ontwikkeld; zie [In de praktijk](../index.md#in-de-praktijk) op de homepagina voor de achtergrond. Voor de methodologie is één ding van belang: modelkeuzes (features, parameters, gewichten) zijn dezelfde als in de Radboud-implementatie en worden hier per pagina onderbouwd, terwijl Radboud-specifieke configuratie (faculteitsnamen, programma-lijsten) uit de gedeelde code is gehaald en per instelling wordt ingevuld via `configuration.json`.
+
 ## Aannames en beperkingen
 
 - Het model extrapoleert op basis van historische patronen. **Structurele breuken** (bijv. nieuwe opleiding, COVID-jaar) worden niet automatisch gedetecteerd.
@@ -62,4 +64,4 @@ Alleen in `-d b` worden `SARIMA_individual` en `SARIMA_cumulative` samengevoegd 
 
 ## Dashboard-visualisatie
 
-Na het opslaan van de resultaten genereert de pipeline een interactief Plotly-dashboard per modus. Het dashboard biedt grafieken per opleiding (voorspellingen, foutmaten, feature importance) en wordt opgeslagen als zelfstandig HTML-bestand onder `data/output/visualisaties/`. Zie [Output begrijpen](../output-begrijpen.md#interactief-dashboard) voor details.
+Na het opslaan van de resultaten genereert de pipeline een interactief Plotly-dashboard per modus. Het dashboard biedt grafieken per opleiding (voorspellingen, foutmaten, feature importance) en wordt opgeslagen als zelfstandig HTML-bestand onder `data/output/visualisaties/`. Zie [Output lezen](../output-begrijpen.md#interactief-dashboard) voor details.

--- a/docs/methodologie/individueel.md
+++ b/docs/methodologie/individueel.md
@@ -1,5 +1,11 @@
 # Individueel model
 
+!!! abstract "In het kort"
+    - **Wat het doet:** schat per aanmelder de kans dat die zich inschrijft, telt die kansen op en extrapoleert de curve naar het einde van het jaar.
+    - **Vertrouw het als:** persoonskenmerken (vooropleiding, herkomst) sterk meebepalen wie doorstroomt en er al veel aanmelders binnen zijn.
+    - **Wees voorzichtig als:** de opleiding nieuw is, het beleid veranderde, of er nog weinig aanmelders zijn.
+    - **In het ensemble:** levert `SARIMA_individual`; in de both-modus gewogen gecombineerd met het cumulatieve `SARIMA_cumulative`.
+
 Het individueel model voorspelt het verwachte cohortaantal door **per individuele student** een inschrijfkans te schatten en die kansen vervolgens te aggregeren tot een wekelijkse cumulatieve curve, die met SARIMA wordt geëxtrapoleerd naar week 38.
 
 Dit is fundamenteel anders dan het cumulatieve spoor: in plaats van geaggregeerde wekelijkse telbestanden te modelleren, werkt dit spoor op **per-student records** uit Osiris/Usis. Dat geeft toegang tot persoonskenmerken (vooropleiding, herkomst, nationaliteit, …) die in geaggregeerde data verloren gaan.
@@ -20,10 +26,8 @@ studentprognose -d b -w 6 -y 2024   # individueel + cumulatief → ensemble
 
 In de `-d b` (both) modus draait dit model parallel aan het cumulatieve spoor; de uitkomsten worden gecombineerd in het [ensemble](ensemble.md).
 
-!!! warning "Sleutelruimte in both-modus: individueel keyt op naam, cumulatief op Isatcode"
-    Sinds de [isatcode-migratie](../je-data-voorbereiden.md) keyt het cumulatieve spoor (en het label) op de numerieke `Isatcode`, terwijl het individuele spoor nog op de **leesbare opleidingsnaam** keyt. Die twee sleutelruimtes overlappen niet, dus de feature-merge tussen beide sporen matcht in de praktijk **0 rijen** op de programmesleutel — de cumulatieve features worden niet daadwerkelijk op de individuele records gejoind. De sporen worden daardoor pas op het **ensemble**-niveau gecombineerd, niet op feature-niveau.
-
-    Dit is gedrag dat losstaat van het sleutel-dtype (ook met de oude string-sleutel matchte de join al niets). De merges zijn dtype-veilig gemaakt zodat ze niet crashen; het structureel uitlijnen van beide sporen op één sleutel wordt opgevolgd in [#238](https://github.com/cedanl/studentprognose/issues/238). Interpreteer de both-uitkomst dus als een **ensemble van twee onafhankelijk geschatte sporen**, niet als een individueel model dat met cumulatieve features is verrijkt.
+!!! warning "Both-modus: twee onafhankelijke voorspellingen"
+    In de both-modus (`-d b`) schat het model beide sporen **onafhankelijk** en combineert ze pas op **ensembleniveau** — de individuele records worden niet verrijkt met cumulatieve cijfers. Interpreteer de both-uitkomst dus als een combinatie van twee losse voorspellingen, niet als een individueel model dat met cumulatieve gegevens is aangevuld.
 
 ## Pipeline op hoofdlijnen
 
@@ -54,19 +58,6 @@ De classifier vertaalt persoonskenmerken naar een kans. De SARIMA extrapoleert d
 
 Voordat de classifier draait, wordt de ruwe per-student data gefilterd en verrijkt. De filterregels zijn bewust streng zodat het model alleen leert van vergelijkbare cases.
 
-```mermaid
-flowchart TD
-    R["Ruwe Osiris/Usis records"] --> F1["Filter:<br/>Ingangsdatum 01-09 of 01-10"]
-    F1 --> F2["Filter:<br/>Eerstejaars croho = 1<br/>Hogerejaars = 0<br/>BBC = 0"]
-    F2 --> F3["Filter:<br/>Examentype ∈ {Bachelor,<br/>Master, Pre-master}"]
-    F3 --> A1["Afleiden:<br/>Herkomst (NL / EER / Niet-EER)<br/>op basis van nationaliteit + EER"]
-    A1 --> A2["Afleiden:<br/>Weeknummer uit datum"]
-    A2 --> A3["Afleiden:<br/>Deadlineweek (week 17,<br/>Bachelor niet-NF)"]
-    A3 --> A4["Afleiden:<br/>is_numerus_fixus,<br/>Sleutel_count per student"]
-    A4 --> A5["Categorie-opschoning:<br/>kleine nationaliteiten →<br/>'Overig' (<100)"]
-    A5 --> Out["Klaar voor classifier"]
-```
-
 Belangrijke afleidingen:
 
 - **Herkomst** — afgeleid uit nationaliteit + EER-vlag (`Nederlandse` → NL; overig EER → EER; rest → Niet-EER). Dit normaliseert kleine landverschillen tot drie hanteerbare groepen.
@@ -80,7 +71,7 @@ Studenten van wie de aanmelding is ingetrokken vóór de voorspelweek krijgen la
 
 ### Wat doet het?
 
-Per individuele student wordt de **kans op inschrijving** geschat: $P(\text{ingeschreven} \mid \text{features})$. De voorspelling is een waarschijnlijkheid tussen 0 en 1, geen harde label.
+Per individuele student schat het model **hoe waarschijnlijk het is dat die zich inschrijft**, gegeven wat we van de aanmelder weten (de features). Het antwoord is een getal tussen 0 en 1 — dus een kans, geen harde ja/nee. In formulevorm: $P(\text{ingeschreven} \mid \text{features})$.
 
 ### Waarom XGBoost?
 
@@ -107,19 +98,10 @@ Categorische features worden one-hot geëncodeerd. Onbekende categorieën in de 
 
 ### Training / test split
 
-```mermaid
-flowchart LR
-    H["Historische jaren<br/>≥ min_training_year<br/>(standaard 2016)"] --> T["Train set"]
-    P["Voorspeljaar"] --> X["Test set<br/>(weken ≤ voorspelweek)"]
-    T --> M["XGBoost<br/>binary:logistic"]
-    X --> M
-    M --> Pr["P(inschrijving)<br/>per student"]
-```
-
 - **Train** — alle historische jaren vanaf `min_training_year` (configureerbaar, standaard 2016), exclusief het voorspeljaar zelf.
 - **Test** — aanmeldingen uit het voorspeljaar tot en met de voorspelweek.
 - **Vermijden van data leakage** — intrekkingen na de voorspelweek worden uit de trainingsdata gefilterd; je mag niet weten wat na week *w* gebeurt als je *voor* week *w* voorspelt.
-- **Backtest-modus** — wanneer je een eerder jaar voorspelt (`predict_year < max_year`), worden zowel het voorspeljaar *als* het meest recente jaar uit de trainingsdata weggelaten. Anders zou het model toekomstige informatie zien die op het simulatie-moment nog niet bestond. Bij voorspellingen voor het meest recente jaar (`predict_year == max_year`) blijft alle historie tot dat jaar gewoon in de trainingsset.
+- **Backtest-modus** — een *backtest* betekent dat je doet alsof je in het verleden staat: je voorspelt een jaar waarvan de uitkomst eigenlijk al bekend is, om te controleren hoe goed het model toen zou hebben gepresteerd. Wanneer je zo'n eerder jaar voorspelt (`predict_year < max_year`), worden zowel het voorspeljaar *als* het meest recente jaar uit de trainingsdata weggelaten. Anders zou het model toekomstige informatie zien die op het simulatie-moment nog niet bestond. Bij voorspellingen voor het meest recente jaar (`predict_year == max_year`) blijft alle historie tot dat jaar gewoon in de trainingsset.
 
 Trainingsdata vóór `min_training_year` wordt bewust weggelaten omdat oudere cohorten een ander aanmeldgedrag vertonen (andere wettelijke kaders, andere studieduur, vóór de invoering van het BSA-regime).
 

--- a/docs/methodologie/ratio-model.md
+++ b/docs/methodologie/ratio-model.md
@@ -1,5 +1,11 @@
 # Ratio-model
 
+!!! abstract "In het kort"
+    - **Wat het doet:** past de historische verhouding tussen aanmeldvolume en inschrijvingen toe op het huidige aanmeldvolume.
+    - **Vertrouw het als:** de instroom stabiel is en je een transparante, uitlegbare schatting nodig hebt.
+    - **Wees voorzichtig als:** er sprake is van structurele groei of daling, een uitzonderlijk jaar (bijv. COVID) in de historie zit, of het nog vroeg in het jaar is.
+    - **In het ensemble:** dient als eenvoudige baseline en sanity-check waartegen de complexere modellen worden afgezet.
+
 Het ratio-model is het eenvoudigste model in de pipeline en dient als **referentiemodel**: volledig transparant, altijd beschikbaar, ook zonder betrouwbare trainingsdata voor de complexere modellen.
 
 !!! tip "Uitgebreide versie — Jupyter notebook"
@@ -10,17 +16,20 @@ Het ratio-model is het eenvoudigste model in de pipeline en dient als **referent
 
 Het ratio-model berekent per opleiding de historische verhouding tussen het totale aanmeldvolume op een bepaald moment in het jaar en het uiteindelijke aantal inschrijvingen. Die ratio wordt vervolgens toegepast op het huidige aanmeldvolume.
 
-**Definitie van aanmeldvolume:**
+Kort gezegd: als in de afgelopen jaren rond deze week een vaste fractie van het aanmeldvolume uiteindelijk tot inschrijving leidde, dan gaat het model ervan uit dat die verhouding dit jaar weer opgaat.
 
-$$\text{Aanmelding} = \text{Ongewogen vooraanmelders} + \text{Inschrijvingen}$$
+??? note "De formules"
+    **Definitie van aanmeldvolume:**
 
-**Historische ratio (gemiddeld over 3 jaar):**
+    $$\text{Aanmelding} = \text{Ongewogen vooraanmelders} + \text{Inschrijvingen}$$
 
-$$\bar{R}_{t} = \frac{1}{3} \sum_{j=1}^{3} \frac{\text{Aanmelding}_{jaar-j,\, week=t}}{\text{Aantal\_studenten}_{jaar-j}}$$
+    **Historische ratio (gemiddeld over 3 jaar):**
 
-**Voorspelling:**
+    $$\bar{R}_{t} = \frac{1}{3} \sum_{j=1}^{3} \frac{\text{Aanmelding}_{jaar-j,\, week=t}}{\text{Aantal\_studenten}_{jaar-j}}$$
 
-$$\hat{y} = \frac{\text{Aanmelding}_{huidig,\, week=t}}{\bar{R}_{t}}$$
+    **Voorspelling:**
+
+    $$\hat{y} = \frac{\text{Aanmelding}_{huidig,\, week=t}}{\bar{R}_{t}}$$
 
 <iframe src="../../assets/plots/ratio_historical.html" width="100%" height="480" frameborder="0" style="border-radius: 8px;"></iframe>
 
@@ -30,7 +39,7 @@ Het venster van 3 jaar is vastgelegd in de constante `LOOKBACK_YEARS` (`src/stud
 
 ## Numerus fixus-correctie
 
-Na de basisberekening past het model een **cap** toe voor numerus fixus-opleidingen: als de gesommeerde voorspelling over herkomstgroepen het vastgestelde maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep.
+Numerus fixus-opleidingen kennen een wettelijk vastgesteld maximum aantal plaatsen; meer studenten dan dat maximum kunnen niet instromen. Daarom past het model na de basisberekening een **cap** toe: als de gesommeerde voorspelling over de herkomstgroepen het maximum overschrijdt, wordt het overschot afgetrokken van de NL-herkomstgroep. Dat het overschot juist bij de NL-groep wordt weggehaald (en niet evenredig over alle groepen) is een beleidskeuze in de correctie.
 
 ## Waarom een ratio-model?
 
@@ -39,11 +48,15 @@ Na de basisberekening past het model een **cap** toe voor numerus fixus-opleidin
 3. **Baseline** — als het ensemble structureel slechter presteert dan de ratio, is er iets mis met de complexere modellen
 4. **Auditeerbaar** — geschikt voor interne verantwoording richting management
 
-## Beperkingen
+## Wanneer vertrouw je het niet?
 
 - Geen rekening met trends: bij structurele groei of daling is de 3-jaars ratio achterhaald.
 - Gevoelig voor uitschieters: één abnormaal jaar (bijv. COVID) kan de gemiddelde ratio sterk beïnvloeden.
 - Week-afhankelijk: de ratio varieert per week. Vroeg in het jaar (weinig aanmelders) is de ratio minder stabiel.
+
+## Relatie tot andere modellen
+
+Het ratio-model is de **baseline** van de pipeline: de eenvoudigste, volledig transparante schatting waartegen de complexere modellen worden afgezet. In het [ensemble](ensemble.md) fungeert het als sanity-check — presteert het ensemble structureel slechter dan de kale ratio, dan is dat een signaal dat er iets mis is met de zwaardere modellen ([SARIMA](sarima.md), [XGBoost](xgboost.md)) en niet dat de ratio het toevallig goed doet. Omdat het geen trainingsdata nodig heeft buiten de historische ratio, is het bovendien altijd beschikbaar, ook als de andere modellen door datagebrek afvallen.
 
 ## Implementatie
 

--- a/docs/methodologie/sarima.md
+++ b/docs/methodologie/sarima.md
@@ -1,5 +1,11 @@
 # SARIMA
 
+!!! abstract "In het kort"
+    - **Wat het doet:** trekt de wekelijkse aanmeldcurve van een opleiding door naar het verwachte eindaantal, op basis van hoe die curve in eerdere jaren liep.
+    - **Vertrouw het als:** de opleiding meerdere jaren stabiele historie heeft en het aanmeldpatroon van jaar tot jaar op elkaar lijkt.
+    - **Wees voorzichtig als:** de opleiding nieuw is (< 3 jaar data), na een uitzonderlijk jaar (bijv. COVID), of vroeg in het jaar wanneer er nog weinig datapunten zijn.
+    - **In het ensemble:** levert de tijdreeksvoorspelling per opleiding per week; in de both-modus gecombineerd met de XGBoost-uitkomsten.
+
 SARIMA staat voor **Seasonal AutoRegressive Integrated Moving Average**. Het is het kerntijdreeksmodel in de pipeline en wordt ingezet in zowel het cumulatieve als het individuele spoor.
 
 !!! tip "Uitgebreide versie — Jupyter notebook"
@@ -22,6 +28,8 @@ Aanmelddata heeft een sterk seizoenspatroon (jaarlijkse cyclus, wekelijkse granu
 
 $$SARIMA(p, d, q)(P, D, Q)_{52}$$
 
+Deze getallen bepalen hoeveel het model naar het verleden en naar het seizoen kijkt; als gebruiker hoef je ze zelden aan te passen.
+
 De nominale seizoenslengte is **52 weken** (één jaar). In het cumulatieve spoor wordt deze automatisch verkleind naar het werkelijke aantal gevulde weken per jaar wanneer dat lager ligt — zie [Seizoenslengte: afgeleid uit de data](#seizoenslengte-afgeleid-uit-de-data). De overige parameters zijn standaard **vaste waarden** (voor het cumulatieve spoor optioneel af te stemmen — zie [Orde-selectie (tuning)](#orde-selectie-tuning)). De keuze hangt af van het spoor en het moment in het jaar:
 
 | Situatie | Order `(p,d,q)` | Seizoensorder `(P,D,Q)` |
@@ -30,9 +38,10 @@ De nominale seizoenslengte is **52 weken** (één jaar). In het cumulatieve spoo
 | Individueel — Bachelor, weken 17–21 | `(1, 0, 1)` | `(1, 1, 1)` |
 | Individueel — overige gevallen | `(1, 1, 1)` | `(1, 1, 0)` |
 
-De implementatie gebruikt `statsforecast.models.ARIMA` (Nixtla) als backend. Dit vervangt de eerdere `statsmodels.tsa.statespace.SARIMAX`-backend. De modelspecificatie is identiek; het verschil zit in de schattingsmethode: **CSS-ML** (conditional sum of squares, gevolgd door maximum likelihood) in plaats van MLE via een Kalman-filter. Dit levert een snelheidswinst van ~10–15× per reeks op bij gelijkwaardige nauwkeurigheid.
+Onder de motorkap gebruikt het model een snellere rekenmethode met gelijkwaardige nauwkeurigheid.
 
-Zie `src/studentprognose/models/sarima.py` voor de `SARIMAForecaster`-klasse.
+??? note "Technisch: schattingsmethode"
+    De implementatie gebruikt `statsforecast.models.ARIMA` (Nixtla) als backend. Dit vervangt de eerdere `statsmodels.tsa.statespace.SARIMAX`-backend. De modelspecificatie is identiek; het verschil zit in de schattingsmethode: **CSS-ML** (conditional sum of squares, gevolgd door maximum likelihood) in plaats van MLE via een Kalman-filter. Dit levert een snelheidswinst van ~10–15× per reeks op bij gelijkwaardige nauwkeurigheid. Bij zeer korte reeksen of reeksen met ontbrekende waarden kan dit iets afwijkende parameterschattingen opleveren.
 
 ## Orde-selectie (tuning)
 
@@ -73,14 +82,13 @@ Orde-tuning raakt uitsluitend stap 1 van het cumulatieve spoor (de curve-extrapo
 
 ## Exogene variabelen (individueel spoor)
 
-In het individuele spoor kan een deadlineweek-variabele als exogene regresssor worden meegegeven. Dit markeert weken 16–17 (Bachelor niet-numerus fixus) of weken 1–2 (numerus fixus) als deadlineweek, zodat het model de aanmeldpiek rond deadlines beter kan modelleren.
+In het individuele spoor kan een deadlineweek-variabele als exogene regressor worden meegegeven. Dit markeert weken 16–17 (Bachelor niet-numerus fixus) of weken 1–2 (numerus fixus) als deadlineweek, zodat het model de aanmeldpiek rond deadlines beter kan modelleren.
 
 ## Aannames
 
 1. **Herhaalbaar seizoenspatroon** — het model gaat ervan uit dat het patroon van dit jaar op het patroon van voorgaande jaren lijkt. Dit geldt niet bij structurele veranderingen (nieuwe opleiding, beleidsingreep, COVID).
 2. **Voldoende historische data** — trainingsdata start vanaf het jaar ingesteld via `min_training_year` in `configuration.json` (standaard 2016). Bij opleidingen met minder dan ~3 jaar data zijn de seizoensschattingen onbetrouwbaar.
 3. **Stationariteit** — het model past één seizoensdifferentiatie toe (`D=1`). Als de trend structureel niet-stationair is, kan de differentiatie onvoldoende zijn.
-4. **CSS-ML schattingsmethode** — de backend gebruikt conditional sum of squares als startpunt voor maximum likelihood. Dit is sneller dan exact MLE via het Kalman-filter, maar kan bij zeer korte reeksen of reeksen met ontbrekende waarden iets afwijkende parameterschattingen opleveren.
 
 ## Wanneer vertrouw je het niet?
 
@@ -91,42 +99,33 @@ In het individuele spoor kan een deadlineweek-variabele als exogene regresssor w
 
 ## Academische-jaargrens (`final_academic_week`)
 
-Het cumulatieve spoor modelleert één academisch jaar als een vaste week-volgorde die loopt van de reset-week (`final_academic_week + 1`) via week 52 door naar `final_academic_week` van het jaar erop. Deze grens bepaalt de voorspelhorizon (`pred_len`), de seizoensvolgorde van de kolommen en de reset-week die als nulpunt wordt geïnjecteerd.
-
-Standaard is dit **week 38** (eind september, de inschrijfdeadline van het legacy Studielink-instellingsformaat). De grens is configureerbaar via `model_config.final_academic_week` omdat niet elke leverancier dezelfde kalender hanteert:
-
-- **Legacy instellingsformaat:** leveringen lopen tot week 38 → `final_academic_week = 38`.
-- **UvA SQL-telbestand:** de aanmeldfase eindigt rond week 36; er zijn geen leveringen in de weken 37–39 (de Studielink-cyclus reset daar). Met de standaard 38 zou het model proberen te voorspellen tot een week die niet in de data bestaat. Daarom `final_academic_week = 36`.
-
-**Aanname:** de waarde moet overeenkomen met de week tot waar de aanmeldfase daadwerkelijk gegevens levert. Een te hoge waarde laat de voorspelling crashen of extrapoleert naar niet-bestaande weken; een te lage waarde kapt de voorspelhorizon onnodig af. De grens geldt voor het cumulatieve spoor; het individuele spoor gebruikt de vaste Studielink-kalender (week 38).
-
-!!! warning "52-weeks model en ISO-week 53"
-    Het seizoensvenster omvat maximaal **52 weken**. In lange ISO-jaren (bijv. een leverdatum eind december 2020 of 2026) levert de afleiding uit de leverdatum **ISO-week 53** op. Zulke weeksnapshots blijven wél in `vooraanmeldingen_cumulatief.csv` staan, maar vallen **buiten het seizoensvenster** dat het cumulatieve model gebruikt — ze worden niet meegetraind (de ETL geeft hierover een waarschuwing). Voor de jaaroverzichten betekent dit dat de allerlaatste decembersnapshot van een lang ISO-jaar niet apart wordt gemodelleerd; de eerstvolgende januarisnapshot (week 1) vangt de cumulatieve stand weer op. Volledige ondersteuning van week 53 zou een variabele seizoenslengte vereisen en is bewust niet in deze stap meegenomen.
+Het cumulatieve spoor modelleert één academisch jaar dat standaard eindigt in **week 38** (eind september, de inschrijfdeadline). Deze grens bepaalt hoe ver het model vooruit voorspelt en is configureerbaar via `model_config.final_academic_week`, omdat niet elke leverancier dezelfde kalender hanteert (het UvA SQL-telbestand levert bijvoorbeeld tot week 36). De waarde moet overeenkomen met de laatste week waarin de aanmeldfase echt gegevens levert: te hoog en het model voorspelt naar niet-bestaande weken, te laag en de voorspelhorizon wordt onnodig afgekapt. De grens geldt voor het cumulatieve spoor; het individuele spoor gebruikt de vaste Studielink-kalender (week 38).
 
 ## Seizoenslengte: afgeleid uit de data
 
-De seizoenslag bepaalt naar welk punt in het verleden het model kijkt om "dezelfde week vorig jaar" te vinden. Nominaal is dat **52 weken**. Het cumulatieve spoor zet een reeks echter in elkaar door de trainingsjaren achter elkaar te plakken over precies de weekkolommen die ná het pivotteren bestaan — de **union van gevulde weken** over alle jaren en opleidingen, plus de geïnjecteerde reset-week. Lege start- en eindweken (vóór de openbaarmakingsdrempel van de telleverancier — bij UvA `Aantal ≥ 21` — en nadat de aanmeldingen weer onder die drempel zakken) bestaan niet als kolom. Die union telt daardoor **minder dan 52 weken** (op de huidige UvA-demodata empirisch ruwweg 43–45). Dat aantal is de werkelijke jaarblok-lengte ("stride") van de afgevlakte reeks.
+De seizoenslengte bepaalt naar welk punt in het verleden het model kijkt om "dezelfde week vorig jaar" te vinden. Nominaal is dat 52 weken, maar in de praktijk zijn niet alle weken van het jaar gevuld met aanmeldingen. Daarom bepaalt het cumulatieve spoor de jaarcyclus **uit de data** in plaats van blind 52 weken aan te houden. De aanpassing verkleint de lengte alleen; een volledig gevuld jaar houdt gewoon 52 weken aan.
 
-Staat de seizoenslag vast op 52 terwijl de stride korter is, dan wijst de lag naar de **verkeerde week-in-het-jaar**: de jaarcyclus staat uit fase en het model kan de seizoensvorm niet reproduceren. Het netto-effect op de prognose is datagedreven — op de UvA-funneldata uit dit zich concreet als een prognose die ná de piek **omhoog drijft in plaats van mee te dalen** met de werkelijke (teruglopende) openstaande vooraanmeldingen.
+Het praktische signaal: **krijg je een prognose die ná de piek omhoog drijft in plaats van mee te dalen** met de teruglopende aanmeldingen, dan is een verkeerd uitgelijnde seizoenslengte vaak de oorzaak.
 
-Daarom stelt het cumulatieve spoor de seizoenslengte gelijk aan deze stride (`len(get_all_weeks_valid(...))`, inclusief de reset-week). De aanpassing **verkleint alleen**: een volledig gevulde cyclus (stride == 52) houdt `season_length = 52`, dus correct gevulde reeksen blijven ongemoeid. Dezelfde afleiding wordt toegepast in de [benchmark](benchmarks.md), zodat modelselectie hetzelfde model meet als productie.
+**Aanname:** de set gevulde weken is over de jaren heen stabiel genoeg om de jaarcyclus goed te benaderen. **Wanneer vertrouw je het niet?** Bij leveranciers of opleidingen waar de gevulde weken sterk wisselen tussen jaren, of bij een gemengde dataset met uiteenlopende weekdekking.
 
-**Aanname:** de set gevulde weken is over de jaren heen stabiel genoeg dat de union een goede benadering is van de cyclus per jaar. Wisselt de weekdekking sterk per jaar, dan wordt de seizoensuitlijning minder scherp.
+??? note "Technisch: hoe de seizoenslengte wordt bepaald"
+    Het cumulatieve spoor plakt de trainingsjaren achter elkaar over precies de weekkolommen die ná het pivotteren bestaan — de **union van gevulde weken** over alle jaren en opleidingen, plus de geïnjecteerde reset-week (`final_academic_week + 1`). Lege start- en eindweken (vóór de openbaarmakingsdrempel van de telleverancier — bij UvA `Aantal ≥ 21` — en nadat de aanmeldingen weer onder die drempel zakken) bestaan niet als kolom. Die union telt daardoor minder dan 52 weken (op de huidige UvA-demodata ruwweg 43–45); dat aantal is de werkelijke jaarblok-lengte ("stride"), waaraan de seizoenslengte gelijk wordt gesteld (`len(get_all_weeks_valid(...))`). Dezelfde afleiding wordt toegepast in de [benchmark](benchmarks.md), zodat modelselectie hetzelfde model meet als productie.
 
-**Wanneer vertrouw je het niet?** Bij leveranciers of opleidingen waar de set gevulde weken sterk wisselt tussen jaren, of bij een gemengde dataset waarin cohorten een uiteenlopende weekdekking hebben.
+??? note "52-weeks model en ISO-week 53"
+    Het seizoensvenster omvat maximaal **52 weken**. In lange ISO-jaren (bijv. een leverdatum eind december 2020 of 2026) levert de afleiding uit de leverdatum **ISO-week 53** op. Zulke weeksnapshots blijven wél in `vooraanmeldingen_cumulatief.csv` staan, maar vallen **buiten het seizoensvenster** dat het cumulatieve model gebruikt — ze worden niet meegetraind (de ETL geeft hierover een waarschuwing). De eerstvolgende januarisnapshot (week 1) vangt de cumulatieve stand weer op.
 
 ## Bekende hardgecodeerde uitzondering: 2021
 
-In `utils/weeks.py` staat een expliciete uitzondering voor collegejaar 2021:
+Dit illustreert een bredere aanname: **het model gaat ervan uit dat historische aanmeldpatronen representatief zijn**. Uitzonderingsjaren zoals 2021 (COVID) moeten handmatig worden afgehandeld.
 
-```python
-if predict_year == 2021:
-    max_week = 38
-```
+??? note "Technisch: de 2021-uitzondering in `utils/weeks.py`"
+    ```python
+    if predict_year == 2021:
+        max_week = 38
+    ```
 
-Dit forceert de maximale week voor dat jaar op 38 (de standaard inschrijfdeadline), in plaats van die te berekenen uit de data. De vermoedelijke reden is dat de aanmeldingscyclus in 2021 een afwijkend patroon had door COVID, waardoor de normale berekening geen betrouwbaar resultaat gaf. De achterliggende reden is nog niet formeel gedocumenteerd — zie issue [#84](https://github.com/cedanl/studentprognose/issues/84).
-
-Dit illustreert een bredere aanname: **het model gaat ervan uit dat historische aanmeldpatronen representatief zijn**. Uitzonderingsjaren zoals 2021 moeten handmatig worden afgehandeld.
+    Dit forceert de maximale week voor 2021 op 38 (de standaard inschrijfdeadline) in plaats van die uit de data te berekenen. Vermoedelijk had de aanmeldingscyclus in 2021 door COVID een afwijkend patroon waardoor de normale berekening geen betrouwbaar resultaat gaf. De achterliggende reden is nog niet formeel gedocumenteerd — zie issue [#84](https://github.com/cedanl/studentprognose/issues/84).
 
 ## Alternatieve tijdreeksmodellen
 

--- a/docs/methodologie/xgboost.md
+++ b/docs/methodologie/xgboost.md
@@ -1,5 +1,11 @@
 # XGBoost
 
+!!! abstract "In het kort"
+    - **Wat het doet:** XGBoost voorspelt op twee plekken — als classifier de inschrijfkans per individuele student, en als regressor het totale cohortaantal uit het wekelijkse vooraanmeldpatroon.
+    - **Vertrouw het als:** er genoeg historische inschrijfpatronen zijn die representatief zijn voor het huidige cohort.
+    - **Wees voorzichtig als:** de samenstelling van vooraanmelders sterk afwijkt van de historie (nieuwe campagne, gewijzigd beleid), of bij opleidingen met weinig historische data.
+    - **In het ensemble:** levert de classifier de curve van het individuele spoor en de regressor de inschrijvingsschatting van het cumulatieve spoor; beide gaan mee in de gewogen eindvoorspelling.
+
 XGBoost wordt op twee plekken ingezet in de pipeline, met fundamenteel verschillende rollen: als **classifier** (individueel spoor) en als **regressor** (cumulatief spoor).
 
 !!! tip "Uitgebreide versie — Jupyter notebook"
@@ -18,7 +24,7 @@ De classifier voorspelt per individuele student de **kans dat deze zich uiteinde
 
 ### Waarom XGBoost hier?
 
-De inschrijfkans hangt af van meerdere interacterende factoren. XGBoost vangt niet-lineaire interacties op zonder expliciete feature engineering, en is robuust bij scheve klasseverdeling (de meeste vooraanmelders schrijven zich wel in — de klassen zijn ongelijk verdeeld).
+De inschrijfkans hangt af van meerdere factoren die op elkaar inwerken. XGBoost vangt zulke niet-lineaire samenhangen op zonder dat je die vooraf handmatig hoeft te specificeren (geen expliciete feature engineering). Bovendien gaat het goed om met het feit dat er veel meer 'wel'- dan 'niet'-inschrijvers zijn: de meeste vooraanmelders schrijven zich uiteindelijk in, dus de twee klassen zijn ongelijk verdeeld.
 
 ### Features
 
@@ -49,7 +55,7 @@ De regressor voorspelt het **totaal aantal inschrijvingen** per opleiding/herkom
 |------|----------|
 | Numeriek | Collegejaar, weekkolommen (week 1 t/m 38 als afzonderlijke kolommen) |
 | Afgeleid — lagged | `Gewogen_t-2`, `Gewogen_t-5`: gewogen vooraanmelders 2 en 5 weken vóór de voorspelweek |
-| Afgeleid — dynamiek | `Gewogen_acceleration`: tweede afgeleide van de aanmeldstroom — `(huidig − t-2) − (t-2 − t-5)`. Positief = instroom versnelt, negatief = instroom vlakt af. |
+| Afgeleid — dynamiek | `Gewogen_acceleration`: geeft aan of de aanmeldstroom versnelt of juist afvlakt — positief = instroom versnelt, negatief = instroom vlakt af. Berekend als de tweede afgeleide van de aanmeldstroom: `(huidig − t-2) − (t-2 − t-5)`. |
 | Afgeleid — commitment | `exclusivity_ratio`: aandeel aanmelders dat exclusief voor deze opleiding kiest — `Aantal aanmelders met 1 aanmelding / (Ongewogen vooraanmelders + ε)`. Hogere waarde = grotere commitment. |
 | Categorisch | Examentype, Faculteit, Croho groepeernaam, Herkomst |
 
@@ -57,7 +63,7 @@ De lagged en afgeleide features worden per (opleiding × herkomst × examentype 
 
 ### Waarom XGBoost hier?
 
-De relatie tussen het cumulatieve vooraanmeldpatroon en het uiteindelijke inschrijvingsaantal is niet-lineair en varieert per opleiding, herkomst en jaar. XGBoost kan dit patroon leren zonder dat de wekelijkse curve expliciet gemodelleerd hoeft te worden.
+Om dezelfde reden als bij de classifier (zie [Waarom XGBoost hier?](#waarom-xgboost-hier) hierboven): de relatie tussen het cumulatieve vooraanmeldpatroon en het uiteindelijke inschrijvingsaantal is niet-lineair en varieert per opleiding, herkomst en jaar. XGBoost leert dat patroon zonder dat de wekelijkse curve expliciet gemodelleerd hoeft te worden.
 
 ### Wanneer vertrouw je het niet?
 
@@ -66,11 +72,22 @@ De relatie tussen het cumulatieve vooraanmeldpatroon en het uiteindelijke inschr
 
 ---
 
+## Relatie tot andere modellen
+
+De twee XGBoost-modellen staan elk aan het begin van een eigen spoor:
+
+- De **classifier** levert per student een inschrijfkans; die kansen worden gesommeerd tot een cohortcurve die vervolgens met [SARIMA](sarima.md) wordt geëxtrapoleerd naar het einde van het jaar (zie [Individueel model](individueel.md)).
+- De **regressor** vormt stap 2 van het cumulatieve spoor: hij vertaalt het (door SARIMA geëxtrapoleerde) vooraanmeldpatroon naar een verwacht aantal inschrijvingen.
+
+De uitkomsten van beide sporen komen samen in het [ensemble](ensemble.md), waar ze gewogen worden gecombineerd met het [ratio-model](ratio-model.md).
+
+---
+
 ## Feature importance
 
 Na het trainen van elk XGBoost-model wordt de **feature importance** geëxtraheerd en gegroepeerd per oorspronkelijke feature. One-hot geëncodeerde categorieën worden teruggegroepeerd naar hun oorspronkelijke kolom (bijv. alle `Herkomst_NL`, `Herkomst_EER`, … worden samengevoegd tot `Herkomst`). Weeknummers worden weergegeven als `Week 1`, `Week 2`, etc.
 
-De gegroepeerde importances worden getoond in het interactieve dashboard (zie [Output begrijpen](../output-begrijpen.md#interactief-dashboard)).
+De gegroepeerde importances worden getoond in het interactieve dashboard (zie [Output lezen](../output-begrijpen.md#interactief-dashboard)).
 
 <iframe src="../../assets/plots/xgb_classifier_importance.html" width="100%" height="450" frameborder="0" style="border-radius: 8px;"></iframe>
 

--- a/docs/output-begrijpen.md
+++ b/docs/output-begrijpen.md
@@ -1,11 +1,14 @@
-# Output begrijpen
+# Output lezen
 
-De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvoerbestanden: een tussenresultaat en drie eindresultaten.
+De tool schrijft je resultaten naar `data/output/`. Het belangrijkste bestand is **`output_first-years_{modus}.xlsx`** — de prognose per opleiding.
+
+!!! abstract "In het kort"
+    - **Waar staat mijn prognose?** In `output_first-years_{modus}.xlsx`, kolom `Ensemble_prediction` (of `SARIMA_cumulative` bij alleen `-d c`).
+    - **Kan ik hem vertrouwen?** Liggen de modellen dicht bij elkaar en is de historische fout (`MAE`/`MAPE`) klein? Zie [Wanneer is een prognose betrouwbaar?](#wanneer-is-een-prognose-betrouwbaar).
+    - **Wat betekent een getal?** Zie [Kolomdefinities](#kolomdefinities). Onbekende term? Zie [Begrippen](begrippen.md).
 
 !!! tip "Uitgebreide versie — Jupyter notebook"
-    Een uitvoerbare versie die een in-memory pipeline-run uitvoert en de outputkolommen stap
-    voor stap interpreteert (inclusief MAE/MAPE-voorbeelden en modelvergelijking) staat in
-    [`notebooks/06_output_interpreteren.ipynb`](https://github.com/cedanl/studentprognose/blob/main/notebooks/06_output_interpreteren.ipynb).
+    Een uitvoerbare versie die de outputkolommen stap voor stap interpreteert (met MAE/MAPE-voorbeelden en modelvergelijking): [`notebooks/06_output_interpreteren.ipynb`](https://github.com/cedanl/studentprognose/blob/main/notebooks/06_output_interpreteren.ipynb).
 
 ## Outputbestanden
 
@@ -14,7 +17,7 @@ De pipeline schrijft de resultaten naar `data/output/`. Er zijn twee typen uitvo
 | `output_prelim_{modus}.xlsx` | Tussenresultaat | Voorlopige voorspellingen vóór ratio-model, ensemble en foutmaten. Nuttig voor debugging. |
 | `output_first-years_{modus}.xlsx` | Eindresultaat | Eerstejaars voorspellingen per opleiding/herkomst/week |
 | `output_volume_{modus}.xlsx` | Eindresultaat | Totaal studentvolume-voorspellingen (alleen bij `-sy v`) |
-| `_totaal_{studentjaar}_{modus}.xlsx` | Audittrail | Doorlopend bestand waar elke run zijn rijen aan toevoegt. Wordt nooit als input ingelezen. Zie [Audittrail](#audittrail-_totaalxlsx). |
+| `_totaal_{studentjaar}_{modus}.xlsx` | Audittrail | Doorlopend bestand waar elke run zijn rijen aan toevoegt. Wordt nooit als input ingelezen. Zie [Audittrail](#audittrail-_totaal_xlsx). |
 
 `{modus}` is `cumulatief`, `individueel` of `beide`, afhankelijk van de gebruikte `-d` vlag.
 `{studentjaar}` is `first-years`, `higher-years` of `volume`, afhankelijk van `-sy`.
@@ -29,17 +32,13 @@ Naast de week-specifieke `output_*.xlsx`-bestanden — die elke run worden overs
 
 Het bestand wordt **nooit** door de pipeline als input ingelezen — de data loader leest enkel de paden uit `configuration.json`. Daarmee is een circulaire afhankelijkheid structureel uitgesloten.
 
-### Wanneer is de audittrail nuttig?
+**Waarvoor nuttig?** Trends over weken heen volgen (hoe ontwikkelde de voorspelling zich door het seizoen?) en achteraf reconstrueren wanneer een voorspelling is gemaakt (`Run_date`), zonder zelf wekelijkse exports te koppelen.
 
-- **Trends over weken heen** — open één bestand om te zien hoe de voorspelling voor een opleiding zich gedurende het inschrijfseizoen ontwikkelde, zonder dat je zelf wekelijkse exports hoeft te koppelen.
-- **Achteraf reconstrueren** — `Run_date` toont wanneer een voorspelling is gemaakt, wat helpt bij retrospectief onderzoek of audits.
-
-### Bekende limieten
-
-- **Filterwijzigingen tussen runs** worden niet gedetecteerd. Als je in week 10 met `-f base.json` draait en in week 11 met een ander filter, leven beide rijensets naast elkaar in dezelfde audittrail. Geen filterhash; documenteer welke filterconfig hoort bij welke run zelf.
-- **Modelversie-drift**: rijen uit oudere runs kunnen door een andere modelvariant zijn gegenereerd. `Run_date` maakt dit traceerbaar maar is geen vervanging voor versiebeheer van de pipeline zelf.
-- **Numerus-fixusvoorspellingen** worden net als in de week-output afgekapt; de audittrail erft die waarden ongewijzigd.
-- **CI-modus** (`--ci test N`) schrijft géén audittrail — alleen reguliere runs.
+??? note "Bekende limieten"
+    - **Filterwijzigingen tussen runs** worden niet gedetecteerd. Draai je week 10 met `-f base.json` en week 11 met een ander filter, dan leven beide rijensets naast elkaar. Documenteer zelf welke filterconfig bij welke run hoort.
+    - **Modelversie-drift**: rijen uit oudere runs kunnen door een andere modelvariant zijn gegenereerd. `Run_date` maakt dit traceerbaar maar vervangt geen versiebeheer.
+    - **Numerus-fixusvoorspellingen** worden afgekapt; de audittrail erft die waarden ongewijzigd.
+    - **CI-modus** (`--ci test N`) schrijft géén audittrail — alleen reguliere runs.
 
 ## Kolomdefinities
 
@@ -121,107 +120,17 @@ Er is geen harde drempel, maar de volgende signalen helpen:
 - Vroeg in het jaar (vóór week 6) — de tijdreeks is dan erg kort
 - Het jaar na een uitzonderlijk jaar (COVID, beleidswijziging)
 
-## Meerdere modellen vergelijken
-
-De individuele modelkolommen naast `Ensemble_prediction` zijn bewust in de output opgenomen. Ze stellen je in staat om:
-
-- Te controleren of de modellen het eens zijn
-- Te signaleren welk model structureel afwijkt voor een specifieke opleiding
-- De baseline (ratio-model) te vergelijken met de complexere modellen — als het ensemble niet beter is dan de ratio, is er reden om kritischer te kijken
-
-Zie [Ensemble](methodologie/ensemble.md) voor uitleg over hoe de gewichten tot stand komen.
+De individuele modelkolommen staan bewust naast `Ensemble_prediction`, zodat je kunt controleren of de modellen het eens zijn, kunt signaleren welk model structureel afwijkt, en de baseline (ratio-model) tegen de complexere modellen kunt afzetten. Zie [Ensemble](methodologie/ensemble.md) voor hoe de gewichten tot stand komen.
 
 ## Foutmaten en numerus-fixusopleidingen
 
 MAE en MAPE worden berekend **exclusief numerus-fixusopleidingen**. Voor deze opleidingen worden de foutkolommen op `NaN` gezet. De reden: bij numerus-fixusopleidingen wordt het voorspelde aantal afgekapt op de capaciteitslimiet, waardoor de modelfouten niet vergelijkbaar zijn met reguliere opleidingen.
 
-## Het model evalueren (`evaluate_predictions`)
+## Het model evalueren (geaggregeerde metrieken)
 
-De per-rij `MAE_*`/`MAPE_*`-kolommen hierboven zijn handig om één rij te lezen, maar voor **modelevaluatie** wil je geaggregeerde, scalaire metrieken (één getal per model). Daarvoor levert het pakket `evaluate_predictions`:
+De per-rij `MAE_*`/`MAPE_*`-kolommen hierboven zijn handig om één rij te lezen. Wil je een model **als geheel** beoordelen — één getal per model, of een eerlijke backtest over meerdere jaren — dan levert het pakket daarvoor de functies `evaluate_predictions`, `pivot_metrics` en `to_mlflow_metrics`.
 
-```python
-from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, DataOption
-
-result = run_pipeline_from_dataframes(
-    year=2023, week=12,
-    data_cumulative=df_cum, data_student_numbers=df_sc,
-    dataset=DataOption.CUMULATIVE, save_output=False,
-)
-
-metrics = evaluate_predictions(result, week=12)
-print(metrics)
-```
-
-De functie vergelijkt elke voorspelkolom met de gerealiseerde `Aantal_studenten` en geeft per model één rij terug met:
-
-| Metriek | Betekenis | Interpretatie |
-|---------|-----------|---------------|
-| `n` | aantal meegetelde (opleiding × herkomst)-rijen | klein `n` → metriek is ruisgevoelig |
-| `mae` | Mean Absolute Error | gemiddelde afwijking in studenten |
-| `mape` | Mean Absolute Percentage Error (fractie) | elke opleiding telt even zwaar — kleine opleidingen domineren |
-| `wape` | Weighted APE = `Σ\|fout\| / Σ\|werkelijk\|` (fractie) | instellingsbrede procentuele fout, robuust tegen kleine opleidingen |
-| `rmse` | Root Mean Squared Error | straft grote uitschieters zwaarder |
-| `bias` | gemiddelde `voorspeld − werkelijk` | positief = structurele overschatting |
-| `r2` | determinatiecoëfficiënt | aandeel verklaarde variantie |
-
-`mape` en `wape` zijn fracties (`0.08` betekent 8%). De metrieken gebruiken dezelfde primitieven en numerus-fixus-uitsluiting als de `MAE_*`-kolommen, dus ze zijn consistent met de rest van de output.
-
-!!! warning "Evalueren kan alleen via een backtest"
-    Een model evalueren betekent voorspellingen vergelijken met de **gerealiseerde** instroom. Voor het lopende, nog niet afgeronde collegejaar bestaat die realisatie nog niet — `Aantal_studenten` is dan leeg en `evaluate_predictions` geeft een foutmelding. Evalueer daarom een **afgerond** collegejaar (bijv. voorspel `year=2023` terwijl je de realisatie van 2023 als `data_student_numbers` meegeeft). De modellen trainen sowieso alleen op jaren vóór het voorspeljaar, dus zo'n backtest lekt geen toekomstinformatie.
-
-!!! tip "Geef altijd `week` mee bij cumulatieve output"
-    In het cumulatieve spoor draagt alleen de **peilweekrij** de `SARIMA_cumulative`-voorspelling; latere weken bevatten enkel de vooraanmeldcurve (met `NaN` als voorspelling). Zonder `week=`-filter mengt `Prognose_ratio` bovendien meerdere weken. Geef de gebruikte peilweek mee (`evaluate_predictions(result, week=12)`) voor een zuivere, één-rij-per-opleiding vergelijking tussen modellen.
-
-Segmenteer met `group_by` (bijv. `group_by="Examentype"` of `group_by=["Examentype", "Herkomst"]`) om te zien waar een model structureel afwijkt.
-
-### Backtesten over meerdere jaren (`pivot_metrics`)
-
-Eén afgerond jaar is **één datapunt**: de instroom schommelt jaar-op-jaar om redenen buiten het model. Voor een eerlijk beeld backtest je daarom meerdere afgeronde jaren op dezelfde peilweek, evalueer je per jaar met `group_by="Collegejaar"`, en draai je het resultaat met `pivot_metrics` tot een model × jaar-matrix:
-
-```python
-import pandas as pd
-from studentprognose import run_pipeline_from_dataframes, evaluate_predictions, pivot_metrics, DataOption
-
-WEEK = 10
-frames = [
-    run_pipeline_from_dataframes(
-        year=jaar, week=WEEK, data_cumulative=df_cum,
-        data_student_numbers=df_sc, dataset=DataOption.CUMULATIVE, save_output=False,
-    )
-    for jaar in (2021, 2022, 2023)            # afgeronde jaren met realisatie
-]
-
-metrics = evaluate_predictions(pd.concat(frames, ignore_index=True),
-                               week=WEEK, group_by="Collegejaar")
-print(pivot_metrics(metrics, value="wape", over="Collegejaar").round(3))
-```
-
-```text
-                    2021   2022   2023   mean    min    max  n_groups
-prediction
-Prognose_ratio     0.078  0.071  0.069  0.073  0.069  0.078         3
-SARIMA_cumulative  0.063  0.058  0.066  0.062  0.058  0.066         3
-```
-
-De `mean`-kolom is het gemiddelde over de jaren; `min`/`max` tonen de spreiding. Ligt de jaar-op-jaar spreiding in dezelfde orde als het verschil tussen modellen, trek dan geen harde conclusie uit één jaar. Kies met `value=` een andere metriek (`"mae"`, `"mape"`, …) en met `over=` een andere as (bijv. `over="Weeknummer"` voor de accuraatheid-over-tijd-curve bij één jaar).
-
-### Metrieken loggen in MS Fabric / Databricks (MLflow)
-
-Beide platforms hebben **MLflow** als ingebouwde experiment-tracker. `to_mlflow_metrics` vlakt het resultaat af tot een dict die je direct kunt loggen, zodat de metrieken in de Fabric/Databricks ML-experiment-UI verschijnen en over runs (jaar/peilweek) vergelijkbaar zijn:
-
-```python
-import mlflow
-from studentprognose import evaluate_predictions, to_mlflow_metrics
-
-metrics = evaluate_predictions(result, week=WEEK)
-
-with mlflow.start_run(run_name=f"prognose_{YEAR}_wk{WEEK}"):
-    mlflow.log_params({"year": YEAR, "week": WEEK, "dataset": "cumulatief"})
-    mlflow.log_metrics(to_mlflow_metrics(metrics))
-    mlflow.log_table(metrics, "metrics.json")  # volledige tabel als artifact
-```
-
-`mlflow` zit standaard in de Fabric- en Databricks-runtime; in een Fabric-notebook worden runs automatisch aan het gekoppelde experiment gehangen. Wil je geen MLflow gebruiken, dan kun je het `metrics`-DataFrame ook gewoon naar een Lakehouse/Delta-tabel wegschrijven voor je eigen monitoring.
+Dat is Python-API-werk (notebooks, cloud, MLflow) en staat daarom op de pagina [Gevorderd gebruik → Het model evalueren](gevorderd-gebruik.md#het-model-evalueren).
 
 ## Interactief dashboard
 
@@ -237,7 +146,7 @@ De dashboards zijn zelfstandige HTML-bestanden (geen server nodig) en kunnen in 
     Sinds deze versie wordt het dashboard alleen gegenereerd als je expliciet `--dashboard` meegeeft. Een voorbeeld:
 
     ```bash
-    studentprognose --dashboard -d both -w 10 -y 2025
+    studentprognose --dashboard -d both -w 10 -y 2024
     ```
 
     Mocht dashboard-generatie onverhoopt falen, dan loopt de rest van de pipeline gewoon door en wordt de stack trace weggeschreven naar `data/output/dashboard_error.log`. De Excel-output blijft in dat geval beschikbaar.

--- a/docs/snelstart.md
+++ b/docs/snelstart.md
@@ -1,0 +1,54 @@
+# Snelstart (5 min)
+
+Van niets naar je eerste prognose — met de **meegeleverde demodata**, dus je hebt nog geen eigen data nodig.
+
+!!! tip "Eerst installeren"
+    Nog niet geïnstalleerd? Zie [Installeren](installeren.md) (drie commando's).
+
+## 1. Projectmap aanmaken
+
+```bash
+mkdir mijn-prognose && cd mijn-prognose
+studentprognose init
+```
+
+`init` maakt de mapstructuur en een `configuration/configuration.json` met alle standaardwaarden. Je kunt het veilig opnieuw draaien; bestaande bestanden worden overgeslagen.
+
+## 2. Draaien
+
+```bash
+studentprognose
+```
+
+Zonder `-w`/`-y` kiest de tool automatisch de laatste beschikbare week en het laatste jaar uit de demodata. Je ziet een melding zoals:
+
+```
+Geen week/jaar opgegeven — automatisch gekozen op basis van beschikbare data: jaar 2024, week 38.
+```
+
+## 3. Resultaat bekijken
+
+De output staat in `data/output/`. Open **`output_first-years_beide.xlsx`**; de kolom `Ensemble_prediction` bevat de prognose per opleiding.
+
+Wil je het visueel? Voeg `--dashboard` toe voor interactieve HTML-grafieken:
+
+```bash
+studentprognose --dashboard
+```
+
+<iframe src="../assets/plots/output_cockpit.html" width="100%" height="400" frameborder="0" style="border-radius: 8px;"></iframe>
+
+*Voorbeelddashboard op de demodata: prognose, conversie en betrouwbaarheid per opleiding.*
+
+## Wat nu?
+
+| Ik wil… | Ga naar |
+|---------|---------|
+| Mijn eigen data gebruiken | [Je data klaarzetten](je-data-voorbereiden.md) |
+| Begrijpen wat `-w`, `-y` en `-d` doen | [Draaien & CLI](aan-de-slag.md) |
+| De output-cijfers interpreteren | [Output lezen](output-begrijpen.md) |
+| Mijn eigen instelling instellen | [Configuratie](configuratie.md) |
+| Weten hoe de modellen werken | [Methodologie](methodologie/index.md) |
+
+!!! note "Kom je een term niet tegen?"
+    De [Begrippenlijst](begrippen.md) legt peilweek, spoor, ETL, ensemble en de rest in gewone taal uit.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,4 @@
+/* Centreer de bovenste navigatietabs (Home, Aan de slag, Configuratie, …) */
+.md-tabs__list {
+  justify-content: center;
+}

--- a/docs/validatie.md
+++ b/docs/validatie.md
@@ -1,5 +1,7 @@
 # Validatie
 
+Krijg je een foutmelding? Spring direct naar [Een validatiefout oplossen](#een-validatiefout-oplossen).
+
 De pipeline voert vóór de ETL automatisch een datakwaliteitscontrole uit op alle ruwe inputbestanden. Dit voorkomt dat fouten in de brondata pas later in de pipeline of in de output zichtbaar worden.
 
 Gebruik `--noetl` om zowel de ETL als de validatie over te slaan (alleen als de data eerder al gevalideerd is).
@@ -35,6 +37,20 @@ De ✓ en ✗ symbolen worden in kleur weergegeven (groen/rood) als de terminal 
 
 In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te omzeilen.
 
+## Een validatiefout oplossen
+
+**Hard error — ontbrekende kolommen:**
+De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober` (de mapping voor het telbestand studenten).
+
+**Soft error — onverwacht collegejaar:**
+Controleer of het bestand het juiste studiejaar bevat. Als de afwijking verwacht is (bijv. historische data), kun je `collegejaar_min_offset` verhogen of met `--yes` doorgaan.
+
+**Soft error — ongeldige herkomstwaarden:**
+Jouw instelling gebruikt mogelijk `"ONBEKEND"` of een andere waarde. Voeg die toe aan `validation.telbestand.herkomst_allowed` in je configuratie.
+
+**Waarschuwing — witruimte gestript:**
+De data wordt automatisch gecorrigeerd. Overweeg de brondata te corrigeren om dit te voorkomen.
+
 ## Gevalideerde bestanden
 
 ### Telbestanden (`data/input_raw/telbestanden/`)
@@ -63,7 +79,7 @@ In geautomatiseerde runs (CI/CD) gebruik je `--yes` om de soft-error prompt te o
 
 ### Telbestand studenten (`data/input_raw/oktober_bestand.xlsx`)
 
-Telbestand met studentaantallen, door de instelling zelf aangeleverd — zie [Je data voorbereiden](je-data-voorbereiden.md#telbestand-studenten). De bestandsnaam heet historisch `oktober_bestand.xlsx`.
+Telbestand met studentaantallen, door de instelling zelf aangeleverd — zie [Je data klaarzetten](je-data-voorbereiden.md#telbestand-studenten). De bestandsnaam heet historisch `oktober_bestand.xlsx`.
 
 | Controle | Type | Wat wordt gecheckt |
 |----------|------|-------------------|
@@ -133,22 +149,23 @@ Met `--yes` verschijnt een waarschuwing in de console maar stopt de pipeline nie
 
 ### Numerus-fixus-sleutels
 
-Direct na het preprocessen — vóór de voorspelling — controleert de pipeline of elke sleutel in [`numerus_fixus`](configuratie.md#numerus_fixus) daadwerkelijk voorkomt in de programmakolom (`Croho groepeernaam`) van de geladen data. Dit voorkomt de stille misconfiguratie uit issue #258: een sleutel die niet matcht, levert bij `.isin`/`==` simpelweg `False` op, zonder foutmelding, waardoor de numerus-fixus-behandeling (aparte regressor, capaciteitsplafond, aparte foutrapportage) ongemerkt niet aangrijpt.
-
-De check draait op de genormaliseerde, gepreprocesste data, zodat het exacte dtype van de kolom wordt gezien.
+Als een numerus-fixus-sleutel niet exact overeenkomt met een opleiding in je data, werd die vroeger stil genegeerd: de speciale numerus-fixus-behandeling (aparte regressor, capaciteitsplafond, aparte foutrapportage) greep dan ongemerkt niet aan, zonder foutmelding. Nu krijg je vóór de voorspelling een duidelijke melding als een sleutel uit [`numerus_fixus`](configuratie.md#numerus_fixus) niet voorkomt in je opleidingen.
 
 | Situatie | Gedrag |
 |----------|--------|
-| Sleutel matcht **geen enkel** geladen spoor | Hard stop — pipeline stopt (typefout of verkeerd formaat) |
-| Sleutel matcht wel het ene, maar niet het andere geladen spoor | Waarschuwing — bekende namen-vs-Isatcodes-mismatch (#238) |
+| Sleutel matcht **geen enkel** geladen spoor | Hard stop — pipeline stopt (waarschijnlijk een typefout of verkeerd formaat) |
+| Sleutel matcht wel het ene, maar niet het andere geladen spoor | Waarschuwing — bekende naam-versus-Isatcode-verschil tussen de twee sporen |
 | Elke sleutel matcht alle geladen sporen | Check slaagt stilzwijgend |
+
+??? note "Technische achtergrond"
+    De check draait direct na het preprocessen op de genormaliseerde, gepreprocesste data, zodat het exacte dtype van de programmakolom (`Croho groepeernaam`) wordt gezien. Een niet-matchende sleutel leverde bij `.isin`/`==` simpelweg `False` op zonder foutmelding (issue #258); het gedeeltelijke-match-geval is de bekende namen-vs-Isatcodes-mismatch uit issue #238.
 
 !!! tip "Oplossing"
     Gebruik voor het cumulatieve spoor de numerieke **Isatcode** als sleutel, voor het individuele spoor de leesbare **opleidingsnaam** — precies de waarde zoals die in de programmakolom van dat spoor staat. Zie [`numerus_fixus`](configuratie.md#numerus_fixus).
 
 ## Post-prediction checks
 
-Nadat het ensemble zijn voorspellingen heeft opgeleverd, voert de pipeline twee informatieve checks uit. Ze stoppen de pipeline **nooit** — ze printen alleen waarschuwingen in de console.
+Nadat het ensemble zijn voorspellingen heeft opgeleverd, krijg je nog twee informatieve checks. Ze stoppen de pipeline **nooit** — je ziet alleen een waarschuwing in de console als de uitkomst opvalt.
 
 | Check | Wat wordt gecheckt |
 |-------|-------------------|
@@ -165,18 +182,4 @@ De week-op-week-check slaat de eerste week van elke run over (geen vorige week b
 
 ## Drempels aanpassen
 
-De standaarddrempels voor NaN-percentages en jaarbereiken zijn instelbaar via `configuration.json`. Zie [Configuratie — validation](configuratie.md#validation--validatiedrempels-overschrijven).
-
-## Een validatiefout oplossen
-
-**Hard error — ontbrekende kolommen:**
-De kolomnaam in jouw bestand wijkt af van de kanonieke naam. Voeg een kolomnamen-mapping toe in `configuration.json` onder `columns.individual` of `columns.oktober` (de mapping voor het telbestand studenten).
-
-**Soft error — onverwacht collegejaar:**
-Controleer of het bestand het juiste studiejaar bevat. Als de afwijking verwacht is (bijv. historische data), kun je `collegejaar_min_offset` verhogen of met `--yes` doorgaan.
-
-**Soft error — ongeldige herkomstwaarden:**
-Jouw instelling gebruikt mogelijk `"ONBEKEND"` of een andere waarde. Voeg die toe aan `validation.telbestand.herkomst_allowed` in je configuratie.
-
-**Waarschuwing — witruimte gestript:**
-De data wordt automatisch gecorrigeerd. Overweeg de brondata te corrigeren om dit te voorkomen.
+De standaarddrempels voor NaN-percentages en jaarbereiken zijn instelbaar via `configuration.json`. Zie [Configuratie — validation](configuratie-referentie.md#validation-validatiedrempels-overschrijven).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,12 @@ edit_uri: edit/main/docs/
 docs_dir: docs
 site_dir: site
 
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
 theme:
   name: material
   language: nl
@@ -73,6 +79,9 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
 
+extra_css:
+  - stylesheets/extra.css
+
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
@@ -80,12 +89,16 @@ extra_javascript:
 
 nav:
   - Home: index.md
-  - Presentatie: presentatie.md
-  - Aan de slag: aan-de-slag.md
-  - Je data voorbereiden: je-data-voorbereiden.md
-  - Configuratie: configuratie.md
-  - Validatie: validatie.md
-  - Output begrijpen: output-begrijpen.md
+  - Aan de slag:
+    - Snelstart (5 min): snelstart.md
+    - Installeren: installeren.md
+    - Je data klaarzetten: je-data-voorbereiden.md
+    - Draaien & CLI: aan-de-slag.md
+    - Output lezen: output-begrijpen.md
+  - Configuratie:
+    - Basis: configuratie.md
+    - Referentie: configuratie-referentie.md
+    - Validatie: validatie.md
   - Methodologie:
     - methodologie/index.md
     - Individueel model: methodologie/individueel.md
@@ -94,7 +107,11 @@ nav:
     - Ratio-model: methodologie/ratio-model.md
     - Ensemble: methodologie/ensemble.md
     - Benchmarks: methodologie/benchmarks.md
-  - API-referentie:
-    - api/index.md
-    - Modellen: api/models.md
-    - Strategies: api/strategies.md
+  - Gevorderd & naslag:
+    - Gevorderd gebruik: gevorderd-gebruik.md
+    - Begrippen: begrippen.md
+    - API-referentie:
+      - api/index.md
+      - Modellen: api/models.md
+      - Strategies: api/strategies.md
+    - Presentatie: presentatie.md


### PR DESCRIPTION
## Wat

Herstructureert de documentatie voor **nieuwe gebruikers** (analisten/onderzoekers), met een korte on-ramp en progressive disclosure voor de diepere stof.

### Nieuw
- **Snelstart** (5 min, op demodata), **Installeren**, **Begrippen** (woordenlijst), **Configuratie-referentie**, **Gevorderd gebruik**
- "In het kort"-samenvattingen en "wanneer vertrouw je het niet?"-secties op de methodologie-pagina's
- Herziene navigatie: *Aan de slag / Configuratie / Methodologie / Gevorderd & naslag*

### Review-fixes (deze review)
- Typo `regresssor` → `regressor` (`methodologie/sarima.md`)
- Kapotte pip-link in de README (verwees naar niet-bestaande anchor `aan-de-slag/#andere-installatiemethoden`) → nu `/installeren/`
- CLI-voorbeelden binnen het demodata-bereik gezet (`-y 2025` → `-y 2024`) zodat copy-paste op demodata niet faalt

## Verificatie
- Alle pagina's geserveerd via `mkdocs serve` en doorgelopen (22 pagina's, allemaal 200)
- `mkdocs build --strict` schoon; server-log warning-vrij
- mkdocstrings API-pagina's renderen echte docstrings; embeds/mermaid/mathjax resolven

## Let op — één gereconcilieerd bestand
`docs/je-data-voorbereiden.md` botste met de al-gemergede commit `6762302a` (examentype als grain-dimensie). Conservatief opgelost: **main's inhoud behouden** (incl. `Bachelor hogerejaars` en de grain/SIS-detail), beginner-docs-structuur intact. Even een blik waard bij review of de simplificatie vs. de grain-detail zo gewenst is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)