### PR TITLE
feat(gui): toon uitgesloten jaren in stap Uitvoeren

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -117,6 +117,14 @@ data 2020 of 2021 dekt. Zolang je nog geen tel- én oktober-bestand hebt
 geüpload, is er geen bereik bekend en meldt de sectie dat je die bestanden eerst
 moet uploaden.
 
+Die uitsluiting is ook zichtbaar op het moment dat je de voorspelling start:
+bovenaan de **Uitvoeren**-pagina staat een uitklapbare sectie **"Uitgesloten
+jaren"** met de actieve jaren (of expliciet "geen") en een link terug naar de
+configuratie om ze te wijzigen. In de **Dataverdeling**-kaart eronder krijgen
+uitgesloten jaren die binnen het traindata-bereik vallen bovendien een
+gearceerde markering op de tijdlijn, zodat je vóór het starten van een run in
+één oogopslag ziet welke jaren buiten de training vallen.
+
 In dezelfde tab **Geavanceerd** kun je op twee plekken een opleiding kiezen via
 een **zoekbare keuzelijst op Isatcode**. Bij *Filteren → Opleidingen* en bij
 *Numerus fixus → Programmasleutel* toont de lijst de opleidingen die in je

--- a/gui/components/train_test_viz.py
+++ b/gui/components/train_test_viz.py
@@ -18,6 +18,7 @@ _T = "#3D68EC"   # traindata — Npuls blauw
 _V = "#E6A020"   # backtest  — amber
 _P = "#DD784B"   # prognose  — Npuls oranje
 _MU = "#6b6b6b"  # muted tekst
+_EXCL = "#C0392B"  # uitgesloten jaar — warm rood (theme.NEGATIVE)
 
 
 # ── Gedeelde hulpfuncties ──────────────────────────────────────────────────
@@ -132,8 +133,16 @@ def render_v1(
     weeks_str: str = "",
     data_start: int = DATA_START,
     data_end: int | None = None,
+    excluded_years: list[int] | None = None,
 ) -> str:
-    """V1 — Horizon: proportionele gesegmenteerde tijdlijn met week-annotatie."""
+    """V1 — Horizon: proportionele gesegmenteerde tijdlijn met week-annotatie.
+
+    Args:
+        excluded_years: Jaren die via ``excluded_data_points`` uit de
+            trainingsdata zijn gesloten (configuratie). Jaren die binnen het
+            traindata-bereik vallen worden als gearceerde marker op de balk
+            getoond.
+    """
     d = _compute(years_str, skip_years, data_start, data_end)
     if d is None:
         return _empty_state()
@@ -199,6 +208,29 @@ def render_v1(
         ts, te = d["test"]
         bar_html += _seg(test_n, _V, _rng(ts, te), 0.1)
     bar_html += _seg(pred_n, _P, pred_bar_label, 0.2, glow=True)
+
+    # ── Uitgesloten-jaren markers (over de traindata-balk) ───────────────────
+    # Alleen jaren binnen het traindata-bereik worden gemarkeerd: dat is waar
+    # ``excluded_data_points`` daadwerkelijk op toepast (zie configuratie).
+    excl_in_train = sorted(
+        y for y in (excluded_years or []) if train_s <= y <= train_e
+    )
+
+    def _excl_marker(year: int, delay: float) -> str:
+        left = train_pct * (year - train_s) / train_n
+        width = max(train_pct / train_n, 1.2)
+        return (
+            f'<div title="Jaar {year} uitgesloten van training" '
+            f'style="position:absolute; left:{left:.2f}%; width:{width:.2f}%; top:0; bottom:0;'
+            f' background:repeating-linear-gradient(45deg, {_EXCL}66, {_EXCL}66 3px,'
+            f' transparent 3px, transparent 7px); border-left:1px solid {_EXCL};'
+            f' border-right:1px solid {_EXCL};'
+            f' animation:sp-v1-up 0.3s {delay:.2f}s ease both;"></div>'
+        )
+
+    excl_overlay_html = "".join(
+        _excl_marker(y, 0.3 + i * 0.05) for i, y in enumerate(excl_in_train)
+    )
 
     # ── Tikmarkeringen op de jaaras ──────────────────────────────────────────
     # Toont de beginjaren van elk segment + het eindjaar van de prognose als
@@ -267,6 +299,17 @@ def render_v1(
     sep = '<span style="color:#ddd; margin:0 3px; font-size:13px;">·</span>'
     legend_html = sep.join(legend_parts)
 
+    excl_note_html = ""
+    if excl_in_train:
+        excl_years_lbl = ", ".join(str(y) for y in excl_in_train)
+        excl_note_html = (
+            f'  <div style="margin-top:6px; display:flex; align-items:center; gap:5px;">'
+            f'<span style="font-size:11px; color:{_EXCL};">&#9888;</span>'
+            f'<span style="font-size:11px; color:{_EXCL};">'
+            f'Uitgesloten van training: {excl_years_lbl}</span>'
+            f'  </div>'
+        )
+
     return (
         "<style>"
         "@keyframes sp-v1-up {"
@@ -286,10 +329,13 @@ def render_v1(
         f'    {week_badge}'
         f'  </div>'
 
-        # Gesegmenteerde balk
-        '  <div style="display:flex; height:52px; border-radius:8px;'
-        '   overflow:hidden; gap:2px;">'
-        f'    {bar_html}'
+        # Gesegmenteerde balk (+ uitgesloten-jaren overlay)
+        '  <div style="position:relative;">'
+        '    <div style="display:flex; height:52px; border-radius:8px;'
+        '     overflow:hidden; gap:2px;">'
+        f'      {bar_html}'
+        '    </div>'
+        f'    {excl_overlay_html}'
         '  </div>'
 
         # Jaaras met tikmarkeringen
@@ -301,6 +347,8 @@ def render_v1(
         f'  <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:10px; align-items:center;">'
         f'    {legend_html}'
         f'  </div>'
+
+        f'{excl_note_html}'
 
         "</div>"
     )

--- a/gui/config_io.py
+++ b/gui/config_io.py
@@ -84,6 +84,17 @@ def validate_config(config: dict) -> list[str]:
     return errors
 
 
+def excluded_years(excluded_data_points: list[dict]) -> list[int]:
+    """Geef de gesorteerde, unieke jaren terug die in uitsluitingsregels voorkomen.
+
+    Een regel telt mee zodra hij een ``year`` bevat, ook als hij daarnaast op
+    herkomst/examentype/opleiding filtert (partiële uitsluiting binnen dat
+    jaar) — zelfde groepering als de jaar-chips in de configuratie-editor.
+    """
+    years = {row["year"] for row in excluded_data_points if row.get("year") is not None}
+    return sorted(years)
+
+
 def parse_json(text: str) -> dict:
     """Parse een JSON-string naar een dict.
 

--- a/gui/pages/config_page.py
+++ b/gui/pages/config_page.py
@@ -380,19 +380,15 @@ class _ConfigView:
 
     def _render_excl_year_chips(self) -> None:
         self._excl_years_chips.clear()
-        years_seen: dict[str, list[int]] = {}
-        for i, row in enumerate(self._excl_rows):
-            yr = row.get("year")
-            if yr is not None:
-                years_seen.setdefault(str(yr), []).append(i)
+        years = config_io.excluded_years(self._excl_rows)
 
-        if not years_seen:
+        if not years:
             with self._excl_years_chips:
                 ui.label("Geen jaren uitgesloten.").classes("text-sm opacity-40 italic")
             return
 
         with self._excl_years_chips:
-            for yr_str in sorted(years_seen.keys()):
+            for yr_str in (str(y) for y in years):
                 with ui.row().classes(
                     "items-center gap-1 px-3 py-1 rounded-full no-wrap"
                 ).style(
@@ -411,10 +407,8 @@ class _ConfigView:
 
     def _available_year_options(self) -> list[int]:
         """Kiesbare jaren minus de reeds uitgesloten jaren (oplopend)."""
-        excluded = {
-            str(r.get("year")) for r in self._excl_rows if r.get("year") is not None
-        }
-        return [y for y in self._selectable_years if str(y) not in excluded]
+        excluded = set(config_io.excluded_years(self._excl_rows))
+        return [y for y in self._selectable_years if y not in excluded]
 
     def _refresh_year_input(self) -> None:
         """Werk de select-opties bij nadat de uitsluitingslijst is veranderd."""
@@ -988,9 +982,7 @@ class _ConfigView:
             ui.button("Rij toevoegen", icon="add", on_click=self._add_nf_row).props("flat")
 
     def _excl_section(self) -> None:
-        excl_year_count = len({
-            str(r.get("year")) for r in self._excl_rows if r.get("year") is not None
-        })
+        excl_year_count = len(config_io.excluded_years(self._excl_rows))
         excl_label = (
             f"Uitsluitingsregels — {excl_year_count} jaar/jaren"
             if excl_year_count

--- a/gui/pages/run.py
+++ b/gui/pages/run.py
@@ -10,7 +10,7 @@ import datetime
 
 from nicegui import app, ui
 
-from gui import nav, process, theme, tracks
+from gui import config_io, nav, process, theme, tracks
 from gui.components import train_test_viz as tvz
 from gui.components.layout import page_shell
 from gui.components.log_stream import ProcessPanel
@@ -142,6 +142,7 @@ class _RunView:
         # bereik zolang de data nog niet is geüpload.
         self._bounds: DataYearBounds | None = self._scan_bounds()
         self._data_start, self._data_end, self._forecast_years = self._resolve_years()
+        self._excluded_years: list[int] = self._load_excluded_years()
         self._default_year: int = (
             self._data_end + 1
             if self._data_end is not None and (self._data_end + 1) in self._forecast_years
@@ -190,6 +191,18 @@ class _RunView:
             # Onleesbare of half-geüploade data mag de pagina nooit breken.
             return None
 
+    @staticmethod
+    def _load_excluded_years() -> list[int]:
+        """Lees de uitgesloten jaren uit ``excluded_data_points`` in de config."""
+        if not STATE.config_path:
+            return []
+        try:
+            config = config_io.load_config(STATE.config_path)
+        except Exception:
+            # Onleesbare of nog niet opgeslagen configuratie mag de pagina nooit breken.
+            return []
+        return config_io.excluded_years(config.get("excluded_data_points", []))
+
     def _resolve_years(self) -> tuple[int, int | None, list[int]]:
         """Leid (start-jaar, eind-jaar, prognosejaar-opties) af.
 
@@ -224,9 +237,56 @@ class _RunView:
             f"en het oktober-bestand ({b.okt_years[0]}–{b.okt_years[-1]})."
         )
 
+    def _excl_years_banner(self) -> None:
+        """Toon welke jaren de actieve configuratie van de trainingsdata uitsluit."""
+        years = self._excluded_years
+        label = (
+            f"Uitgesloten jaren — {len(years)} jaar/jaren"
+            if years
+            else "Uitgesloten jaren — geen"
+        )
+        border_color = theme.NEGATIVE if years else "#e0e0e0"
+        with ui.expansion(label, icon="block" if years else "check_circle").classes(
+            "w-full mb-4"
+        ).style(
+            "background: white; border-radius: 10px; overflow: hidden; "
+            f"border: 1px solid {border_color}30; border-left: 4px solid {border_color}; "
+            "box-shadow: 0 1px 5px rgba(0,0,0,0.05);"
+        ):
+            if years:
+                ui.label(
+                    "Deze jaren zijn uitgesloten van de trainingsdata (via "
+                    "Configuratie › Geavanceerd › Uitsluitingsregels). Het "
+                    "prognosejaar zelf wordt hierbij altijd beschermd."
+                ).classes("text-sm opacity-60 mb-2")
+                with ui.row().classes("gap-2 flex-wrap"):
+                    for y in years:
+                        with ui.row().classes(
+                            "items-center gap-1 px-3 py-1 rounded-full no-wrap"
+                        ).style(
+                            f"background: {theme.WARNING}18; "
+                            f"border: 1px solid {theme.WARNING}40;"
+                        ):
+                            ui.label(str(y)).classes(
+                                "text-sm font-medium font-mono"
+                            ).style(f"color: {theme.WARNING}")
+            else:
+                ui.label(
+                    "Er zijn geen probleemjaren (bijv. COVID) uitgesloten van de "
+                    "trainingsdata."
+                ).classes("text-sm opacity-60")
+            if nav.is_available("/config"):
+                ui.button(
+                    "Wijzig in Configuratie",
+                    icon="tune",
+                    on_click=lambda: ui.navigate.to("/config"),
+                ).props("flat dense color=accent").classes("mt-2")
+
     # ── UI-opbouw ────────────────────────────────────────────────────────────
 
     def _build(self) -> None:
+        self._excl_years_banner()
+
         with ui.card().classes("w-full"):
             with ui.grid(columns=2).classes("w-full gap-4"):
 
@@ -471,7 +531,12 @@ class _RunView:
         weeks = self._weeks.value or ""
         self._viz_html.set_content(
             tvz.render_v1(
-                self._years_as_str(), skip, weeks, self._data_start, self._data_end
+                self._years_as_str(),
+                skip,
+                weeks,
+                self._data_start,
+                self._data_end,
+                self._excluded_years,
             )
         )
 

--- a/tests/gui/test_config_io.py
+++ b/tests/gui/test_config_io.py
@@ -86,3 +86,17 @@ def test_parse_json_rejects_invalid():
 def test_validate_config_aggregates_ensemble_errors():
     config = {"ensemble_weights": {"default": {"individual": 0.9, "cumulative": 0.9}}}
     assert len(config_io.validate_config(config)) == 1
+
+
+def test_excluded_years_dedupes_and_sorts():
+    rules = [{"year": 2021}, {"year": 2020}, {"year": 2020, "herkomst": "NL"}]
+    assert config_io.excluded_years(rules) == [2020, 2021]
+
+
+def test_excluded_years_ignores_rules_without_year():
+    rules = [{"herkomst": "NL"}, {"year_before": 2019}]
+    assert config_io.excluded_years(rules) == []
+
+
+def test_excluded_years_empty_input():
+    assert config_io.excluded_years([]) == []

--- a/tests/gui/test_train_test_viz.py
+++ b/tests/gui/test_train_test_viz.py
@@ -61,6 +61,31 @@ def test_render_v1_reflects_overlap_not_2016():
     assert "2016" not in html
 
 
+# ── render_v1: uitgesloten-jaren markers (#284) ─────────────────────────────
+
+
+def test_render_v1_marks_excluded_years_within_training():
+    html = tvz.render_v1(
+        "2026", 0, data_start=2020, data_end=2025, excluded_years=[2020, 2021]
+    )
+    assert "Uitgesloten van training: 2020, 2021" in html
+    assert html.count("uitgesloten van training") == 2  # één marker per jaar
+
+
+def test_render_v1_ignores_excluded_years_outside_training_range():
+    """Een uitgesloten jaar buiten het traindata-bereik krijgt geen marker."""
+    html = tvz.render_v1(
+        "2026", 0, data_start=2020, data_end=2025, excluded_years=[2010]
+    )
+    assert "Uitgesloten van training" not in html
+
+
+def test_render_v1_without_excluded_years_has_no_marker():
+    html = tvz.render_v1("2026", 0, data_start=2020, data_end=2025)
+    assert "Uitgesloten van training" not in html
+    assert "uitgesloten van training" not in html
+
+
 # ── scan_data_year_bounds: overlap uit projectbestanden ─────────────────────
 
 


### PR DESCRIPTION
## Summary
- De configuratie kan probleemjaren (bijv. COVID) uitsluiten van de trainingsdata, maar die keuze was in de **Uitvoeren**-stap nergens zichtbaar.
- Voegt een uitklapbare "Uitgesloten jaren"-sectie toe bovenaan de Uitvoeren-pagina (chips per jaar, of "geen"), met een link terug naar Configuratie.
- Markeert diezelfde uitgesloten jaren in de Dataverdeling-tijdlijn (gearceerde overlay + legenda-waarschuwing) wanneer ze binnen het traindata-bereik vallen.
- `gui/config_io.py`: nieuwe gedeelde `excluded_years()`-helper (single source of truth), hergebruikt door zowel de configuratie-editor als de Uitvoeren-pagina.
- `docs/gui.md` bijgewerkt conform de docs-regel voor GUI-wijzigingen.

Closes #284

## Test plan
- [x] `uv run pytest` — 680/680 groen (674 bestaand + 6 nieuwe tests voor `excluded_years()` en de `render_v1`-marker)
- [x] Handmatig geverifieerd via een live GUI-sessie (Playwright, headless Chromium): COVID-jaren toegevoegd via Configuratie → Geavanceerd, banner en tijdlijn-marker op de Uitvoeren-pagina getoond, "geen"-status bij lege configuratie, Prognosejaren-dropdown ongewijzigd (voorspeljaar blijft beschermd conform bestaand backend-gedrag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)